### PR TITLE
ci: add standalone demoapp tests workflow

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,26 @@
+name: Setup Build
+description: Common setup steps for checkout, Java, and Gradle
+
+inputs:
+  java-version:
+    description: 'Java version to use'
+    required: false
+    default: '21'
+  cache-read-only:
+    description: 'Whether to use read-only Gradle cache mode'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup JDK
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.java-version }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+      with:
+        cache-read-only: ${{ inputs.cache-read-only }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,25 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
+      - uses: ./.github/actions/setup-build
         with:
-          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            .gradle
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties', '**/libs.versions.toml', '**/build.gradle.kts') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
 
       - name: Download dependencies
         run: |
@@ -197,30 +181,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: ${{ matrix.java }}
+          cache-read-only: 'true'
+
       - uses: actions/download-artifact@v7
         with:
           name: build-java-${{ matrix.java }}-${{ matrix.os }}
           path: build/
-
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            .gradle
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties', '**/libs.versions.toml', '**/build.gradle.kts') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
 
       - name: Run tests
         id: run_tests
@@ -313,25 +282,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
+      - uses: ./.github/actions/setup-build
         with:
-          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            .gradle
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties', '**/libs.versions.toml', '**/build.gradle.kts') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          cache-read-only: 'true'
 
       - name: Run Detekt Static Analysis
         id: run_detekt
@@ -382,25 +336,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
+      - uses: ./.github/actions/setup-build
         with:
-          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            .gradle
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties', '**/libs.versions.toml', '**/build.gradle.kts') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          cache-read-only: 'true'
 
       - name: Run Ktlint Code Formatting Check
         id: run_ktlint
@@ -445,25 +384,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
+      - uses: ./.github/actions/setup-build
         with:
-          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            .gradle
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties', '**/libs.versions.toml', '**/build.gradle.kts') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          cache-read-only: 'true'
 
       - name: Verify coverage thresholds
         id: verify_coverage

--- a/.github/workflows/post-slack-alerts.yml
+++ b/.github/workflows/post-slack-alerts.yml
@@ -2,7 +2,7 @@ name: Post Slack Alerts
 
 on:
   workflow_run:
-    workflows: ["Build and Test (Gradle)"]
+    workflows: ["Build and Test (Gradle)", "Standalone Demo App Tests"]
     types:
       - completed
 

--- a/.github/workflows/standalone-demoapp-tests.yml
+++ b/.github/workflows/standalone-demoapp-tests.yml
@@ -1,0 +1,167 @@
+name: Standalone Demo App Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      java_versions:
+        description: "Java versions to run (array, e.g. [17,21])"
+        required: false
+        default: '["17","21"]'
+      os:
+        description: "Select operating system"
+        required: false
+        type: choice
+        options:
+          - ubuntu-latest
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
+          - macos-latest
+          - macos-26
+          - macos-15-intel
+          - macos-15
+          - macos-13
+          - macos-14
+        default: ubuntu-latest
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: standalone-demoapp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-to-maven-local:
+    runs-on: ubuntu-latest
+    name: Publish to Maven Local
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.parallel=false -Dorg.gradle.caching=true"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '21'
+
+      - name: Publish to Maven Local
+        run: ./gradlew publishToMavenLocal --no-daemon
+        shell: bash
+
+      - name: Upload Maven Local repository
+        uses: actions/upload-artifact@v6
+        with:
+          name: maven-local-repo
+          path: ~/.m2/repository
+          compression-level: 0  # JARs are already compressed; skip re-compression
+          retention-days: 1     # only needed within this run
+
+  test-demoapps:
+    needs: publish-to-maven-local
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        demoapp: [cli-starter, jetty-starter, ktor-starter, micronaut-starter]
+    name: Test ${{ matrix.demoapp }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '21'
+          cache-read-only: 'true'
+
+      - name: Download Maven Local repository
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local-repo
+          path: ~/.m2/repository
+
+      - name: Test ${{ matrix.demoapp }}
+        run: cd demoapps/${{ matrix.demoapp }} && USE_MAVEN_LOCAL=true ./gradlew test --no-daemon
+        shell: bash
+
+  test-starwars:
+    needs: publish-to-maven-local
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ inputs.os && fromJSON(format('["{0}"]', inputs.os)) || fromJSON('["ubuntu-latest"]') }}
+        java: ${{ fromJSON(inputs.java_versions || '["17","21"]') }}
+    name: Test starwars (Java ${{ matrix.java }}) ${{ matrix.os }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: ${{ matrix.java }}
+          cache-read-only: 'true'
+
+      - name: Download Maven Local repository
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local-repo
+          path: ~/.m2/repository
+
+      - name: Test starwars
+        run: cd demoapps/starwars && USE_MAVEN_LOCAL=true ./gradlew test --no-daemon
+        shell: bash
+
+  collect-failure-info:
+    runs-on: ubuntu-latest
+    needs: [publish-to-maven-local, test-demoapps, test-starwars]
+    if: failure()
+    steps:
+      - name: Collect failure metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=${{ github.run_id }}
+
+          failed_jobs=$(gh api repos/${{ github.repository }}/actions/runs/$run_id/jobs \
+            --jq '[.jobs[] | select(.conclusion=="failure") | .name] | join(", ")')
+
+          failed_steps=$(gh api repos/${{ github.repository }}/actions/runs/$run_id/jobs \
+            --jq '[.jobs[] | select(.conclusion=="failure") | .steps[] | select(.conclusion=="failure") | .name] | join(", ")')
+
+          mkdir -p slack-alert
+          cat > slack-alert/failure-info.json <<EOF
+          {
+            "workflow": "${{ github.workflow }}",
+            "run_number": "${{ github.run_number }}",
+            "repository": "${{ github.event.repository.name }}",
+            "failed_jobs": "$failed_jobs",
+            "failed_steps": "$failed_steps",
+            "branch": "${{ github.ref_name }}",
+            "actor": "${{ github.actor }}",
+            "sha": "${{ github.sha }}",
+            "server_url": "${{ github.server_url }}",
+            "repository_full": "${{ github.repository }}",
+            "run_id": "${{ github.run_id }}"
+          }
+          EOF
+        shell: bash
+
+      - name: Upload failure info artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: slack-alert
+          path: slack-alert/

--- a/.github/workflows/standalone-demoapp-tests.yml
+++ b/.github/workflows/standalone-demoapp-tests.yml
@@ -55,7 +55,7 @@ jobs:
           java-version: '21'
 
       - name: Publish to Maven Local
-        run: ./gradlew publishToMavenLocal --no-daemon
+        run: ./gradlew publishToMavenLocal -PpublishMinimal --no-daemon
         shell: bash
 
       - name: Upload Maven Local repository

--- a/build-logic/shared/build.gradle.kts
+++ b/build-logic/shared/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `kotlin-dsl`
+    kotlin("jvm")
     `maven-publish`
 }
 
