### PR TITLE
refactor(engine): move exception handler classes to tenant/runtime

### DIFF
--- a/engine/runtime/build.gradle.kts
+++ b/engine/runtime/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(libs.viaduct.shared.graphql)
     implementation(libs.viaduct.shared.logging)
     implementation(libs.viaduct.snipped.errors)
-    implementation(libs.viaduct.tenant.api)
     implementation(libs.micrometer.core)
 
     testFixturesApi(libs.graphql.java)
@@ -58,6 +57,7 @@ dependencies {
     testImplementation(libs.strikt.core)
     testImplementation(libs.viaduct.engine.wiring)
     testImplementation(libs.viaduct.service.runtime)
+    testImplementation(libs.viaduct.tenant.runtime)
     testImplementation(libs.viaduct.shared.arbitrary)
     testImplementation(testFixtures(libs.viaduct.engine.api))
     testImplementation(testFixtures(libs.viaduct.engine.runtime))

--- a/engine/runtime/src/test/kotlin/viaduct/engine/runtime/AccessCheckExecutionTest.kt
+++ b/engine/runtime/src/test/kotlin/viaduct/engine/runtime/AccessCheckExecutionTest.kt
@@ -19,7 +19,7 @@ import viaduct.engine.api.mocks.mkEngineObjectData
 import viaduct.engine.api.mocks.mkRSS
 import viaduct.engine.api.mocks.mkSchemaWithWiring
 import viaduct.engine.api.mocks.runFeatureTest
-import viaduct.engine.runtime.execution.ViaductDataFetcherExceptionHandler
+import viaduct.tenant.runtime.execution.ViaductDataFetcherExceptionHandler
 import viaduct.service.api.spi.ResolverErrorBuilder
 import viaduct.service.api.spi.ResolverErrorReporter
 

--- a/engine/wiring/build.gradle.kts
+++ b/engine/wiring/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.viaduct.engine.api)
     implementation(libs.viaduct.engine.runtime)
     implementation(libs.viaduct.service.api)
+    implementation(libs.viaduct.tenant.runtime)
     implementation(libs.viaduct.shared.deferred)
     implementation(libs.viaduct.shared.utils)
 

--- a/engine/wiring/src/main/kotlin/viaduct/engine/EngineConfiguration.kt
+++ b/engine/wiring/src/main/kotlin/viaduct/engine/EngineConfiguration.kt
@@ -13,7 +13,7 @@ import viaduct.engine.api.fragment.ViaductExecutableFragmentParser
 import viaduct.engine.api.instrumentation.resolver.ViaductResolverInstrumentation
 import viaduct.engine.runtime.ViaductFragmentLoader
 import viaduct.engine.runtime.execution.DefaultCoroutineInterop
-import viaduct.engine.runtime.execution.ViaductDataFetcherExceptionHandler
+import viaduct.tenant.runtime.execution.ViaductDataFetcherExceptionHandler
 import viaduct.service.api.spi.FlagManager
 import viaduct.service.api.spi.GlobalIDCodec
 import viaduct.service.api.spi.ResolverErrorBuilder

--- a/service/runtime/build.gradle.kts
+++ b/service/runtime/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(libs.viaduct.engine.api)
     implementation(libs.viaduct.engine.runtime)
     implementation(libs.viaduct.engine.wiring)
+    implementation(libs.viaduct.tenant.runtime)
 
     implementation(libs.viaduct.shared.graphql)
     implementation(libs.viaduct.shared.utils)

--- a/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaduct.kt
+++ b/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaduct.kt
@@ -31,7 +31,7 @@ import viaduct.engine.api.coroutines.CoroutineInterop
 import viaduct.engine.api.instrumentation.resolver.ViaductResolverInstrumentation
 import viaduct.engine.runtime.execution.DefaultCoroutineInterop
 import viaduct.engine.runtime.execution.TenantNameResolver
-import viaduct.engine.runtime.execution.ViaductDataFetcherExceptionHandler
+import viaduct.tenant.runtime.execution.ViaductDataFetcherExceptionHandler
 import viaduct.engine.runtime.tenantloading.DispatcherRegistryFactory
 import viaduct.engine.runtime.tenantloading.RequiredSelectionsAreInvalid
 import viaduct.service.api.ExecutionInput

--- a/tenant/runtime/build.gradle.kts
+++ b/tenant/runtime/build.gradle.kts
@@ -17,7 +17,9 @@ dependencies {
     implementation(libs.viaduct.tenant.api)
 
     implementation(libs.viaduct.engine.api)
+    implementation(libs.viaduct.engine.runtime)
     implementation(libs.viaduct.service.api)
+    implementation(libs.viaduct.snipped.errors)
 
     implementation(libs.viaduct.shared.graphql)
     implementation(libs.viaduct.shared.utils)

--- a/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/execution/UnwrapExceptionUtil.kt
+++ b/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/execution/UnwrapExceptionUtil.kt
@@ -1,4 +1,4 @@
-package viaduct.engine.runtime.execution
+package viaduct.tenant.runtime.execution
 
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.CompletionException

--- a/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/execution/ViaductDataFetcherExceptionHandler.kt
+++ b/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/execution/ViaductDataFetcherExceptionHandler.kt
@@ -1,4 +1,4 @@
-package viaduct.engine.runtime.execution
+package viaduct.tenant.runtime.execution
 
 import com.airbnb.viaduct.errors.ViaductException
 import graphql.GraphQLError

--- a/tenant/runtime/src/test/kotlin/viaduct/tenant/runtime/execution/ViaductDataFetcherExceptionHandlerTest.kt
+++ b/tenant/runtime/src/test/kotlin/viaduct/tenant/runtime/execution/ViaductDataFetcherExceptionHandlerTest.kt
@@ -1,4 +1,4 @@
-package viaduct.engine.runtime.execution
+package viaduct.tenant.runtime.execution
 
 import com.airbnb.viaduct.errors.ViaductException
 import graphql.Scalars


### PR DESCRIPTION
**PUBLIC**
refactor(engine): move exception handler classes to tenant/runtime

Move ViaductDataFetcherExceptionHandler and UnwrapExceptionUtil from engine/runtime to tenant/runtime to break the engine/runtime -> tenant/api dependency cycle.

This enables moving CheckerDispatcher into engine/runtime without creating:
engine/api -> engine/runtime -> tenant/api -> engine/api

Changes:
- Move UnwrapExceptionUtil to tenant/runtime/execution
- Move ViaductDataFetcherExceptionHandler to tenant/runtime/execution
- Move ViaductDataFetcherExceptionHandlerTest to tenant/runtime
- Update dependencies in build.gradle.kts files:
  - engine/runtime: remove tenant/api, add tenant/runtime (test)
  - tenant/runtime: add engine/runtime, snipped/errors
  - engine/wiring: add tenant/runtime
  - service/runtime: add tenant/runtime
- Update imports in consuming files

## Test Plan
- [x] Ran `./gradlew :core:engine:engine-runtime:compileKotlin :core:engine:engine-wiring:compileKotlin :core:service:service-runtime:compileKotlin :core:tenant:tenant-runtime:compileKotlin` - all modules compile successfully
- [x] Ran `./gradlew :core:engine:engine-runtime:test :core:tenant:tenant-runtime:test` - all tests pass