### PR TITLE
Register CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+viaduct.airbnb.tech


### PR DESCRIPTION
## Description
Register the new CNAME to trigger a default GH page redirect

I know this is currently being managed by a different infrastructure committing this change anyway for consistency

## How was it tested?  What documentation was provided?
Done across all other airbnb sites
