### PR TITLE
fix(demoapps): resolve standalone mode dependency resolution

### DIFF
--- a/demoapps/cli-starter/gradle/libs.versions.toml
+++ b/demoapps/cli-starter/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+viaduct = "0.20.0-SNAPSHOT"
 kotlin = "2.2.21"
 logback = "1.5.21"
 coroutines = "1.5.2"
@@ -14,9 +15,9 @@ viaduct-module = { id = "com.airbnb.viaduct.module-gradle-plugin", version.ref =
 [libraries]
 # Viaduct
 viaduct-bom = { group = "com.airbnb.viaduct", name = "bom", version.ref = "viaduct" }
-viaduct-api = { group = "com.airbnb.viaduct", name = "api" }
-viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime" }
-viaduct-test-fixtures = { group = "com.airbnb.viaduct", name = "test-fixtures" }
+viaduct-api = { group = "com.airbnb.viaduct", name = "api", version.ref = "viaduct" }
+viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime", version.ref = "viaduct" }
+viaduct-test-fixtures = { group = "com.airbnb.viaduct", name = "test-fixtures", version.ref = "viaduct" }
 
 # Runtime dependencies
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }

--- a/demoapps/cli-starter/settings.gradle.kts
+++ b/demoapps/cli-starter/settings.gradle.kts
@@ -1,7 +1,5 @@
 // tag::dependency-resolution[30] How to setup settings.gradle.kts on a new viaduct application
 
-val viaductVersion: String by settings
-
 // When part of composite build, use local gradle-plugins
 // When standalone, use Maven Central (only after version is published)
 pluginManagement {
@@ -19,11 +17,5 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-    }
-    versionCatalogs {
-        create("libs") {
-            // This injects a dynamic value that your TOML can reference.
-            version("viaduct", viaductVersion)
-        }
     }
 }

--- a/demoapps/jetty-starter/gradle/libs.versions.toml
+++ b/demoapps/jetty-starter/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+viaduct = "0.20.0-SNAPSHOT"
 jetty = "11.0.26"
 kotest = "5.8.1"
 kotlin = "1.9.24"
@@ -16,9 +17,9 @@ viaduct-module = { id = "com.airbnb.viaduct.module-gradle-plugin", version.ref =
 
 [libraries]
 viaduct-bom = { group = "com.airbnb.viaduct", name = "bom", version.ref = "viaduct" }
-viaduct-api = { group = "com.airbnb.viaduct", name = "api" }
-viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime" }
-viaduct-test-fixtures = { group = "com.airbnb.viaduct", name = "test-fixtures" }
+viaduct-api = { group = "com.airbnb.viaduct", name = "api", version.ref = "viaduct" }
+viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime", version.ref = "viaduct" }
+viaduct-test-fixtures = { group = "com.airbnb.viaduct", name = "test-fixtures", version.ref = "viaduct" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
 jakarta-servlet-api = { group = "jakarta.servlet", name = "jakarta.servlet-api", version.ref = "jakarta" }
 jetty-server = { group = "org.eclipse.jetty", name = "jetty-server", version.ref = "jetty" }

--- a/demoapps/jetty-starter/settings.gradle.kts
+++ b/demoapps/jetty-starter/settings.gradle.kts
@@ -1,7 +1,5 @@
 rootProject.name = "viaduct-jetty-starter"
 
-val viaductVersion: String by settings
-
 // When part of composite build, use local gradle-plugins
 // When standalone, use Maven Central (only after version is published)
 pluginManagement {
@@ -19,12 +17,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-    }
-    versionCatalogs {
-        create("libs") {
-            // This injects a dynamic value that your TOML can reference.
-            version("viaduct", viaductVersion)
-        }
     }
 }
 

--- a/demoapps/ktor-starter/gradle/libs.versions.toml
+++ b/demoapps/ktor-starter/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+viaduct = "0.20.0-SNAPSHOT"
 coroutinesReactor = "1.10.2"
 kotest = "6.0.5"
 kotlin = "2.2.21"
@@ -14,9 +15,9 @@ viaduct-module = { id = "com.airbnb.viaduct.module-gradle-plugin", version.ref =
 [libraries]
 # Viaduct
 viaduct-bom = { group = "com.airbnb.viaduct", name = "bom", version.ref = "viaduct" }
-viaduct-api = { group = "com.airbnb.viaduct", name = "api" }
-viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime" }
-viaduct-test-fixtures = { group = "com.airbnb.viaduct", name = "test-fixtures" }
+viaduct-api = { group = "com.airbnb.viaduct", name = "api", version.ref = "viaduct" }
+viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime", version.ref = "viaduct" }
+viaduct-test-fixtures = { group = "com.airbnb.viaduct", name = "test-fixtures", version.ref = "viaduct" }
 
 # Common libraries
 jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }

--- a/demoapps/ktor-starter/settings.gradle.kts
+++ b/demoapps/ktor-starter/settings.gradle.kts
@@ -1,7 +1,5 @@
 rootProject.name = "viaduct-ktor-starter"
 
-val viaductVersion: String by settings
-
 // When part of composite build, use local gradle-plugins
 // When standalone, use Maven Central (only after version is published)
 pluginManagement {
@@ -19,12 +17,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-    }
-    versionCatalogs {
-        create("libs") {
-            // This injects a dynamic value that your TOML can reference.
-            version("viaduct", viaductVersion)
-        }
     }
 }
 

