### PR TITLE
fix(ci): Harden build scan diagnostics and PR comments

### DIFF
--- a/.github/scripts/extract_build_scan_url.py
+++ b/.github/scripts/extract_build_scan_url.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Extract the last Gradle build scan URL from command output."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+BUILD_SCAN_PATTERN = re.compile(
+    r"https://(?:gradle\.com|scans\.gradle\.com)/s/[A-Za-z0-9]+"
+)
+
+
+def extract_build_scan_url(text: str) -> str | None:
+    """Returns the last build scan URL found in text, if any."""
+    matches = BUILD_SCAN_PATTERN.findall(text)
+    return matches[-1] if matches else None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        print(f"Usage: {argv[0]} [log-file]", file=sys.stderr)
+        return 2
+
+    if len(argv) == 2:
+        text = Path(argv[1]).read_text()
+    else:
+        text = sys.stdin.read()
+
+    url = extract_build_scan_url(text)
+    if url:
+        print(url)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/maybe_capture_build_scan_artifact.py
+++ b/.github/scripts/maybe_capture_build_scan_artifact.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Persist a failing Gradle build scan payload to a workflow artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from extract_build_scan_url import extract_build_scan_url
+
+
+def maybe_capture_build_scan_artifact(
+    *,
+    log_file: Path,
+    status: int,
+    artifact_path: Path = Path("build-scan-artifact.json"),
+    pr_number: str = "",
+    label: str = "",
+) -> str | None:
+    """Stores the last build scan payload when the Gradle command fails."""
+    if status == 0:
+        return None
+
+    scan_url = extract_build_scan_url(log_file.read_text())
+    if not scan_url:
+        return None
+
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    parsed_pr_number = int(pr_number) if pr_number.isdigit() else None
+    artifact_path.write_text(
+        json.dumps(
+            {
+                "pr_number": parsed_pr_number,
+                "label": label,
+                "url": scan_url,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+    return scan_url
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_file")
+    parser.add_argument("--status", required=True, type=int)
+    parser.add_argument("--artifact-path", default="build-scan-artifact.json")
+    parser.add_argument("--pr-number", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--label", default="")
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    scan_url = maybe_capture_build_scan_artifact(
+        log_file=Path(args.log_file),
+        status=args.status,
+        artifact_path=Path(args.artifact_path),
+        pr_number=str(args.pr_number),
+        label=str(args.label),
+    )
+    if scan_url:
+        print(f"Captured build scan: {scan_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/post_build_scan_comments.py
+++ b/.github/scripts/post_build_scan_comments.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Collect build scan artifacts and render a PR comment payload."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+COMMENT_MARKER = "<!-- viaduct-build-scan-comment -->"
+
+
+def read_metadata_scan_entry(file_path: Path) -> tuple[str, str] | None:
+    try:
+        metadata = json.loads(file_path.read_text())
+    except json.JSONDecodeError:
+        return None
+
+    label = metadata.get("label")
+    url = metadata.get("url")
+    if not label or not url:
+        return None
+    return label, url
+
+
+def read_legacy_scan_entry(relative_dir: str, file_path: Path) -> tuple[str, str] | None:
+    if file_path.name == "pr-number.txt" or file_path.suffix != ".txt":
+        return None
+
+    url = file_path.read_text().strip()
+    if not url or url == "null":
+        return None
+
+    job_name = file_path.stem
+    matrix_info = relative_dir.removeprefix("build-scan-urls-").replace(f"{job_name}-", "", 1)
+    return f"{job_name} ({matrix_info})", url
+
+
+def collect_build_scan_data(base_dir: Path) -> tuple[int | None, dict[str, str]]:
+    if not base_dir.exists():
+        return None, {}
+
+    pr_number = None
+    scans_by_job: dict[str, str] = {}
+    artifact_dirs = sorted(entry for entry in base_dir.iterdir() if entry.is_dir())
+    candidate_dirs = artifact_dirs or [base_dir]
+
+    for dir_path in candidate_dirs:
+        if pr_number is None:
+            pr_file = dir_path / "pr-number.txt"
+            if pr_file.exists():
+                raw_pr_number = pr_file.read_text().strip()
+                if raw_pr_number and raw_pr_number != "null":
+                    try:
+                        pr_number = int(raw_pr_number)
+                    except ValueError:
+                        pass
+
+        files = sorted(entry for entry in dir_path.iterdir() if entry.is_file())
+        metadata_files = [entry for entry in files if entry.suffix == ".json"]
+        if metadata_files:
+            for file_path in metadata_files:
+                metadata_entry = read_metadata_scan_entry(file_path)
+                if metadata_entry is None:
+                    continue
+                label, url = metadata_entry
+                scans_by_job[label] = url
+            continue
+
+        relative_dir = "." if dir_path == base_dir else str(dir_path.relative_to(base_dir))
+        for file_path in files:
+            legacy_entry = read_legacy_scan_entry(relative_dir, file_path)
+            if legacy_entry is None:
+                continue
+            label, url = legacy_entry
+            scans_by_job[label] = url
+
+    return pr_number, scans_by_job
+
+
+def build_comment_body(*, run_url: str, scans_by_job: dict[str, str]) -> str:
+    body_lines = [
+        COMMENT_MARKER,
+        "## Gradle Build Scan URLs",
+        "",
+        f"The [Build and Test workflow]({run_url}) produced Gradle build scans. Here are the build scan links for debugging:",
+        "",
+        "| Job | Build Scan |",
+        "|-----|------------|",
+    ]
+    for job, url in sorted(scans_by_job.items()):
+        body_lines.append(f"| {job} | [View Build Scan]({url}) |")
+    body_lines.extend([
+        "",
+        "---",
+        "*Posted automatically by the post-build-scan-comments workflow.*",
+    ])
+    return "\n".join(body_lines)
+
+
+def build_comment_payload(
+    *,
+    base_dir: Path,
+    run_id: str,
+    repository: str,
+    server_url: str,
+) -> dict[str, int | str | None]:
+    pr_number, scans_by_job = collect_build_scan_data(base_dir)
+    if pr_number is None:
+        return {
+            "pr_number": None,
+            "body": None,
+            "comment_marker": COMMENT_MARKER,
+        }
+    if not scans_by_job:
+        return {
+            "pr_number": pr_number,
+            "body": None,
+            "comment_marker": COMMENT_MARKER,
+        }
+
+    run_url = f"{server_url.rstrip('/')}/{repository}/actions/runs/{run_id}"
+    return {
+        "pr_number": pr_number,
+        "body": build_comment_body(run_url=run_url, scans_by_job=scans_by_job),
+        "comment_marker": COMMENT_MARKER,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-dir", default="build-scan-urls")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--server-url", required=True)
+    return parser.parse_args(argv[1:])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    payload = build_comment_payload(
+        base_dir=Path(args.base_dir),
+        run_id=args.run_id,
+        repository=args.repository,
+        server_url=args.server_url,
+    )
+    print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/post_build_scan_comments.py
+++ b/.github/scripts/post_build_scan_comments.py
@@ -12,30 +12,22 @@ from pathlib import Path
 COMMENT_MARKER = "<!-- viaduct-build-scan-comment -->"
 
 
-def read_metadata_scan_entry(file_path: Path) -> tuple[str, str] | None:
+def read_metadata_scan_entry(file_path: Path) -> tuple[int | None, str, str] | None:
     try:
         metadata = json.loads(file_path.read_text())
     except json.JSONDecodeError:
         return None
 
+    pr_number = metadata.get("pr_number")
     label = metadata.get("label")
     url = metadata.get("url")
     if not label or not url:
         return None
-    return label, url
-
-
-def read_legacy_scan_entry(relative_dir: str, file_path: Path) -> tuple[str, str] | None:
-    if file_path.name == "pr-number.txt" or file_path.suffix != ".txt":
-        return None
-
-    url = file_path.read_text().strip()
-    if not url or url == "null":
-        return None
-
-    job_name = file_path.stem
-    matrix_info = relative_dir.removeprefix("build-scan-urls-").replace(f"{job_name}-", "", 1)
-    return f"{job_name} ({matrix_info})", url
+    if isinstance(pr_number, str) and pr_number.isdigit():
+        pr_number = int(pr_number)
+    if pr_number is not None and not isinstance(pr_number, int):
+        pr_number = None
+    return pr_number, label, url
 
 
 def collect_build_scan_data(base_dir: Path) -> tuple[int | None, dict[str, str]]:
@@ -44,38 +36,14 @@ def collect_build_scan_data(base_dir: Path) -> tuple[int | None, dict[str, str]]
 
     pr_number = None
     scans_by_job: dict[str, str] = {}
-    artifact_dirs = sorted(entry for entry in base_dir.iterdir() if entry.is_dir())
-    candidate_dirs = artifact_dirs or [base_dir]
-
-    for dir_path in candidate_dirs:
-        if pr_number is None:
-            pr_file = dir_path / "pr-number.txt"
-            if pr_file.exists():
-                raw_pr_number = pr_file.read_text().strip()
-                if raw_pr_number and raw_pr_number != "null":
-                    try:
-                        pr_number = int(raw_pr_number)
-                    except ValueError:
-                        pass
-
-        files = sorted(entry for entry in dir_path.iterdir() if entry.is_file())
-        metadata_files = [entry for entry in files if entry.suffix == ".json"]
-        if metadata_files:
-            for file_path in metadata_files:
-                metadata_entry = read_metadata_scan_entry(file_path)
-                if metadata_entry is None:
-                    continue
-                label, url = metadata_entry
-                scans_by_job[label] = url
+    for file_path in sorted(base_dir.rglob("*.json")):
+        metadata_entry = read_metadata_scan_entry(file_path)
+        if metadata_entry is None:
             continue
-
-        relative_dir = "." if dir_path == base_dir else str(dir_path.relative_to(base_dir))
-        for file_path in files:
-            legacy_entry = read_legacy_scan_entry(relative_dir, file_path)
-            if legacy_entry is None:
-                continue
-            label, url = legacy_entry
-            scans_by_job[label] = url
+        file_pr_number, label, url = metadata_entry
+        if pr_number is None and file_pr_number is not None:
+            pr_number = file_pr_number
+        scans_by_job[label] = url
 
     return pr_number, scans_by_job
 
@@ -131,7 +99,7 @@ def build_comment_payload(
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--base-dir", default="build-scan-urls")
+    parser.add_argument("--base-dir", default="build-scan-artifacts")
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--repository", required=True)
     parser.add_argument("--server-url", required=True)

--- a/.github/scripts/run_gradle_with_build_scan_capture.sh
+++ b/.github/scripts/run_gradle_with_build_scan_capture.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -u -o pipefail
+
+label=""
+start_message=""
+success_message=""
+failure_message=""
+artifact_path="build-scan-artifact.json"
+exit_mode="propagate"
+declare -a failure_notes=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label)
+      label="$2"
+      shift 2
+      ;;
+    --start-message)
+      start_message="$2"
+      shift 2
+      ;;
+    --success-message)
+      success_message="$2"
+      shift 2
+      ;;
+    --failure-message)
+      failure_message="$2"
+      shift 2
+      ;;
+    --failure-note)
+      failure_notes+=("$2")
+      shift 2
+      ;;
+    --artifact-path)
+      artifact_path="$2"
+      shift 2
+      ;;
+    --always-succeed)
+      exit_mode="always-zero"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$label" ]]; then
+  echo "Missing required argument: --label" >&2
+  exit 2
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "Missing command to run" >&2
+  exit 2
+fi
+
+if [[ -n "$start_message" ]]; then
+  echo "$start_message"
+fi
+
+log_file="$(mktemp)"
+if "$@" 2>&1 | tee "$log_file"; then
+  status=0
+  if [[ -n "$success_message" ]]; then
+    echo "$success_message"
+  fi
+else
+  status=$?
+  if [[ -n "$failure_message" ]]; then
+    echo "$failure_message"
+  fi
+  for note in "${failure_notes[@]}"; do
+    echo "$note"
+  done
+fi
+
+# Only upload scan artifacts created by the trusted capture script in this step.
+rm -f "$artifact_path"
+python3 .github/scripts/maybe_capture_build_scan_artifact.py \
+  "$log_file" \
+  --status "$status" \
+  --artifact-path "$artifact_path" \
+  --label "$label"
+
+if [[ "$exit_mode" == "always-zero" ]]; then
+  exit 0
+fi
+
+exit "$status"

