### PR TITLE
Fix Dokka/Jacoco variant ambiguity

### DIFF
--- a/build-logic/src/main/kotlin/conventions/dokka.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/dokka.gradle.kts
@@ -9,6 +9,14 @@ plugins {
     id("org.jetbrains.dokka-javadoc")
 }
 
+// Suppress Dokka's internal consumable configurations to avoid Gradle variant ambiguity
+// with other plugins like jacoco-report-aggregation
+configurations.configureEach {
+    if (name.contains("dokka", ignoreCase = true) && name.contains("Consumable", ignoreCase = true)) {
+        isCanBeConsumed = false
+    }
+}
+
 dokka {
     // Shared configuration for documented modules goes here
     moduleVersion.set(project.version.toString())


### PR DESCRIPTION
Fixes the build failure introduced in PR #149.

## Problem
The Dokka plugin creates multiple consumable configurations (HTML and Javadoc outputs). When the  plugin tries to resolve dependencies for the  task, it encounters these Dokka variants and cannot distinguish between them, causing a Gradle variant ambiguity error.

## Solution
Configure Dokka's internal consumable configurations to not be consumable outside of documentation tasks by setting  for configurations that contain "dokka" and "Consumable" in their names.

## Testing
- Local gradle build should now pass
- CI tests should complete successfully
- Dokka documentation generation should continue to work as expected

Fixes #149