@@ -33,3 +33,4 @@ publishing {
         }
     }
 }
+

--- a/build-logic/src/main/kotlin/buildroot/versioning.gradle.kts
+++ b/build-logic/src/main/kotlin/buildroot/versioning.gradle.kts
@@ -27,7 +27,7 @@ fun findVersionFile(start: File): File {
 val versionFile = findVersionFile(rootDir)
 val baseVersion: String = versionFile.readText().trim().ifEmpty { "0.0.0" }
 
-logger.lifecycle("Using version from VERSION file: $baseVersion")
+logger.info("Using version from VERSION file: $baseVersion")
 
 gradle.allprojects {
     group = "com.airbnb.viaduct"

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -22,6 +22,8 @@ abstract class ViaductPublishingExtension @Inject constructor(objects: ObjectFac
 
 val viaductPublishing = extensions.create<ViaductPublishingExtension>("viaductPublishing")
 
+val publishMinimal = providers.gradleProperty("publishMinimal").isPresent
+
 mavenPublishing {
     val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
     publishToMavenCentral(automaticRelease = true)
@@ -31,7 +33,10 @@ mavenPublishing {
     when {
         plugins.hasPlugin("java-platform") -> configure(JavaPlatform())
         plugins.hasPlugin("com.gradle.plugin-publish") -> configure(GradlePublishPlugin())
-        else -> configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationJavadoc"), sourcesJar = true))
+        else -> configure(KotlinJvm(
+            javadocJar = if (publishMinimal) JavadocJar.Empty() else JavadocJar.Dokka("dokkaGeneratePublicationJavadoc"),
+            sourcesJar = !publishMinimal
+        ))
     }
 }
 
@@ -74,8 +79,6 @@ afterEvaluate {
         setRequired {
             gradle.taskGraph.allTasks.any { it is PublishToMavenRepository }
         }
-        project.logger.lifecycle(publishing.publications.toString())
-        publishing.publications.forEach { project.logger.lifecycle("Publication: ${it.name}") }
         publishing.publications.forEach { sign(it) }
     }
 }

--- a/demoapps/micronaut-starter/settings.gradle.kts
+++ b/demoapps/micronaut-starter/settings.gradle.kts
@@ -7,11 +7,12 @@ val viaductVersion: String by settings
 pluginManagement {
     if (gradle.parent != null) {
         includeBuild("../../gradle-plugins")
-    }
-    repositories {
-        if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
-        mavenCentral()
-        gradlePluginPortal()
+    } else {
+        repositories {
+            if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
+            mavenCentral()
+            gradlePluginPortal()
+        }
     }
 }
 

--- a/included-builds/core/settings.gradle.kts
+++ b/included-builds/core/settings.gradle.kts
@@ -24,10 +24,12 @@ includeNamed(":tenant:codegen", "../..")
 includeNamed(":tenant:runtime", "../..")
 includeNamed(":tenant:wiring", "../..")
 
-// Include Java API modules
-includeNamed(":x:javaapi:api", "../..")
-includeNamed(":x:javaapi:codegen", "../..")
-includeNamed(":x:javaapi:runtime", "../..")
+// Include Java API modules (skipped when publishMinimal is set — not needed by demoapps)
+if (!providers.gradleProperty("publishMinimal").isPresent) {
+    includeNamed(":x:javaapi:api", "../..")
+    includeNamed(":x:javaapi:codegen", "../..")
+    includeNamed(":x:javaapi:runtime", "../..")
+}
 
 // Include all shared modules
 includeNamed(":shared:apiannotations", "../..")

--- a/test-fixtures/build.gradle.kts
+++ b/test-fixtures/build.gradle.kts
@@ -84,6 +84,11 @@ plugins.withId("org.jetbrains.kotlin.jvm") {
 }
 afterEvaluate {
     publishing.publications.withType<MavenPublication>().configureEach {
+        // The shadow jar bundles all Viaduct classes; transitive deps are intentionally
+        // stripped from the POM. The capability-based dep on tenant-api test fixtures
+        // cannot be represented in Maven POM but is irrelevant since the POM has no deps.
+        suppressPomMetadataWarningsFor("apiElements")
+        suppressPomMetadataWarningsFor("runtimeElements")
         pom.withXml {
             val deps = asNode().get("dependencies") as groovy.util.NodeList
             deps.forEach { (it as groovy.util.Node).parent().remove(it) }

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -38,6 +38,9 @@ publishing {
             artifact(tasks["sourcesJar"])
             artifact(emptyJavadocJar.get())
 
+            suppressPomMetadataWarningsFor("testFixturesApiElements")
+            suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
+
             pom {
                 name.set("Viaduct Tools")
                 description.set("A GraphQL-based microservice alternative.")


### PR DESCRIPTION
Closes the first half of #295, which is to build and test demo apps as "external" builds. (The second half — removing demoapps from the composite build — is a separate change.)

To do this, a new `Standalone Demo App Tests` workflow publishes all Viaduct artifacts to Maven Local and then tests each demo app in isolation — exactly as an external consumer would use them. This catches dependency-packaging bugs that composite builds hide via source substitution.

## Commits

**`ci: add setup-build composite action and migrate build-and-test to use it`**

Extracts the `setup-java` → `setup-gradle` sequence into `.github/actions/setup-build`, a composite action with a `cache-read-only` input. Migrates all five jobs in `build-and-test.yml` to use it, removing the redundant inline steps and the `actions/cache` steps that were duplicating what `gradle/actions/setup-gradle` already manages. Downstream jobs (`test`, `detekt`, `ktlint`, `coverage-verification`) pass `cache-read-only: true` — only the `build` job needs to write the cache.

**`ci: add standalone demoapp tests workflow`**

Three-job workflow in `.github/workflows/standalone-demoapp-tests.yml`:

| Job | Runs on | Purpose |
|-----|---------|---------| 
| `publish-to-maven-local` | ubuntu / Java 21 | `./gradlew publishToMavenLocal`; uploads `~/.m2/repository` as a workflow artifact |
| `test-demoapps` | ubuntu / Java 21 (matrix: cli-starter, jetty-starter, ktor-starter, micronaut-starter) | Downloads the artifact; runs `USE_MAVEN_LOCAL=true ./gradlew test` for each app in parallel |
| `test-starwars` | ubuntu × Java 17+21 (macOS available via `workflow_dispatch`) | Same, for the starwars demo app across Java versions |

Also adds `USE_MAVEN_LOCAL` support to all demoapps' `settings.gradle.kts` files and adds the new workflow to `post-slack-alerts.yml`.

The default `test-starwars` matrix uses Ubuntu only. macOS runner provisioning added ~4 min of queue time with no meaningful benefit (Viaduct publishes platform-independent JARs). macOS can still be selected via `workflow_dispatch`.

**`fix(build-logic): clean up warnings surfaced by publishToMavenLocal`**

Running `publishToMavenLocal` carefully exposed three pre-existing issues:

- `build-logic:shared` applied `kotlin-dsl`, which internally applies `java-gradle-plugin` and auto-creates a `pluginMaven` publication. Combined with an explicit `maven` publication this produced duplicate publications and a spurious "no valid plugin descriptors" warning. Fixed by switching to `kotlin("jvm")` (shared has no Gradle API dependencies).
- `test-fixtures` and `tools` publish Gradle capability variants that cannot be expressed in Maven POM format, producing noisy metadata warnings. Suppressed with `suppressPomMetadataWarningsFor()`.
- `versioning.gradle.kts` logged the resolved version at `lifecycle` level on every build. Downgraded to `info`.

**`perf(ci): add publishMinimal mode to speed up Maven Local publishing`**

Introduces a `publishMinimal` Gradle property that strips everything unnecessary from the `publishToMavenLocal` path: skips Dokka javadoc generation and sources jars, and excludes the `x/javaapi` modules entirely from the build graph (avoiding their heavyweight annotation processing). The standalone workflow passes `-PpublishMinimal` to take advantage of this.

## Testing

Verified on [rstata/viaduct#1](https://github.com/rstata/viaduct/pull/1):
- `publish-to-maven-local` completes and `maven-local-repo` artifact is visible in the run
- All four `test-demoapps` matrix shards pass in parallel
- Both `test-starwars` Java shards (17, 21) pass on Ubuntu
- `collect-failure-info` is skipped (no failures)
- Total wall time: ~6.5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)