### PR TITLE
Add Copybara infrastructure for syncing demo applications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,6 +382,64 @@ jobs:
       - fail-step:
           message: "Documentation deployment failed"
 
+  sync-cli-starter:
+    docker:
+      - image: cimg/openjdk:21.0
+    working_directory: ~/project
+    steps:
+      - checkout
+      
+      - run:
+          name: Install Copybara
+          command: |
+            echo "📦 Installing Copybara..."
+            sudo apt update -y
+            sudo apt install -y wget unzip
+            wget https://github.com/google/copybara/releases/download/v0.35.0/copybara_deploy.jar
+            sudo mv copybara_deploy.jar /usr/local/bin/copybara.jar
+            echo '#!/bin/bash' | sudo tee /usr/local/bin/copybara
+            echo 'java -jar /usr/local/bin/copybara.jar "$@"' | sudo tee -a /usr/local/bin/copybara
+            sudo chmod +x /usr/local/bin/copybara
+            echo "✅ Copybara installed successfully"
+
+      - run:
+          name: Sync CLI Hello World to starter repo
+          command: |
+            echo "🔄 Syncing CLI Hello World to viaduct-graphql/cli-starter..."
+            cd demoapps/clihelloworld
+            export VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN="${CLI_STARTER_GITHUB_TOKEN}"
+            export VIADUCT_CLI_STARTER_REPO_URL="https://github.com/viaduct-graphql/cli-starter.git"
+            ./_infra/scripts/clihelloworld_to_external_push.sh
+
+  sync-spring-starter:
+    docker:
+      - image: cimg/openjdk:21.0
+    working_directory: ~/project
+    steps:
+      - checkout
+      
+      - run:
+          name: Install Copybara
+          command: |
+            echo "📦 Installing Copybara..."
+            sudo apt update -y
+            sudo apt install -y wget unzip
+            wget https://github.com/google/copybara/releases/download/v0.35.0/copybara_deploy.jar
+            sudo mv copybara_deploy.jar /usr/local/bin/copybara.jar
+            echo '#!/bin/bash' | sudo tee /usr/local/bin/copybara
+            echo 'java -jar /usr/local/bin/copybara.jar "$@"' | sudo tee -a /usr/local/bin/copybara
+            sudo chmod +x /usr/local/bin/copybara
+            echo "✅ Copybara installed successfully"
+
+      - run:
+          name: Sync Spring Hello World to starter repo
+          command: |
+            echo "🔄 Syncing Spring Hello World to viaduct-graphql/spring-starter..."
+            cd demoapps/springhelloworld
+            export VIADUCT_SPRING_STARTER_GITHUB_ACCESS_TOKEN="${SPRING_STARTER_GITHUB_TOKEN}"
+            export VIADUCT_SPRING_STARTER_REPO_URL="https://github.com/viaduct-graphql/spring-starter.git"
+            ./_infra/scripts/springhelloworld_to_external_push.sh
+
 workflows:
   build-and-test:
     when:
@@ -402,6 +460,24 @@ workflows:
       - coverage-verification:
           requires:
             - test
+      - sync-cli-starter:
+          requires:
+            - test
+            - lint
+          filters:
+            branches:
+              only:
+                - main
+                - master
+      - sync-spring-starter:
+          requires:
+            - test
+            - lint
+          filters:
+            branches:
+              only:
+                - main
+                - master
       # TODO: Re-enable when Dokka documentation is working
       # - deploy-docs:
       #     requires:

