### PR TITLE
fix: Configure shadow jar as main artifact for fat jar modules

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -44,9 +44,25 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("org.slf4j", "viaduct.shaded.slf4j")
 }
 
-// Make shadowJar replace the default jar
+// Make the default jar task produce the shadow jar output
 tasks.named<Jar>("jar") {
-    archiveClassifier.set("thin")  // Move default jar out of the way
+    enabled = false
+}
+
+// Configure apiElements and runtimeElements to use shadow jar
+configurations {
+    named("apiElements") {
+        outgoing {
+            artifacts.clear()
+            artifact(tasks.shadowJar)
+        }
+    }
+    named("runtimeElements") {
+        outgoing {
+            artifacts.clear()
+            artifact(tasks.shadowJar)
+        }
+    }
 }
 
 tasks.named("assemble") {

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -60,9 +60,25 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("org.slf4j", "viaduct.shaded.slf4j")
 }
 
-// Make shadowJar replace the default jar
+// Make the default jar task produce the shadow jar output
 tasks.named<Jar>("jar") {
-    archiveClassifier.set("thin")  // Move default jar out of the way
+    enabled = false
+}
+
+// Configure apiElements and runtimeElements to use shadow jar
+configurations {
+    named("apiElements") {
+        outgoing {
+            artifacts.clear()
+            artifact(tasks.shadowJar)
+        }
+    }
+    named("runtimeElements") {
+        outgoing {
+            artifacts.clear()
+            artifact(tasks.shadowJar)
+        }
+    }
 }
 
 tasks.named("assemble") {

--- a/test-fixtures/build.gradle.kts
+++ b/test-fixtures/build.gradle.kts
@@ -33,9 +33,25 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("org.slf4j", "viaduct.shaded.slf4j")
 }
 
-// Make shadowJar replace the default jar
+// Make the default jar task produce the shadow jar output
 tasks.named<Jar>("jar") {
-    archiveClassifier.set("thin")  // Move default jar out of the way
+    enabled = false
+}
+
+// Configure apiElements and runtimeElements to use shadow jar
+configurations {
+    named("apiElements") {
+        outgoing {
+            artifacts.clear()
+            artifact(tasks.shadowJar)
+        }
+    }
+    named("runtimeElements") {
+        outgoing {
+            artifacts.clear()
+            artifact(tasks.shadowJar)
+        }
+    }
 }
 
 tasks.named("assemble") {


### PR DESCRIPTION
## Summary

- Fix shadow jar publishing so standalone consumers get the fat jar instead of the empty thin jar
- Configure `apiElements` and `runtimeElements` variants to use the shadow jar artifact
- Remove the `isCompositeBuild` conditional logic (no longer needed with proper fat jar publishing)

<public>
fix: Configure shadow jar as main artifact for fat jar modules

The shadow plugin was building fat jars correctly, but Gradle's apiElements and
runtimeElements variants were still pointing to the thin jar. This caused standalone
consumers to get an empty jar instead of the fat jar with bundled classes.
</public>

## Test Plan

- [x] Verified composite mode works: `./gradlew :cli-starter:test :jetty-starter:test`
- [x] Verified standalone mode works with mavenLocal (per RELEASE-RUNBOOK.md instructions)
- [x] Verified published module metadata now points to fat jar instead of thin jar