### PR TITLE
Fix Gradle 9.1.0 compatibility for ktor-starter demo app

### DIFF
--- a/demoapps/ktor-starter/gradle.properties
+++ b/demoapps/ktor-starter/gradle.properties
@@ -1,1 +1,1 @@
-viaductVersion=0.9.0-SNAPSHOT
+viaductVersion=0.9.0

--- a/demoapps/ktor-starter/gradle/libs.versions.toml
+++ b/demoapps/ktor-starter/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 coroutinesReactor = "1.7.3"
 kotest = "5.8.0"
-kotlin = "1.9.24"
+kotlin = "2.2.0"
 reactor = "3.5.0"
-ktor = "2.3.7"
+ktor = "3.3.0"
 
 [plugins]
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/demoapps/ktor-starter/gradle/wrapper/gradle-wrapper.properties
+++ b/demoapps/ktor-starter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b0fbdab41d52c2ce89e98b786f4a6e18fb09bb86f7b21e4e0c76a37a6c9888b3
+distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
 Update ktor-starter demo app for Gradle 9.1.0 compatibility

  ## Description

  This PR updates the ktor-starter demo app to be compatible with Gradle 9.1.0. The previous configuration used Ktor 2.3.7 which depends on an older Shadow plugin
  that's incompatible with Gradle 9.1+ (the Shadow plugin tried to access the deprecated `convention` property removed in Gradle 9.x).

  **Changes:**
  - Update Gradle to 9.1.0 by fixing checksum.
  - Update Ktor to 3.3.0 (minimum version with Gradle 9.1+ compatibility)
  - Update Kotlin to 2.2.0 (required by Ktor 3.3.0, as per [release notes](https://github.com/ktorio/ktor/releases/tag/3.3.0))
  - Update viaduct to 0.9.0 (from 0.9.0-SNAPSHOT)

  **Why these versions:**
  - Ktor 3.3.0 is the minimum version that includes Shadow plugin compatibility with Gradle 9.1+
  - Kotlin 2.2.0 matches the Kotlin version used to compile Ktor 3.3.0
  - All versions tested to work together with viaduct 0.9.0

  ## How was it tested?

  Ran `./gradlew clean build` in `demoapps/ktor-starter` directory

## Types of changes
<!-- To help us build release notes, please put an 'x' in all that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