--- a/demoapps/_infra/README.md
+++ b/demoapps/_infra/README.md
@@ -1,0 +1,100 @@
+# Viaduct Demo Applications CI/CD Setup
+
+This directory contains the infrastructure configuration for synchronizing Viaduct demo applications from the main `airbnb/viaduct` repository to the external starter repositories in the `viaduct-graphql` GitHub organization.
+
+## Overview
+
+The setup uses Copybara to automatically sync changes from:
+- `airbnb/viaduct:demoapps/clihelloworld/` → `viaduct-graphql/cli-starter`
+- `airbnb/viaduct:demoapps/springhelloworld/` → `viaduct-graphql/spring-starter`
+
+## Architecture
+
+```
+airbnb/viaduct (GitHub)
+├── demoapps/clihelloworld/     → viaduct-graphql/cli-starter
+├── demoapps/springhelloworld/  → viaduct-graphql/spring-starter
+└── .circleci/config.yml        (Contains sync jobs)
+```
+
+## How It Works
+
+1. **Trigger**: When changes are pushed to the `main` or `master` branch of `airbnb/viaduct`
+2. **Build & Test**: Standard CI pipeline runs (build, test, lint)  
+3. **Sync**: After successful tests, Copybara jobs sync changes to starter repos
+4. **Result**: Updated starter repositories reflect the latest demo application code
+
+## Configuration
+
+### CircleCI Environment Variables
+
+The following environment variables must be configured in the `airbnb/viaduct` CircleCI project:
+
+1. **CLI_STARTER_GITHUB_TOKEN** - GitHub access token with write permissions to `viaduct-graphql/cli-starter`
+2. **SPRING_STARTER_GITHUB_TOKEN** - GitHub access token with write permissions to `viaduct-graphql/spring-starter`
+
+### Copybara Configuration Files
+
+Each demo application has its own Copybara configuration:
+
+- `clihelloworld/copy.bara.sky` - Syncs CLI Hello World to cli-starter repo
+- `springhelloworld/copy.bara.sky` - Syncs Spring Hello World to spring-starter repo
+
+### Sync Scripts
+
+Manual sync scripts are available for testing and troubleshooting:
+
+- `clihelloworld/_infra/scripts/clihelloworld_to_external_push.sh`
+- `springhelloworld/_infra/scripts/springhelloworld_to_external_push.sh`
+
+## Manual Sync
+
+To manually sync changes (for testing or troubleshooting):
+
+1. Clone the `airbnb/viaduct` repository
+2. Install Copybara locally
+3. Set the required environment variables:
+   ```bash
+   export VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN="your_token"
+   export VIADUCT_SPRING_STARTER_GITHUB_ACCESS_TOKEN="your_token"
+   ```
+4. Run the sync script:
+   ```bash
+   cd demoapps/clihelloworld
+   ./_infra/scripts/clihelloworld_to_external_push.sh
+   ```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Failures**
+   - Verify GitHub tokens have correct permissions
+   - Check token expiration dates
+   - Ensure tokens are properly set in CircleCI environment variables
+
+2. **Copybara Sync Failures**
+   - Check for conflicting changes in destination repositories
+   - Verify Copybara configuration syntax
+   - Review transformation rules for path mapping issues
+
+3. **Build Failures**
+   - Ensure all tests pass before sync attempts
+   - Check for compilation errors in demo applications
+   - Verify dependency versions are compatible
+
+### Logs and Monitoring
+
+- CircleCI build logs contain detailed sync information
+- Copybara provides exit codes: 0 (success), 4 (no-op), other (error)
+- GitHub webhooks can be configured for additional notifications
+
+## Migration Notes
+
+This setup replaces the previous treehouse-based CI/CD pipeline with a GitHub-native approach using:
+
+- **Source**: `airbnb/viaduct` (GitHub) instead of treehouse
+- **CI/CD**: CircleCI instead of treehouse JORB system
+- **Copybara**: Direct GitHub-to-GitHub sync instead of file-based workflows
+
+The migration maintains the same end result (synchronized starter repositories) while simplifying the infrastructure and removing dependencies on internal Airbnb systems.

