### PR TITLE
build: only run scheduled release job on airbnb/viaduct repo

### DIFF
--- a/.github/workflows/prepare-release-candidate.yml
+++ b/.github/workflows/prepare-release-candidate.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   prepare-release-candidate:
     runs-on: ubuntu-latest
+    if: github.repository == 'airbnb/viaduct'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Do not run the scheduled release candidate preparation job on forks.

## How was it tested?  What documentation was provided?

n/a

## Types of changes
<!-- To help us build release notes, please put an 'x' in all that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