--- a/demoapps/micronaut-starter/gradle/libs.versions.toml
+++ b/demoapps/micronaut-starter/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+viaduct = "0.20.0-SNAPSHOT"
 kotlin = "2.1.0"
 ksp = "2.1.0-1.0.29"
 micronaut = "4.7.4"

--- a/demoapps/micronaut-starter/settings.gradle.kts
+++ b/demoapps/micronaut-starter/settings.gradle.kts
@@ -1,7 +1,5 @@
 rootProject.name = "viaduct-micronaut-starter"
 
-val viaductVersion: String by settings
-
 // When part of composite build, use local gradle-plugins
 // When standalone, use Maven Central (only after version is published)
 pluginManagement {
@@ -18,12 +16,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-    }
-    versionCatalogs {
-        create("libs") {
-            // This injects a dynamic value that your TOML can reference.
-            version("viaduct", viaductVersion)
-        }
     }
 }
 

--- a/demoapps/starwars/gradle/libs.versions.toml
+++ b/demoapps/starwars/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+viaduct = "0.20.0-SNAPSHOT"
 coroutinesReactor = "1.10.2"
 kotest = "6.0.5"
 kotlin = "2.2.21"
@@ -24,12 +25,12 @@ micronaut-inject-java = { group = "io.micronaut", name = "micronaut-inject-java"
 micronaut-validation = { group = "io.micronaut", name = "micronaut-http-validation", version.ref = "micronaut" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 viaduct-bom = { group = "com.airbnb.viaduct", name = "bom", version.ref = "viaduct" }
-viaduct-api = { group = "com.airbnb.viaduct", name = "api" }
-viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime" }
-viaduct-engine-wiring = { group = "com.airbnb.viaduct", name = "engine-wiring" }
-viaduct-service-wiring = { group = "com.airbnb.viaduct", name = "service-wiring" }
-viaduct-tenant-api = { group = "com.airbnb.viaduct", name = "tenant-api" }
-viaduct-tenant-runtime = { group = "com.airbnb.viaduct", name = "tenant-runtime" }
+viaduct-api = { group = "com.airbnb.viaduct", name = "api", version.ref = "viaduct" }
+viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime", version.ref = "viaduct" }
+viaduct-engine-wiring = { group = "com.airbnb.viaduct", name = "engine-wiring", version.ref = "viaduct" }
+viaduct-service-wiring = { group = "com.airbnb.viaduct", name = "service-wiring", version.ref = "viaduct" }
+viaduct-tenant-api = { group = "com.airbnb.viaduct", name = "tenant-api", version.ref = "viaduct" }
+viaduct-tenant-runtime = { group = "com.airbnb.viaduct", name = "tenant-runtime", version.ref = "viaduct" }
 guice = { group = "com.google.inject", name = "guice", version.ref = "guice" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlinx-coroutines-reactor = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactor", version.ref = "coroutinesReactor" }

--- a/demoapps/starwars/settings.gradle.kts
+++ b/demoapps/starwars/settings.gradle.kts
@@ -1,5 +1,3 @@
-val viaductVersion: String by settings
-
 // When part of composite build, use local gradle-plugins
 // When standalone, use Maven Central (only after version is published)
 pluginManagement {
@@ -17,12 +15,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-    }
-    versionCatalogs {
-        create("libs") {
-            // This injects a dynamic value that your TOML can reference.
-            version("viaduct", viaductVersion)
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes demoapps failing to build in standalone mode
- Removes broken dynamic version injection via settings.gradle.kts
- Adds explicit viaduct versions in TOML files with proper version.ref

## Problem
Demoapps in standalone mode failed with:
```
Could not find com.airbnb.viaduct:api:.
```

The empty version (`.`) was caused by `versionCatalogs { create("libs") { version("viaduct", ...) } }` not loading the TOML file, and the TOML library entries lacking `version.ref = "viaduct"`.

## Solution
1. Remove `val viaductVersion: String by settings` and `versionCatalogs` block
2. Add `viaduct = "0.20.0-SNAPSHOT"` to each demoapp's `libs.versions.toml`
3. Add `version.ref = "viaduct"` to all Viaduct library declarations

For unpublished SNAPSHOTs, users can add `mavenLocal()` after running `publishToMavenLocal`.

## Test Plan
- [x] Verified composite mode still works: `./gradlew :cli-starter:build`
- [x] Verified dependency substitution works: dependencies show `-> project :api`

<public>
fix(demoapps): resolve standalone mode dependency resolution

Fixes demoapps failing to build in standalone mode with error
"Could not find com.airbnb.viaduct:api:." by adding explicit
viaduct versions to TOML files and removing broken dynamic
version injection.
</public>