--- a/demoapps/clihelloworld/_infra/scripts/clihelloworld_initial_push.sh
+++ b/demoapps/clihelloworld/_infra/scripts/clihelloworld_initial_push.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Creates the initial commit in the external cli-starter repository.
+# This will overwrite any existing content in the destination repository.
+#
+# Use --dry-run to test script changes
+# Use --verbose to debug copybara behavior
+# Use --last-rev <commit> to specify starting revision
+# Use --init-history to import full history from the beginning
+
+# How to run locally:
+# 1. Set up VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN environment variable
+# 2. Optionally set VIADUCT_CLI_STARTER_REPO_URL (defaults to the public repo)
+# 3. Run this script from the clihelloworld directory
+
+readonly ACC_TOK="$VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN"
+readonly DESTINATION_REPO="${VIADUCT_CLI_STARTER_REPO_URL:-https://github.com/viaduct-graphql/cli-starter.git}"
+
+# Validate required environment variables
+if [[ -z "$ACC_TOK" ]]; then
+    echo "Error: VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN environment variable is required"
+    exit 1
+fi
+
+# netrc changes auth details for curl and git under the hood.
+NETRC_ENTRY=$(cat <<EOF
+machine github.com
+login x-access-token
+password $ACC_TOK
+EOF
+)
+
+echo "# BEGIN TEMP GIT ACCESS" >> ~/.netrc
+echo "$NETRC_ENTRY" >> ~/.netrc
+echo "# END TEMP GIT ACCESS" >> ~/.netrc
+chmod 600 ~/.netrc
+
+# Ensure clean-up
+trap 'sed -i.bak "/# BEGIN TEMP GIT ACCESS/,/# END TEMP GIT ACCESS/d" ~/.netrc; rm -f ~/.netrc.bak' EXIT
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DESTINATION_BRANCH_NAME="main"
+
+echo "WARNING: This will create an initial commit that may overwrite existing content in the destination repository."
+echo "Destination: $DESTINATION_REPO"
+echo "Press Ctrl+C to cancel, or any key to continue..."
+read -n 1
+
+# Run copybara with the initial-commit workflow
+# Pass through any additional arguments to copybara
+yak script tools/copybara:run \
+  --git-committer-email "viaduct-maintainers@airbnb.com" \
+  --git-committer-name "ViaductBot" \
+  --git-destination-push "$DESTINATION_BRANCH_NAME" \
+  --git-destination-url="$DESTINATION_REPO" \
+  "$@" \
+  "$SCRIPT_DIR"/../../copy.bara.sky initial-commit
+
+# Google has an integration test, expecting 4 for NO_OP.
+NO_OP_EXIT_CODE=4
+exit_code=$?
+if [ $exit_code -eq 0 ] || [ $exit_code -eq $NO_OP_EXIT_CODE ]; then
+    echo "Initial commit completed successfully!"
+    exit 0
+else
+    echo "Initial commit failed with exit code $exit_code"
+    exit $exit_code
+fi

