### PR TITLE
build(fix): Restore detekt/ktlint CI and fix build-scan upload steps

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -159,7 +159,7 @@ jobs:
           path: build/
 
       - name: Upload build scan URLs
-        if: ${{ steps.save_build_scan_url.conclusion == 'success' }}
+        if: ${{ always() && steps.save_build_scan_url.conclusion == 'success' }}
         uses: actions/upload-artifact@v6
         with:
           name: build-scan-urls-build-${{ matrix.java }}-${{ matrix.os }}
@@ -260,7 +260,7 @@ jobs:
         shell: bash
 
       - name: Upload build scan URLs
-        if: ${{ steps.save_test_scan_url.conclusion == 'success' }}
+        if: ${{ always() && steps.save_test_scan_url.conclusion == 'success' }}
         uses: actions/upload-artifact@v6
         with:
           name: build-scan-urls-test-${{ matrix.java }}-${{ matrix.os }}
@@ -314,7 +314,7 @@ jobs:
           path: '**/build/reports/detekt/**/*'
 
       - name: Upload build scan URLs
-        if: ${{ steps.save_detekt_scan_url.conclusion == 'success' }}
+        if: ${{ always() && steps.save_detekt_scan_url.conclusion == 'success' }}
         uses: actions/upload-artifact@v6
         with:
           name: build-scan-urls-detekt-${{ matrix.java }}-${{ matrix.os }}
@@ -361,7 +361,7 @@ jobs:
         shell: bash
 
       - name: Upload build scan URLs
-        if: ${{ steps.save_ktlint_scan_url.conclusion == 'success' }}
+        if: ${{ always() && steps.save_ktlint_scan_url.conclusion == 'success' }}
         uses: actions/upload-artifact@v6
         with:
           name: build-scan-urls-ktlint-${{ matrix.java }}-${{ matrix.os }}
@@ -410,7 +410,7 @@ jobs:
         shell: bash
 
       - name: Upload build scan URLs
-        if: ${{ steps.save_coverage_scan_url.conclusion == 'success' }}
+        if: ${{ always() && steps.save_coverage_scan_url.conclusion == 'success' }}
         uses: actions/upload-artifact@v6
         with:
           name: build-scan-urls-coverage-${{ matrix.java }}-${{ matrix.os }}

--- a/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
+++ b/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
@@ -179,6 +179,16 @@ registerSubprojectAggregate(
     description = "[orchestration] Tests all SUBPROJECTS in THIS build.",
     taskTypes = listOf(Test::class.java)
 )
+registerSubprojectAggregate(
+    aggregateName = "orchestrationDetektAll",
+    description = "[orchestration] Runs detekt on all SUBPROJECTS in THIS build.",
+    taskNames = setOf("detekt")
+)
+registerSubprojectAggregate(
+    aggregateName = "orchestrationKtlintCheckAll",
+    description = "[orchestration] Runs ktlintCheck on all SUBPROJECTS in THIS build.",
+    taskNames = setOf("ktlintCheck")
+)
 
 // Publishing
 registerSubprojectAggregate(
@@ -232,6 +242,18 @@ if (gradle.parent != null) {
         group = "publishing",
         description = "Publishes all publishable subprojects in this included build to Maven Central."
     )
+    aliasConventionalTaskToAggregate(
+        conventionalName = "detekt",
+        aggregateName = "orchestrationDetektAll",
+        group = "verification",
+        description = "Runs detekt on all subprojects in this included build."
+    )
+    aliasConventionalTaskToAggregate(
+        conventionalName = "ktlintCheck",
+        aggregateName = "orchestrationKtlintCheckAll",
+        group = "verification",
+        description = "Runs ktlintCheck on all subprojects in this included build."
+    )
 }
 
 // ---------------- Workspace-wide tasks (ROOT ONLY) ----------------
@@ -272,5 +294,17 @@ if (gradle.parent == null) {
         dependsOn(tasksNamedInSubprojects("publishAllPublicationsToMavenCentralRepository"))
         dependsOn(tasksNamedInSubprojects("publishToMavenCentral"))
         dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationPublishAllToMavenCentral") })
+    }
+
+    // detekt: root subprojects + included builds' aggregate
+    ensureTask("detekt", "verification", "Runs detekt across root and participating included builds.") {
+        dependsOn(tasksNamedInSubprojects("detekt"))
+        dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationDetektAll") })
+    }
+
+    // ktlintCheck: root subprojects + included builds' aggregate
+    ensureTask("ktlintCheck", "verification", "Runs ktlintCheck across root and participating included builds.") {
+        dependsOn(tasksNamedInSubprojects("ktlintCheck"))
+        dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationKtlintCheckAll") })
     }
 }


### PR DESCRIPTION
## Summary

- Adds `detekt` and `ktlintCheck` as workspace-level orchestration tasks in `orchestration.gradle.kts`, following the existing pattern for `build`, `check`, `test`, etc. After the March 2026 build restructuring moved all source modules into the `core` and `gradle-plugins` included builds, these tasks were no longer visible at the root project level, causing CI to fail with \"Task not found\" on every run.
- Fixes the \"Upload build scan URLs\" step in all five jobs (`build`, `test`, `detekt`, `ktlint`, `coverage-verification`) by adding `always() &&` to the `if` condition. Without it, GitHub Actions' implicit `success() &&` prefix caused the upload to be skipped whenever a prior step had failed — exactly the situation where the scan URL is most needed.

## Test plan

- [ ] Verify `./gradlew detekt` and `./gradlew ktlintCheck` resolve and run across `core` and `gradle-plugins` modules
- [ ] Confirm CI detekt and ktlint jobs pass on this branch
- [ ] Build-scan upload fix was validated on `rstata/viaduct` branch `test-buildscan`: both "Upload build scan URLs" steps showed `success` (previously `skipped`) in a failing detekt/ktlint run

🤖 Generated with [Claude Code](https://claude.com/claude-code)