### PR TITLE
fix(ci): resolve trigger-all-builds script failures

### DIFF
--- a/.github/workflows/trigger-all-builds.yml
+++ b/.github/workflows/trigger-all-builds.yml
@@ -18,9 +18,11 @@ jobs:
       - name: Trigger all build combinations
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
           echo "🚀 Triggering builds on all supported OS and Java combinations..."
           echo "Reason: ${{ inputs.reason || 'Called from another workflow' }}"
+          echo "Branch: ${{ github.ref_name }}"
           chmod +x ./.github/scripts/trigger_all_builds.sh
           ./.github/scripts/trigger_all_builds.sh
         shell: bash


### PR DESCRIPTION
## Type
fix(ci)

## Description
Resolve trigger-all-builds script failures that prevented successful execution

## Problem
The trigger-all-builds workflow was failing with exit code -1 and triggering builds on the wrong branch:

1. Script exited after first successful trigger due to bash arithmetic evaluation in `set -e` mode
2. Triggered workflows defaulted to main branch instead of using the caller's branch

## Solution

### Fixed arithmetic operation exit code issue
- **Before**: `((counter++))` returned 0 when counter was 0, causing `set -e` to exit
- **After**: `counter=$((counter + 1))` doesn't trigger exit on evaluation

### Fixed branch targeting
- Added `GITHUB_REF` environment variable passing from workflow to script
- Added branch detection logic in script (supports both GitHub Actions and local execution)
- Added `--ref "${BRANCH_REF}"` flag to `gh workflow run` command

## Changes
- `.github/scripts/trigger_all_builds.sh`:
  - Changed arithmetic: `((counter++))` → `counter=$((counter + 1))`
  - Added branch detection from `GITHUB_REF` or current git branch
  - Added `--ref` parameter to workflow triggers
  
- `.github/workflows/trigger-all-builds.yml`:
  - Added `GITHUB_REF: ${{ github.ref }}` environment variable
  - Added branch display in output

## Testing
Verified on `release/v0.9.0` branch (run [#19142070264](https://github.com/airbnb/viaduct/actions/runs/19142070264)):
- ✅ All 9 build combinations triggered (3 OS × 3 Java versions)
- ✅ All builds executed on correct branch (`release/v0.9.0`)
- ✅ Zero failed triggers
- ✅ Complete execution in 28 seconds

## Breaking Changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)