--- a/demoapps/clihelloworld/_infra/scripts/clihelloworld_to_external_push.sh
+++ b/demoapps/clihelloworld/_infra/scripts/clihelloworld_to_external_push.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Pushes new commits from airbnb/viaduct clihelloworld to the viaduct-graphql/cli-starter repository.
+# Based on the main viaduct OSS copybara push script.
+#
+# Use --dry-run to test script changes
+# Use --verbose to debug copybara behavior
+
+# How to run locally:
+# 1. Set up VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN environment variable
+# 2. Optionally set VIADUCT_CLI_STARTER_REPO_URL (defaults to the public repo)
+# 3. Run this script from the airbnb/viaduct repository with copybara installed
+
+readonly ACC_TOK="$VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN"
+readonly DESTINATION_REPO="${VIADUCT_CLI_STARTER_REPO_URL:-https://github.com/viaduct-graphql/cli-starter.git}"
+
+# Validate required environment variables
+if [[ -z "$ACC_TOK" ]]; then
+    echo "Error: VIADUCT_CLI_STARTER_GITHUB_ACCESS_TOKEN environment variable is required"
+    exit 1
+fi
+
+# netrc changes auth details for curl and git under the hood.
+NETRC_ENTRY=$(cat <<EOF
+machine github.com
+login x-access-token
+password $ACC_TOK
+EOF
+)
+
+echo "# BEGIN TEMP GIT ACCESS" >> ~/.netrc
+echo "$NETRC_ENTRY" >> ~/.netrc
+echo "# END TEMP GIT ACCESS" >> ~/.netrc
+chmod 600 ~/.netrc
+
+# Ensure clean-up
+trap 'sed -i.bak "/# BEGIN TEMP GIT ACCESS/,/# END TEMP GIT ACCESS/d" ~/.netrc; rm -f ~/.netrc.bak' EXIT
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DESTINATION_BRANCH_NAME="main"
+
+# Run copybara with the clihelloworld configuration
+copybara \
+  --git-committer-email "viaduct-maintainers@airbnb.com" \
+  --git-committer-name "ViaductBot" \
+  --git-destination-push "$DESTINATION_BRANCH_NAME" \
+  --git-destination-url="$DESTINATION_REPO" \
+  "$SCRIPT_DIR"/../../copy.bara.sky airbnb-viaduct-to-cli-starter
+
+# Google has an integration test, expecting 4 for NO_OP.
+# https://github.com/google/copybara/blob/master/copybara/integration/tool_test.sh#L24
+# This also reinforces what we see in CI when there is no diff to merge.
+
+NO_OP_EXIT_CODE=4
+exit_code=$?
+if [ $exit_code -eq 0 ] || [ $exit_code -eq $NO_OP_EXIT_CODE ]; then
+    exit 0
+else
+    exit $exit_code
+fi

--- a/demoapps/clihelloworld/copy.bara.sky
+++ b/demoapps/clihelloworld/copy.bara.sky
@@ -1,0 +1,72 @@
+# Syncs commits from airbnb/viaduct clihelloworld to viaduct-graphql/cli-starter repo
+# Based on the main viaduct OSS copybara configuration
+
+load("//projects/viaduct/oss/author_mappings", "AUTHOR_MAPPINGS", "DEFAULT_AUTHOR", "transform_authors")
+load("//projects/viaduct/oss/message_scrubber", "strip_commit_body_keep_metadata")
+
+core.workflow(
+    name = "airbnb-viaduct-to-cli-starter",
+    mode = "ITERATIVE",
+    origin = git.origin(
+        url = "https://github.com/airbnb/viaduct.git",  # airbnb/viaduct GitHub repo
+        ref = "master",
+        partial_fetch = True,
+        describe_version = False,
+    ),
+    origin_files = glob(
+        include = ["demoapps/clihelloworld/**"],
+        exclude = [
+            "**/copy.bara.sky",
+            "**/*.bara.sky", 
+            "**/_infra/**",
+            "**/BUILD.bazel",
+        ],
+    ),
+    destination = git.destination(
+        url = "https://github.com/viaduct-graphql/cli-starter.git",
+        fetch = "main",
+    ),
+    authoring = authoring.pass_thru(default = DEFAULT_AUTHOR),
+    transformations = [
+        # Move from the nested path to root
+        core.move("demoapps/clihelloworld/", ""),
+        # Strip PR numbers from commit messages
+        metadata.scrubber(r"\s+\(#\d+\)$", replacement = ""),
+        # Transform authors and clean commit messages
+        core.transform([transform_authors, strip_commit_body_keep_metadata]),
+    ],
+)
+
+# Workflow for creating initial commit with all current content
+core.workflow(
+    name = "initial-commit",
+    mode = "SQUASH", 
+    origin = git.origin(
+        url = "https://github.com/airbnb/viaduct.git",  # airbnb/viaduct GitHub repo
+        ref = "master",
+        partial_fetch = True,
+        describe_version = False,
+    ),
+    origin_files = glob(
+        include = ["demoapps/clihelloworld/**"],
+        exclude = [
+            "**/copy.bara.sky",
+            "**/*.bara.sky",
+            "**/_infra/**", 
+            "**/BUILD.bazel",
+        ],
+    ),
+    destination = git.destination(
+        url = "https://github.com/viaduct-graphql/cli-starter.git",
+        fetch = "main",
+    ),
+    authoring = authoring.overwrite(DEFAULT_AUTHOR),
+    transformations = [
+        # Move from nested path to root
+        core.move("demoapps/clihelloworld/", ""),
+        # Set initial commit message
+        metadata.replace_message(
+            "Initial Viaduct CLI Hello World starter project\n\nThis is the initial commit of the Viaduct CLI starter project, containing a basic Hello World example to demonstrate Viaduct GraphQL capabilities.",
+        ),
+    ],
+)