--- a/.github/scripts/tests/test_extract_build_scan_url.py
+++ b/.github/scripts/tests/test_extract_build_scan_url.py
@@ -1,0 +1,47 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from subprocess import run
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from extract_build_scan_url import extract_build_scan_url
+
+
+class TestExtractBuildScanUrl(unittest.TestCase):
+    def test_returns_none_when_no_url_present(self):
+        self.assertIsNone(extract_build_scan_url("plain gradle output"))
+
+    def test_extracts_gradle_com_url(self):
+        text = "Publishing build scan...\nhttps://gradle.com/s/abc123def\n"
+        self.assertEqual(extract_build_scan_url(text), "https://gradle.com/s/abc123def")
+
+    def test_extracts_scans_gradle_com_url(self):
+        text = "Publishing build scan...\nhttps://scans.gradle.com/s/xyz789\n"
+        self.assertEqual(extract_build_scan_url(text), "https://scans.gradle.com/s/xyz789")
+
+    def test_returns_last_url_when_multiple_are_present(self):
+        text = "\n".join([
+            "Earlier: https://gradle.com/s/first123",
+            "Later: https://scans.gradle.com/s/second456",
+        ])
+        self.assertEqual(extract_build_scan_url(text), "https://scans.gradle.com/s/second456")
+
+    def test_cli_reads_file_and_prints_url(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write("Scan:\nhttps://scans.gradle.com/s/abc123xyz\n")
+            log_path = Path(f.name)
+
+        result = run(
+            [sys.executable, str(Path(__file__).parent.parent / "extract_build_scan_url.py"), str(log_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        self.assertEqual(result.stdout.strip(), "https://scans.gradle.com/s/abc123xyz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_maybe_capture_build_scan_artifact.py
+++ b/.github/scripts/tests/test_maybe_capture_build_scan_artifact.py
@@ -1,0 +1,103 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from subprocess import run
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from maybe_capture_build_scan_artifact import maybe_capture_build_scan_artifact
+
+
+class TestMaybeCaptureBuildScanArtifact(unittest.TestCase):
+    def test_skips_successful_commands(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            log_file = tempdir_path / "gradle.log"
+            log_file.write_text("https://scans.gradle.com/s/success123\n")
+
+            captured = maybe_capture_build_scan_artifact(
+                log_file=log_file,
+                status=0,
+                artifact_path=tempdir_path / "artifacts" / "build-scan-artifact.json",
+                pr_number="42",
+            )
+
+            self.assertIsNone(captured)
+            self.assertFalse((tempdir_path / "artifacts").exists())
+
+    def test_skips_failures_without_scan_urls(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            log_file = tempdir_path / "gradle.log"
+            log_file.write_text("plain gradle output\n")
+
+            captured = maybe_capture_build_scan_artifact(
+                log_file=log_file,
+                status=1,
+                artifact_path=tempdir_path / "artifacts" / "build-scan-artifact.json",
+                pr_number="42",
+            )
+
+            self.assertIsNone(captured)
+            self.assertFalse((tempdir_path / "artifacts").exists())
+
+    def test_writes_single_json_payload_for_failures(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            log_file = tempdir_path / "gradle.log"
+            log_file.write_text("https://scans.gradle.com/s/failure123\n")
+
+            captured = maybe_capture_build_scan_artifact(
+                log_file=log_file,
+                status=1,
+                artifact_path=tempdir_path / "artifacts" / "build-scan-artifact.json",
+                pr_number="42",
+                label="Test (Java 17, ubuntu-latest)",
+            )
+
+            self.assertEqual(captured, "https://scans.gradle.com/s/failure123")
+            self.assertEqual(
+                json.loads((tempdir_path / "artifacts" / "build-scan-artifact.json").read_text()),
+                {
+                    "pr_number": 42,
+                    "label": "Test (Java 17, ubuntu-latest)",
+                    "url": "https://scans.gradle.com/s/failure123",
+                },
+            )
+
+    def test_cli_uses_pr_number_environment_variable(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            log_file = tempdir_path / "gradle.log"
+            log_file.write_text("https://gradle.com/s/cli123\n")
+
+            result = run(
+                [
+                    sys.executable,
+                    str(Path(__file__).parent.parent / "maybe_capture_build_scan_artifact.py"),
+                    str(log_file),
+                    "--status",
+                    "1",
+                    "--artifact-path",
+                    str(tempdir_path / "artifacts" / "build-scan-artifact.json"),
+                    "--label",
+                    "Build (Java 21, ubuntu-latest)",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "PR_NUMBER": "99"},
+            )
+
+            self.assertIn("Captured build scan: https://gradle.com/s/cli123", result.stdout)
+            self.assertEqual(
+                json.loads((tempdir_path / "artifacts" / "build-scan-artifact.json").read_text()),
+                {
+                    "pr_number": 99,
+                    "label": "Build (Java 21, ubuntu-latest)",
+                    "url": "https://gradle.com/s/cli123",
+                },
+            )

--- a/.github/scripts/tests/test_post_build_scan_comments.py
+++ b/.github/scripts/tests/test_post_build_scan_comments.py
@@ -1,0 +1,150 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from post_build_scan_comments import (
+    COMMENT_MARKER,
+    build_comment_body,
+    build_comment_payload,
+    collect_build_scan_data,
+)
+
+
+class TestPostBuildScanComments(unittest.TestCase):
+    def test_collect_build_scan_data_reads_explicit_metadata_labels(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "pr-number.txt").write_text("42\n")
+            (artifact_dir / "test.json").write_text(
+                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
+            )
+
+            pr_number, scans_by_job = collect_build_scan_data(Path(tempdir))
+
+            self.assertEqual(pr_number, 42)
+            self.assertEqual(
+                scans_by_job["Test (Java 21, ubuntu-latest)"],
+                "https://scans.gradle.com/s/abc123",
+            )
+
+    def test_collect_build_scan_data_falls_back_to_legacy_text_file_parsing(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_dir = Path(tempdir) / "build-scan-urls-build-21-ubuntu-latest"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "build-assemble.txt").write_text("https://gradle.com/s/legacy123\n")
+
+            _, scans_by_job = collect_build_scan_data(Path(tempdir))
+
+            self.assertEqual(
+                scans_by_job["build-assemble (build-21-ubuntu-latest)"],
+                "https://gradle.com/s/legacy123",
+            )
+
+    def test_collect_build_scan_data_handles_a_single_flat_downloaded_artifact(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir_path = Path(tempdir)
+            (tempdir_path / "pr-number.txt").write_text("7\n")
+            (tempdir_path / "build-assemble.json").write_text(
+                '{"label": "Build assemble (Java 11, ubuntu-latest)", "url": "https://gradle.com/s/flat123"}'
+            )
+
+            pr_number, scans_by_job = collect_build_scan_data(tempdir_path)
+
+            self.assertEqual(pr_number, 7)
+            self.assertEqual(
+                scans_by_job["Build assemble (Java 11, ubuntu-latest)"],
+                "https://gradle.com/s/flat123",
+            )
+
+    def test_collect_build_scan_data_skips_malformed_metadata_files(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "broken.json").write_text("{not json")
+            (artifact_dir / "test.json").write_text(
+                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/valid123"}'
+            )
+
+            _, scans_by_job = collect_build_scan_data(Path(tempdir))
+
+            self.assertEqual(len(scans_by_job), 1)
+            self.assertEqual(
+                scans_by_job["Test (Java 21, ubuntu-latest)"],
+                "https://scans.gradle.com/s/valid123",
+            )
+
+    def test_build_comment_body_includes_marker_and_sorts_rows_by_label(self):
+        body = build_comment_body(
+            run_url="https://github.com/example/repo/actions/runs/123",
+            scans_by_job={
+                "Zed": "https://gradle.com/s/zed",
+                "Alpha": "https://gradle.com/s/alpha",
+            },
+        )
+
+        self.assertIn(COMMENT_MARKER, body)
+        self.assertLess(
+            body.index("| Alpha | [View Build Scan](https://gradle.com/s/alpha) |"),
+            body.index("| Zed | [View Build Scan](https://gradle.com/s/zed) |"),
+        )
+
+    def test_build_comment_payload_renders_comment_body(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "pr-number.txt").write_text("42\n")
+            (artifact_dir / "test.json").write_text(
+                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
+            )
+
+            payload = build_comment_payload(
+                base_dir=Path(tempdir),
+                run_id="123",
+                repository="example/repo",
+                server_url="https://github.com",
+            )
+
+        self.assertEqual(payload["pr_number"], 42)
+        self.assertEqual(payload["comment_marker"], COMMENT_MARKER)
+        self.assertIn(COMMENT_MARKER, payload["body"])
+        self.assertIn("https://github.com/example/repo/actions/runs/123", payload["body"])
+
+    def test_build_comment_payload_returns_empty_body_when_pr_number_is_missing(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "test.json").write_text(
+                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
+            )
+
+            payload = build_comment_payload(
+                base_dir=Path(tempdir),
+                run_id="123",
+                repository="example/repo",
+                server_url="https://github.com",
+            )
+
+        self.assertIsNone(payload["pr_number"])
+        self.assertIsNone(payload["body"])
+        self.assertEqual(payload["comment_marker"], COMMENT_MARKER)
+
+    def test_build_comment_payload_returns_empty_body_when_scans_are_missing(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir.mkdir(parents=True)
+            (artifact_dir / "pr-number.txt").write_text("42\n")
+
+            payload = build_comment_payload(
+                base_dir=Path(tempdir),
+                run_id="123",
+                repository="example/repo",
+                server_url="https://github.com",
+            )
+
+        self.assertEqual(payload["pr_number"], 42)
+        self.assertIsNone(payload["body"])
+        self.assertEqual(payload["comment_marker"], COMMENT_MARKER)

--- a/.github/scripts/tests/test_post_build_scan_comments.py
+++ b/.github/scripts/tests/test_post_build_scan_comments.py
@@ -14,13 +14,12 @@ from post_build_scan_comments import (
 
 
 class TestPostBuildScanComments(unittest.TestCase):
-    def test_collect_build_scan_data_reads_explicit_metadata_labels(self):
+    def test_collect_build_scan_data_reads_single_json_payloads(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir = Path(tempdir) / "build-scan-artifact-test-21-ubuntu-latest"
             artifact_dir.mkdir(parents=True)
-            (artifact_dir / "pr-number.txt").write_text("42\n")
-            (artifact_dir / "test.json").write_text(
-                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
+            (artifact_dir / "build-scan-artifact.json").write_text(
+                '{"pr_number": 42, "label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
             )
 
             pr_number, scans_by_job = collect_build_scan_data(Path(tempdir))
@@ -31,25 +30,11 @@ class TestPostBuildScanComments(unittest.TestCase):
                 "https://scans.gradle.com/s/abc123",
             )
 
-    def test_collect_build_scan_data_falls_back_to_legacy_text_file_parsing(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            artifact_dir = Path(tempdir) / "build-scan-urls-build-21-ubuntu-latest"
-            artifact_dir.mkdir(parents=True)
-            (artifact_dir / "build-assemble.txt").write_text("https://gradle.com/s/legacy123\n")
-
-            _, scans_by_job = collect_build_scan_data(Path(tempdir))
-
-            self.assertEqual(
-                scans_by_job["build-assemble (build-21-ubuntu-latest)"],
-                "https://gradle.com/s/legacy123",
-            )
-
     def test_collect_build_scan_data_handles_a_single_flat_downloaded_artifact(self):
         with tempfile.TemporaryDirectory() as tempdir:
             tempdir_path = Path(tempdir)
-            (tempdir_path / "pr-number.txt").write_text("7\n")
-            (tempdir_path / "build-assemble.json").write_text(
-                '{"label": "Build assemble (Java 11, ubuntu-latest)", "url": "https://gradle.com/s/flat123"}'
+            (tempdir_path / "build-scan-artifact.json").write_text(
+                '{"pr_number": 7, "label": "Build assemble (Java 11, ubuntu-latest)", "url": "https://gradle.com/s/flat123"}'
             )
 
             pr_number, scans_by_job = collect_build_scan_data(tempdir_path)
@@ -62,11 +47,11 @@ class TestPostBuildScanComments(unittest.TestCase):
 
     def test_collect_build_scan_data_skips_malformed_metadata_files(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir = Path(tempdir) / "build-scan-artifact-test-21-ubuntu-latest"
             artifact_dir.mkdir(parents=True)
             (artifact_dir / "broken.json").write_text("{not json")
-            (artifact_dir / "test.json").write_text(
-                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/valid123"}'
+            (artifact_dir / "build-scan-artifact.json").write_text(
+                '{"pr_number": 42, "label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/valid123"}'
             )
 
             _, scans_by_job = collect_build_scan_data(Path(tempdir))
@@ -94,11 +79,10 @@ class TestPostBuildScanComments(unittest.TestCase):
 
     def test_build_comment_payload_renders_comment_body(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir = Path(tempdir) / "build-scan-artifact-test-21-ubuntu-latest"
             artifact_dir.mkdir(parents=True)
-            (artifact_dir / "pr-number.txt").write_text("42\n")
-            (artifact_dir / "test.json").write_text(
-                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
+            (artifact_dir / "build-scan-artifact.json").write_text(
+                '{"pr_number": 42, "label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
             )
 
             payload = build_comment_payload(
@@ -115,10 +99,10 @@ class TestPostBuildScanComments(unittest.TestCase):
 
     def test_build_comment_payload_returns_empty_body_when_pr_number_is_missing(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir = Path(tempdir) / "build-scan-artifact-test-21-ubuntu-latest"
             artifact_dir.mkdir(parents=True)
-            (artifact_dir / "test.json").write_text(
-                '{"label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
+            (artifact_dir / "build-scan-artifact.json").write_text(
+                '{"pr_number": null, "label": "Test (Java 21, ubuntu-latest)", "url": "https://scans.gradle.com/s/abc123"}'
             )
 
             payload = build_comment_payload(
@@ -134,9 +118,9 @@ class TestPostBuildScanComments(unittest.TestCase):
 
     def test_build_comment_payload_returns_empty_body_when_scans_are_missing(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            artifact_dir = Path(tempdir) / "build-scan-urls-test-21-ubuntu-latest"
+            artifact_dir = Path(tempdir) / "build-scan-artifact-test-21-ubuntu-latest"
             artifact_dir.mkdir(parents=True)
-            (artifact_dir / "pr-number.txt").write_text("42\n")
+            (artifact_dir / "build-scan-artifact.json").write_text('{"pr_number": 42, "label": "", "url": ""}')
 
             payload = build_comment_payload(
                 base_dir=Path(tempdir),
@@ -145,6 +129,6 @@ class TestPostBuildScanComments(unittest.TestCase):
                 server_url="https://github.com",
             )
 
-        self.assertEqual(payload["pr_number"], 42)
+        self.assertIsNone(payload["pr_number"])
         self.assertIsNone(payload["body"])
         self.assertEqual(payload["comment_marker"], COMMENT_MARKER)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,8 @@
 name: Build and Test (Gradle)
 
+env:
+  PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -73,17 +76,12 @@ jobs:
         run: |
           echo "🔨 Building project..."
           ./gradlew clean || { echo "❌ Clean failed"; exit 1; }
-          ./gradlew assemble --scan || { echo "❌ Assemble failed"; exit 1; }
-          echo "✅ Project built successfully"
-        shell: bash
-
-      - name: Save build scan URL
-        id: save_build_scan_url
-        if: ${{ failure() && steps.build_project.conclusion == 'failure' }}
-        run: |
-          mkdir -p build-scan-urls
-          echo "${{ steps.build_project.outputs.build-scan-url }}" > build-scan-urls/build-assemble.txt
-          echo "${{ github.event.pull_request.number }}" > build-scan-urls/pr-number.txt
+          bash .github/scripts/run_gradle_with_build_scan_capture.sh \
+            --label "Build assemble (Java ${{ matrix.java }}, ${{ matrix.os }})" \
+            --success-message "✅ Project built successfully" \
+            --failure-message "❌ Assemble failed" \
+            --artifact-path build-scan-artifact.json \
+            -- ./gradlew assemble --scan
         shell: bash
 
       - name: Verify Dokka output
@@ -159,11 +157,11 @@ jobs:
           path: build/
 
       - name: Upload build scan URLs
-        if: ${{ always() && steps.save_build_scan_url.conclusion == 'success' }}
+        if: ${{ always() && hashFiles('build-scan-artifact.json') != '' }}
         uses: actions/upload-artifact@v6
         with:
-          name: build-scan-urls-build-${{ matrix.java }}-${{ matrix.os }}
-          path: build-scan-urls/
+          name: build-scan-artifact-build-${{ matrix.java }}-${{ matrix.os }}
+          path: build-scan-artifact.json
 
   test:
     runs-on: ${{ matrix.os }}
@@ -193,21 +191,14 @@ jobs:
       - name: Run tests
         id: run_tests
         run: |
-          echo "🧪 Running tests..."
-          ./gradlew test --scan --continue || {
-            echo "⚠️ Some tests failed, but continuing"
-            echo "Test failures are not blocking the pipeline"
-          }
+          bash .github/scripts/run_gradle_with_build_scan_capture.sh \
+            --label "Test (Java ${{ matrix.java }}, ${{ matrix.os }})" \
+            --start-message "🧪 Running tests..." \
+            --failure-message "⚠️ Some tests failed, but continuing" \
+            --artifact-path build-scan-artifact.json \
+            --always-succeed \
+            -- ./gradlew test --scan --continue
           echo "✅ Test execution completed"
-        shell: bash
-
-      - name: Save test build scan URL
-        id: save_test_scan_url
-        if: ${{ failure() && steps.run_tests.conclusion == 'failure' }}
-        run: |
-          mkdir -p build-scan-urls
-          echo "${{ steps.run_tests.outputs.build-scan-url }}" > build-scan-urls/test.txt
-          echo "${{ github.event.pull_request.number }}" > build-scan-urls/pr-number.txt
         shell: bash
 
       - name: Generate coverage and test reports
@@ -260,11 +251,11 @@ jobs:
         shell: bash
 
       - name: Upload build scan URLs
-        if: ${{ always() && steps.save_test_scan_url.conclusion == 'success' }}
+        if: ${{ always() && hashFiles('build-scan-artifact.json') != '' }}
         uses: actions/upload-artifact@v6
         with:
-          name: build-scan-urls-test-${{ matrix.java }}-${{ matrix.os }}
-          path: build-scan-urls/
+          name: build-scan-artifact-test-${{ matrix.java }}-${{ matrix.os }}
+          path: build-scan-artifact.json
 
   detekt:
     runs-on: ${{ matrix.os }}
@@ -289,21 +280,13 @@ jobs:
       - name: Run Detekt Static Analysis
         id: run_detekt
         run: |
-          echo "🧹 Running Detekt static analysis..."
-          ./gradlew detekt --no-daemon --max-workers=1 || {
-            echo "❌ Detekt found code style violations"
-            exit 1
-          }
-          echo "✅ Detekt analysis passed"
-        shell: bash
-
-      - name: Save detekt build scan URL
-        id: save_detekt_scan_url
-        if: ${{ failure() && steps.run_detekt.conclusion == 'failure' }}
-        run: |
-          mkdir -p build-scan-urls
-          echo "${{ steps.run_detekt.outputs.build-scan-url }}" > build-scan-urls/detekt.txt
-          echo "${{ github.event.pull_request.number }}" > build-scan-urls/pr-number.txt
+          bash .github/scripts/run_gradle_with_build_scan_capture.sh \
+            --label "Detekt (Java ${{ matrix.java }}, ${{ matrix.os }})" \
+            --start-message "🧹 Running Detekt static analysis..." \
+            --success-message "✅ Detekt analysis passed" \
+            --failure-message "❌ Detekt found code style violations" \
+            --artifact-path build-scan-artifact.json \
+            -- ./gradlew detekt --scan --no-daemon --max-workers=1
         shell: bash
 
       - name: Upload Detekt reports
@@ -314,11 +297,11 @@ jobs:
           path: '**/build/reports/detekt/**/*'
 
       - name: Upload build scan URLs
-        if: ${{ always() && steps.save_detekt_scan_url.conclusion == 'success' }}
+        if: ${{ always() && hashFiles('build-scan-artifact.json') != '' }}
         uses: actions/upload-artifact@v6
         with:
-          name: build-scan-urls-detekt-${{ matrix.java }}-${{ matrix.os }}
-          path: build-scan-urls/
+          name: build-scan-artifact-detekt-${{ matrix.java }}-${{ matrix.os }}
+          path: build-scan-artifact.json
 
   ktlint:
     runs-on: ${{ matrix.os }}
@@ -343,29 +326,21 @@ jobs:
       - name: Run Ktlint Code Formatting Check
         id: run_ktlint
         run: |
-          echo "🧹 Running Ktlint code formatting check..."
-          ./gradlew ktlintCheck --no-daemon --max-workers=1 || {
-            echo "❌ Ktlint found code formatting violations"
-            exit 1
-          }
-          echo "✅ Ktlint formatting check passed"
-        shell: bash
-
-      - name: Save ktlint build scan URL
-        id: save_ktlint_scan_url
-        if: ${{ failure() && steps.run_ktlint.conclusion == 'failure' }}
-        run: |
-          mkdir -p build-scan-urls
-          echo "${{ steps.run_ktlint.outputs.build-scan-url }}" > build-scan-urls/ktlint.txt
-          echo "${{ github.event.pull_request.number }}" > build-scan-urls/pr-number.txt
+          bash .github/scripts/run_gradle_with_build_scan_capture.sh \
+            --label "Ktlint (Java ${{ matrix.java }}, ${{ matrix.os }})" \
+            --start-message "🧹 Running Ktlint code formatting check..." \
+            --success-message "✅ Ktlint formatting check passed" \
+            --failure-message "❌ Ktlint found code formatting violations" \
+            --artifact-path build-scan-artifact.json \
+            -- ./gradlew ktlintCheck --scan --no-daemon --max-workers=1
         shell: bash
 
       - name: Upload build scan URLs
-        if: ${{ always() && steps.save_ktlint_scan_url.conclusion == 'success' }}
+        if: ${{ always() && hashFiles('build-scan-artifact.json') != '' }}
         uses: actions/upload-artifact@v6
         with:
-          name: build-scan-urls-ktlint-${{ matrix.java }}-${{ matrix.os }}
-          path: build-scan-urls/
+          name: build-scan-artifact-ktlint-${{ matrix.java }}-${{ matrix.os }}
+          path: build-scan-artifact.json
 
   coverage-verification:
     runs-on: ${{ matrix.os }}
@@ -391,30 +366,22 @@ jobs:
       - name: Verify coverage thresholds
         id: verify_coverage
         run: |
-          echo "🎯 Verifying coverage thresholds..."
-          ./gradlew testCodeCoverageVerification --no-configuration-cache -x testCodeCoverageReport || {
-            echo "❌ Coverage thresholds not met"
-            echo "Please check the coverage report and add more tests"
-            exit 1
-          }
-          echo "✅ Coverage thresholds met successfully"
-        shell: bash
-
-      - name: Save coverage build scan URL
-        id: save_coverage_scan_url
-        if: ${{ failure() && steps.verify_coverage.conclusion == 'failure' }}
-        run: |
-          mkdir -p build-scan-urls
-          echo "${{ steps.verify_coverage.outputs.build-scan-url }}" > build-scan-urls/coverage-verification.txt
-          echo "${{ github.event.pull_request.number }}" > build-scan-urls/pr-number.txt
+          bash .github/scripts/run_gradle_with_build_scan_capture.sh \
+            --label "Coverage verification (Java ${{ matrix.java }}, ${{ matrix.os }})" \
+            --start-message "🎯 Verifying coverage thresholds..." \
+            --success-message "✅ Coverage thresholds met successfully" \
+            --failure-message "❌ Coverage thresholds not met" \
+            --failure-note "Please check the coverage report and add more tests" \
+            --artifact-path build-scan-artifact.json \
+            -- ./gradlew testCodeCoverageVerification --scan --no-configuration-cache -x testCodeCoverageReport
         shell: bash
 
       - name: Upload build scan URLs
-        if: ${{ always() && steps.save_coverage_scan_url.conclusion == 'success' }}
+        if: ${{ always() && hashFiles('build-scan-artifact.json') != '' }}
         uses: actions/upload-artifact@v6
         with:
-          name: build-scan-urls-coverage-${{ matrix.java }}-${{ matrix.os }}
-          path: build-scan-urls/
+          name: build-scan-artifact-coverage-${{ matrix.java }}-${{ matrix.os }}
+          path: build-scan-artifact.json
 
   collect-failure-info:
     runs-on: ubuntu-latest

--- a/.github/workflows/post-build-scan-comments.yml
+++ b/.github/workflows/post-build-scan-comments.yml
@@ -19,20 +19,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download all build scan URL artifacts
+      - name: Download all build scan artifacts
         uses: actions/download-artifact@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-          pattern: build-scan-urls-*
-          path: build-scan-urls
+          pattern: build-scan-artifact-*
+          path: build-scan-artifacts
           merge-multiple: false
 
       - name: Prepare build scan PR comment
         id: prepare_comment
         run: |
           comment_payload="$(python3 .github/scripts/post_build_scan_comments.py \
-            --base-dir build-scan-urls \
+            --base-dir build-scan-artifacts \
             --run-id "${{ github.event.workflow_run.id }}" \
             --repository "${{ github.repository }}" \
             --server-url "${{ github.server_url }}")"

--- a/.github/workflows/post-build-scan-comments.yml
+++ b/.github/workflows/post-build-scan-comments.yml
@@ -17,6 +17,8 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'failure'
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download all build scan URL artifacts
         uses: actions/download-artifact@v7
         with:
@@ -26,87 +28,64 @@ jobs:
           path: build-scan-urls
           merge-multiple: false
 
-      - name: Collect scan URLs and post PR comment
+      - name: Prepare build scan PR comment
+        id: prepare_comment
+        run: |
+          comment_payload="$(python3 .github/scripts/post_build_scan_comments.py \
+            --base-dir build-scan-urls \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --repository "${{ github.repository }}" \
+            --server-url "${{ github.server_url }}")"
+          {
+            echo 'comment_payload<<EOF'
+            printf '%s\n' "$comment_payload"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
         uses: actions/github-script@v8
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            const baseDir = 'build-scan-urls';
-            if (!fs.existsSync(baseDir)) {
-              console.log('No build scan URL artifacts found');
-              return;
-            }
-
-            // Find the PR number from any artifact directory
-            let prNumber = null;
-            const artifactDirs = fs.readdirSync(baseDir);
-            for (const dir of artifactDirs) {
-              const prFile = path.join(baseDir, dir, 'pr-number.txt');
-              if (fs.existsSync(prFile)) {
-                const num = fs.readFileSync(prFile, 'utf8').trim();
-                if (num && num !== '' && num !== 'null') {
-                  prNumber = parseInt(num, 10);
-                  break;
-                }
-              }
-            }
-
-            if (!prNumber) {
+            const payload = JSON.parse(${{ toJson(steps.prepare_comment.outputs.comment_payload) }});
+            if (!payload.pr_number) {
               console.log('No PR number found in artifacts, skipping comment');
               return;
             }
-
-            console.log(`Found PR number: ${prNumber}`);
-
-            // Collect all scan URLs grouped by job type
-            const scansByJob = {};
-            for (const dir of artifactDirs) {
-              const dirPath = path.join(baseDir, dir);
-              if (!fs.statSync(dirPath).isDirectory()) continue;
-
-              const files = fs.readdirSync(dirPath);
-              for (const file of files) {
-                if (file === 'pr-number.txt') continue;
-                if (!file.endsWith('.txt')) continue;
-
-                const url = fs.readFileSync(path.join(dirPath, file), 'utf8').trim();
-                if (!url || url === '' || url === 'null') continue;
-
-                // Extract job name from the file name (e.g., "build-assemble.txt" -> "build-assemble")
-                const jobName = file.replace('.txt', '');
-                // Extract matrix info from directory name (e.g., "build-scan-urls-build-21-ubuntu-latest")
-                const matrixInfo = dir.replace('build-scan-urls-', '').replace(`${jobName}-`, '');
-
-                const key = `${jobName} (${matrixInfo})`;
-                scansByJob[key] = url;
-              }
-            }
-
-            if (Object.keys(scansByJob).length === 0) {
+            if (!payload.body) {
               console.log('No build scan URLs found in artifacts');
               return;
             }
 
-            // Build the comment body
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.payload.workflow_run.id}`;
-            let body = `## Gradle Build Scan URLs\n\n`;
-            body += `The [Build and Test workflow](${runUrl}) produced Gradle build scans. Here are the build scan links for debugging:\n\n`;
-            body += `| Job | Build Scan |\n`;
-            body += `|-----|------------|\n`;
-            for (const [job, url] of Object.entries(scansByJob).sort()) {
-              body += `| ${job} | [View Build Scan](${url}) |\n`;
-            }
-            body += `\n---\n*Posted automatically by the post-build-scan-comments workflow.*`;
-
-            console.log('Posting comment:', body);
-
-            await github.rest.issues.createComment({
-              issue_number: prNumber,
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              issue_number: payload.pr_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              per_page: 100,
             });
+            const existingComment = comments.find((comment) =>
+              comment.body?.includes(payload.comment_marker) ||
+              (
+                comment.user?.type === 'Bot' &&
+                comment.body?.includes('## Gradle Build Scan URLs') &&
+                comment.body?.includes('post-build-scan-comments workflow.')
+              )
+            );
 
-            console.log('Comment posted successfully');
+            if (existingComment) {
+              console.log(`Updating existing build scan comment ${existingComment.id}`);
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: payload.body,
+              });
+              return;
+            }
+
+            console.log('Creating new build scan comment');
+            await github.rest.issues.createComment({
+              issue_number: payload.pr_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: payload.body,
+            });


### PR DESCRIPTION
## Summary

In fixing the failing PRs (#308) I noticed that build scans weren't getting surfaced. This PR addresses that problem by:

- capture Gradle build scan URLs directly from failing job output instead of relying on missing shell-step outputs
- persist a single JSON build-scan artifact per failing step with the PR number, label, and URL
- keep build-scan comment generation in Python as a pure input/output step, while leaving GitHub-side effects in the workflow
- update `Post Build Scan Comments` to refresh an existing bot comment instead of posting duplicates
- centralize the repeated Gradle/build-scan capture workflow logic in a shared shell helper
- add focused test coverage for build scan extraction, artifact capture, and comment rendering

## Validation
- `bash -n .github/scripts/run_gradle_with_build_scan_capture.sh`
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_extract_build_scan_url.py'`
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_maybe_capture_build_scan_artifact.py'`
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_post_build_scan_comments.py'`
- `python3 -m compileall .github/scripts`
- `git diff --check`
- remote canary validation on `rstata/viaduct#4`
  - all checks completed successfully (`28 successful`, `2 skipped`, `0 failing`)

## Notes
- remote canary validation exposed that `actions/download-artifact` does not guarantee a single unpacked layout for matched artifacts. The comment collector now scans recursively for JSON payloads, so it works whether files are unpacked directly into the target directory or under per-artifact subdirectories
- the `rstata` canary used a temporary validation-only branch/PR so the actual feature branch history stayed clean
