### PR TITLE
test: add appliedDirectives test coverage for args and scalars

### DIFF
--- a/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/test/ViaductExtendedSchemaContract.kt
+++ b/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/test/ViaductExtendedSchemaContract.kt
@@ -404,18 +404,25 @@ interface ViaductExtendedSchemaContract {
 
     @Test
     fun `test appliedDirectives returns the right list of directive names`() {
-        // TODO(https://app.asana.com/1/150975571430/project/1203659453427089/task/1210815630416759?focus=true): add tests for directives on args & scalars
         makeSchema(
             """
             directive @d1 on OBJECT | INPUT_OBJECT | ENUM | INTERFACE | UNION
             directive @d2 on OBJECT | INPUT_OBJECT | ENUM | INTERFACE | UNION
             directive @d3 on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
             directive @d4 on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+            directive @d5 on ARGUMENT_DEFINITION
+            directive @d6 on ARGUMENT_DEFINITION
+            directive @d7 on SCALAR
+            directive @d8 on SCALAR
+            scalar CustomScalar @d7
+            extend scalar CustomScalar @d8
             type Query @d1 {
                 f1: String @d3
+                f3(arg1: String @d5): Int
             }
             extend type Query @d2 {
                 f2: Int @d3 @d4
+                f4(arg2: Int @d5 @d6): String
             }
             enum Enum @d1 {
                 V1 @d3
@@ -431,6 +438,7 @@ interface ViaductExtendedSchemaContract {
             }
             interface Interface @d1 {
                 f1: Enum @d3
+                f3(arg3: Boolean @d5): String
             }
             extend interface Interface @d2 {
                 f2: String @d3 @d4
@@ -470,6 +478,18 @@ interface ViaductExtendedSchemaContract {
             }
             withField("Interface", "f2") {
                 assertEquals(listOf("d3", "d4"), it.appliedDirectives.map { it.name })
+            }
+            withArg("Query", "f3", "arg1") {
+                assertEquals(listOf("d5"), it.appliedDirectives.map { it.name })
+            }
+            withArg("Query", "f4", "arg2") {
+                assertEquals(listOf("d5", "d6"), it.appliedDirectives.map { it.name })
+            }
+            withArg("Interface", "f3", "arg3") {
+                assertEquals(listOf("d5"), it.appliedDirectives.map { it.name })
+            }
+            withType("CustomScalar") {
+                assertEquals(listOf("d7", "d8"), it.appliedDirectives.map { it.name })
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds test coverage for directives applied to arguments and scalar types in `ViaductExtendedSchemaContract`
- Resolves the TODO comment requesting these test cases

## Rationale
The existing test suite had a TODO comment indicating that test coverage was needed for directives on `ARGUMENT_DEFINITION` and `SCALAR` locations. This PR completes that test coverage to ensure the `appliedDirectives` functionality works correctly for these GraphQL schema elements.

## Changes
- Added `@d5` and `@d6` directives targeting `ARGUMENT_DEFINITION` 
- Added `@d7` and `@d8` directives targeting `SCALAR`
- Created `CustomScalar` type with applied directives for testing scalars
- Added field arguments (`arg1`, `arg2`, `arg3`) with applied directives for testing arguments
- Added assertions verifying that `appliedDirectives` correctly returns directive names for both arguments and scalars

## Test Coverage
- Arguments: Tests single and multiple directives on arguments across Query and Interface types
- Scalars: Tests single and extended scalar directives on custom scalar type

Fixes #5