### PR TITLE
Fix typo in documentation: taht -> that

### DIFF
--- a/docs/content/docs/getting_started/_index.md
+++ b/docs/content/docs/getting_started/_index.md
@@ -83,7 +83,7 @@ plugins {
 }
 ```
 
-You can see the two Viaduct plugins appearing here.  Viaduct applications are structured as multi-project Gradle builds.  The root project must contain the _application_ plugin shown above: this plugin coordinates certain build processes across the engine application.  In addition, one or more projects also apply the _module_ plugin, which indicates that that project contains application code (in our case, the code found in `HelloWorldResolvers.kt`).  As this example shows, a Viaduct application can be as simple as a single project build, in which case both plugins are applied to taht one project.
+You can see the two Viaduct plugins appearing here.  Viaduct applications are structured as multi-project Gradle builds.  The root project must contain the _application_ plugin shown above: this plugin coordinates certain build processes across the engine application.  In addition, one or more projects also apply the _module_ plugin, which indicates that that project contains application code (in our case, the code found in `HelloWorldResolvers.kt`).  As this example shows, a Viaduct application can be as simple as a single project build, in which case both plugins are applied to that one project.
 
 ## Extending the Application
 


### PR DESCRIPTION
## Description
Fix a typo in the getting started page of the documentation.

## Motivation and Context
My eye got caught on it while I was reading, and I figured I could do something about it.

## How has this been tested?
Honestly, I didn't test it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