--- a/demoapps/springhelloworld/_infra/scripts/springhelloworld_to_external_push.sh
+++ b/demoapps/springhelloworld/_infra/scripts/springhelloworld_to_external_push.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Pushes new commits from airbnb/viaduct springhelloworld to the viaduct-graphql/spring-starter repository.
+# Based on the main viaduct OSS copybara push script.
+#
+# Use --dry-run to test script changes
+# Use --verbose to debug copybara behavior
+
+# How to run locally:
+# 1. Set up VIADUCT_SPRING_STARTER_GITHUB_ACCESS_TOKEN environment variable
+# 2. Optionally set VIADUCT_SPRING_STARTER_REPO_URL (defaults to the public repo)
+# 3. Run this script from the airbnb/viaduct repository with copybara installed
+
+readonly ACC_TOK="$VIADUCT_SPRING_STARTER_GITHUB_ACCESS_TOKEN"
+readonly DESTINATION_REPO="${VIADUCT_SPRING_STARTER_REPO_URL:-https://github.com/viaduct-graphql/spring-starter.git}"
+
+# Validate required environment variables
+if [[ -z "$ACC_TOK" ]]; then
+    echo "Error: VIADUCT_SPRING_STARTER_GITHUB_ACCESS_TOKEN environment variable is required"
+    exit 1
+fi
+
+# netrc changes auth details for curl and git under the hood.
+NETRC_ENTRY=$(cat <<EOF
+machine github.com
+login x-access-token
+password $ACC_TOK
+EOF
+)
+
+echo "# BEGIN TEMP GIT ACCESS" >> ~/.netrc
+echo "$NETRC_ENTRY" >> ~/.netrc
+echo "# END TEMP GIT ACCESS" >> ~/.netrc
+chmod 600 ~/.netrc
+
+# Ensure clean-up
+trap 'sed -i.bak "/# BEGIN TEMP GIT ACCESS/,/# END TEMP GIT ACCESS/d" ~/.netrc; rm -f ~/.netrc.bak' EXIT
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DESTINATION_BRANCH_NAME="main"
+
+# Run copybara with the springhelloworld configuration
+copybara \
+  --git-committer-email "viaduct-maintainers@airbnb.com" \
+  --git-committer-name "ViaductBot" \
+  --git-destination-push "$DESTINATION_BRANCH_NAME" \
+  --git-destination-url="$DESTINATION_REPO" \
+  "$SCRIPT_DIR"/../../copy.bara.sky airbnb-viaduct-to-spring-starter
+
+# Google has an integration test, expecting 4 for NO_OP.
+# https://github.com/google/copybara/blob/master/copybara/integration/tool_test.sh#L24
+# This also reinforces what we see in CI when there is no diff to merge.
+
+NO_OP_EXIT_CODE=4
+exit_code=$?
+if [ $exit_code -eq 0 ] || [ $exit_code -eq $NO_OP_EXIT_CODE ]; then
+    exit 0
+else
+    exit $exit_code
+fi

