### PR TITLE
Fix broken URL tag to StarWars repo

### DIFF
--- a/docs/content/docs/getting_started/starwars/_index.md
+++ b/docs/content/docs/getting_started/starwars/_index.md
@@ -20,8 +20,7 @@ The StarWars demo showcases:
 
 ## Getting the starwars application
 
-The StarWars application is available on GitHub at [github.com/viaduct-graphql/starwars](https://github.com/viaduct-
-graphql/starwars).
+The StarWars application is available on GitHub at [github.com/viaduct-graphql/starwars](https://github.com/viaduct-graphql/starwars).
 
 ```shell
 git clone https://github.com/viaduct-graphql/starwars.git


### PR DESCRIPTION
The formatting broke the URL to the repo, this is just a simple fix for QoL.