### PR TITLE
docs: Improve IDE testing guide with automated Claude Code testing instructions

### DIFF
--- a/docs/content/docs/contributors/ide_testing/_index.md
+++ b/docs/content/docs/contributors/ide_testing/_index.md
@@ -8,21 +8,54 @@ weight: 3
 
 This guide outlines a comprehensive testing procedure to ensure proper integration and functionality of the Viaduct Gradle plugins within various Integrated Development Environments (IDEs). These plugins perform extensive code generation, which substantially complicates IDE integration. The code generation process is triggered upon modification of files within the `src/main/viaduct/schema` directories of the modules that make up a Viaduct application that have the `.graphqls` extension (we call these files collectively the module's _schema partition_).
 
+## Automated Testing with Claude Code
+
+### Running the Test Command
+
+Execute the following command to run automated IDE compatibility testing with appropriate permissions:
+
+```bash
+airchat -- --settings '{
+    "sandbox": {
+      "enabled": true,
+      "autoAllowBashIfSandboxed": true,
+      "allowUnsandboxedCommands": false,
+      "excludedCommands": [],
+      "network": {
+        "allowUnixSockets": [],
+        "allowLocalBinding": false
+      }
+    },
+    "permissions": {
+      "allow": [
+        "Read(./**)",
+        "Edit(./**)"
+      ],
+      "deny": [
+        "Read(../)",
+        "Edit(../)",
+        "WebFetch"
+      ]
+    }
+  }'
+```
+
+### Test Prompt
+
 Copy and paste this prompt into Claude Code to execute automated IDE testing:
 
----
-
+```text
 Execute automated IDE compatibility testing for the Viaduct GraphQL code generation plugins.
 
 **Setup:**
 
 - IntelliJ IDEA should be open with viaduct project loaded (not individual demo apps)
-- IntelliJ MCP server should be running at `http://127.0.0.1:64342/sse`
+- IntelliJ MCP server should be running at `http://localhost:64342/sse`
 - Playwright MCP should be available for browser testing
 
 **Instructions:**
 
-1. Read `Guide To Testing IDEs.md` to understand the test scenarios
+1. Read viaduct/docs/content/docs/contributors/ide_testing/_index.md to understand the test scenarios
 2. Focus on the **starwars** demo application only
 3. Create IntelliJ run configurations for:
    - QueryResolverUnitTests
@@ -45,6 +78,15 @@ Execute automated IDE compatibility testing for the Viaduct GraphQL code generat
 - Target 80-85% test coverage
 
 Generate a detailed test report showing what was tested, results achieved, and any limitations encountered.
+```
+
+### Prerequisites
+
+Before running the automated tests, ensure:
+
+- IntelliJ IDEA is open with the viaduct project loaded (not individual demo apps)
+- IntelliJ MCP server is running at `http://localhost:64342/sse`
+- Playwright MCP is available for browser testing
 
 ## Test Procedures
 


### PR DESCRIPTION
## Summary

Enhanced the IDE testing guide to make it easier to run automated IDE compatibility tests using Claude Code.

## Changes

- **Added airchat command with settings**: Included the complete `airchat` command with sandbox and permission settings for running automated tests
- **Made content copyable**: Wrapped both the command and prompt in code blocks (bash and text respectively) so Hugo will render them with copy buttons
- **Fixed guide path reference**: Updated prompt to reference the correct path `viaduct/docs/content/docs/contributors/ide_testing/_index.md` instead of the non-existent `Guide To Testing IDEs.md`
- **Improved structure**: Reorganized the "Automated Testing with Claude Code" section with clear subsections for Running the Test Command, Test Prompt, and Prerequisites
- **Fixed localhost reference**: Changed `127.0.0.1` to `localhost` for the IntelliJ MCP server URL

## Benefits

- Reduces permission prompts during testing with auto-allow bash in sandbox mode
- Makes it much easier for contributors to copy and execute automated tests
- Provides clear, step-by-step instructions with proper numbering for the LLM to follow
- Improves discoverability by referencing the correct file path

## Testing

Verified markdown syntax and code block formatting renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)