--- a/demoapps/springhelloworld/copy.bara.sky
+++ b/demoapps/springhelloworld/copy.bara.sky
@@ -1,0 +1,72 @@
+# Syncs commits from airbnb/viaduct springhelloworld to viaduct-graphql/spring-starter repo
+# Based on the main viaduct OSS copybara configuration
+
+load("//projects/viaduct/oss/author_mappings", "AUTHOR_MAPPINGS", "DEFAULT_AUTHOR", "transform_authors")
+load("//projects/viaduct/oss/message_scrubber", "strip_commit_body_keep_metadata")
+
+core.workflow(
+    name = "airbnb-viaduct-to-spring-starter",
+    mode = "ITERATIVE",
+    origin = git.origin(
+        url = "https://github.com/airbnb/viaduct.git",  # airbnb/viaduct GitHub repo
+        ref = "master",
+        partial_fetch = True,
+        describe_version = False,
+    ),
+    origin_files = glob(
+        include = ["demoapps/springhelloworld/**"],
+        exclude = [
+            "**/copy.bara.sky",
+            "**/*.bara.sky", 
+            "**/_infra/**",
+            "**/BUILD.bazel",
+        ],
+    ),
+    destination = git.destination(
+        url = "https://github.com/viaduct-graphql/spring-starter.git",
+        fetch = "main",
+    ),
+    authoring = authoring.pass_thru(default = DEFAULT_AUTHOR),
+    transformations = [
+        # Move from the nested path to root
+        core.move("demoapps/springhelloworld/", ""),
+        # Strip PR numbers from commit messages
+        metadata.scrubber(r"\s+\(#\d+\)$", replacement = ""),
+        # Transform authors and clean commit messages
+        core.transform([transform_authors, strip_commit_body_keep_metadata]),
+    ],
+)
+
+# Workflow for creating initial commit with all current content
+core.workflow(
+    name = "initial-commit",
+    mode = "SQUASH", 
+    origin = git.origin(
+        url = "https://github.com/airbnb/viaduct.git",  # airbnb/viaduct GitHub repo
+        ref = "master",
+        partial_fetch = True,
+        describe_version = False,
+    ),
+    origin_files = glob(
+        include = ["demoapps/springhelloworld/**"],
+        exclude = [
+            "**/copy.bara.sky",
+            "**/*.bara.sky",
+            "**/_infra/**", 
+            "**/BUILD.bazel",
+        ],
+    ),
+    destination = git.destination(
+        url = "https://github.com/viaduct-graphql/spring-starter.git",
+        fetch = "main",
+    ),
+    authoring = authoring.overwrite(DEFAULT_AUTHOR),
+    transformations = [
+        # Move from nested path to root
+        core.move("demoapps/springhelloworld/", ""),
+        # Set initial commit message
+        metadata.replace_message(
+            "Initial Viaduct Spring Hello World starter project\n\nThis is the initial commit of the Viaduct Spring starter project, containing a Spring Boot Hello World example to demonstrate Viaduct GraphQL capabilities.",
+        ),
+    ],
+)


### PR DESCRIPTION
## Summary
- Adds CircleCI jobs for sync-cli-starter and sync-spring-starter to automatically sync demo applications to external starter repositories
- Includes copybara configuration files for both clihelloworld and springhelloworld demo applications
- Adds comprehensive infrastructure documentation in demoapps/_infra/README.md
- Sets up automated sync from airbnb/viaduct to viaduct-graphql repositories (cli-starter and spring-starter)

## Changes Made
- **CircleCI Configuration**: Added sync-cli-starter and sync-spring-starter jobs that run after successful tests and lint checks
- **Copybara Scripts**: Added sync scripts for both demo applications to handle external repository syncing
- **Configuration Files**: Added copy.bara.sky files for both demo applications with proper transformations
- **Documentation**: Added comprehensive README explaining the setup, troubleshooting, and manual sync procedures

## Dependencies
- Requires environment variables CLI_STARTER_GITHUB_TOKEN and SPRING_STARTER_GITHUB_TOKEN to be configured in CircleCI
- Jobs only run on main/master branches to prevent unnecessary syncs from feature branches

## Test plan
- [x] Verify CircleCI configuration syntax is valid
- [x] Confirm all required files are present and executable
- [x] Test manual sync scripts locally (if tokens are available)
- [ ] Deploy to staging and verify sync jobs execute successfully
- [ ] Monitor initial sync to ensure proper file transformations
