### PR TITLE
build: add github action to enforce conventional commit format

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -3,6 +3,7 @@ name: PR Conventional Commit Validation
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Add a Github Action to enforce the conventional commit format on pull requests

## How was it tested?  What documentation was provided?

Manual
