### PR TITLE
feat(ci): add publish-branch.yml atomic workflow for snapshot and release publication

### DIFF
--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -134,6 +134,7 @@ jobs:
       && (needs.confirm-versions.result == 'success' || needs.confirm-versions.result == 'skipped')
       && (needs.check.result == 'success' || needs.check.result == 'skipped')
     runs-on: ubuntu-latest
+    environment: ${{ inputs.mode == 'release' && 'release' || '' }}
     outputs:
       source_sha: ${{ steps.sha.outputs.source_sha }}
     steps:
@@ -152,8 +153,6 @@ jobs:
 
       - name: Publish artifacts
         env:
-          VIADUCT_SONATYPE_USERNAME: ${{ secrets.VIADUCT_SONATYPE_USERNAME }}
-          VIADUCT_SONATYPE_PASSWORD: ${{ secrets.VIADUCT_SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.VIADUCT_SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.VIADUCT_SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -1,0 +1,180 @@
+name: Publish Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Publication mode: snapshot or release"
+        required: true
+        type: choice
+        options:
+          - snapshot
+          - release
+      ref:
+        description: "Git ref to checkout and publish"
+        required: true
+        type: string
+      run_checks:
+        description: "Run ./gradlew check before publishing"
+        required: false
+        default: true
+        type: boolean
+      confirm_versions:
+        description: "Run ./gradlew confirmDemoAppVersions"
+        required: false
+        default: true
+        type: boolean
+
+  workflow_call:
+    inputs:
+      mode:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
+      run_checks:
+        required: false
+        default: true
+        type: boolean
+      confirm_versions:
+        required: false
+        default: true
+        type: boolean
+    outputs:
+      source_sha:
+        description: "SHA of the published commit"
+        value: ${{ jobs.publish.outputs.source_sha }}
+      version:
+        description: "Version from VERSION file"
+        value: ${{ jobs.validate.outputs.effective_version }}
+      snapshot_tag:
+        description: "Suggested snapshot tag"
+        value: ${{ jobs.validate.outputs.snapshot_tag }}
+    secrets:
+      VIADUCT_GRADLE_PUBLISH_KEY:
+        required: false
+      VIADUCT_GRADLE_PUBLISH_SECRET:
+        required: false
+      VIADUCT_SONATYPE_USERNAME:
+        required: true
+      VIADUCT_SONATYPE_PASSWORD:
+        required: true
+      GPG_PRIVATE_KEY:
+        required: true
+      GPG_PASSPHRASE:
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ inputs.ref }}-${{ inputs.mode }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      effective_version: ${{ steps.validate.outputs.effective_version }}
+      snapshot_tag: ${{ steps.validate.outputs.snapshot_tag }}
+      is_release_branch: ${{ steps.validate.outputs.is_release_branch }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Validate branch and version state
+        id: validate
+        run: |
+          python3 .github/scripts/validate_release_state.py \
+            --mode "${{ inputs.mode }}" \
+            --branch "${{ inputs.ref }}"
+        shell: bash
+
+  confirm-versions:
+    if: inputs.confirm_versions
+    needs: [validate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '21'
+
+      - name: Confirm demoapp versions match VERSION
+        run: ./gradlew confirmDemoAppVersions --no-daemon
+        shell: bash
+
+  check:
+    if: inputs.run_checks
+    needs: [validate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '21'
+
+      - name: Run checks
+        run: ./gradlew check --no-daemon --stacktrace
+        shell: bash
+
+  publish:
+    needs: [validate, confirm-versions, check]
+    if: |
+      always()
+      && needs.validate.result == 'success'
+      && (needs.confirm-versions.result == 'success' || needs.confirm-versions.result == 'skipped')
+      && (needs.check.result == 'success' || needs.check.result == 'skipped')
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.sha.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '21'
+
+      - name: Capture source SHA
+        id: sha
+        run: echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Publish artifacts
+        env:
+          VIADUCT_SONATYPE_USERNAME: ${{ secrets.VIADUCT_SONATYPE_USERNAME }}
+          VIADUCT_SONATYPE_PASSWORD: ${{ secrets.VIADUCT_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.VIADUCT_SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.VIADUCT_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+          GRADLE_PUBLISH_KEY: ${{ secrets.VIADUCT_GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.VIADUCT_GRADLE_PUBLISH_SECRET }}
+        run: |
+          set -euo pipefail
+          MODE="${{ inputs.mode }}"
+
+          if [ "$MODE" = "release" ]; then
+            echo "Publishing RELEASE artifacts..."
+            export RELEASE=true
+            # Publish to Gradle Plugin Portal (release only)
+            ./gradlew gradle-plugins:publishPlugins --no-daemon --stacktrace
+            # Publish to Maven Central
+            ./gradlew publishToMavenCentral --no-daemon --stacktrace
+          else
+            echo "Publishing SNAPSHOT artifacts..."
+            export RELEASE=false
+            # Snapshots only go to Sonatype OSSRH, not Gradle Plugin Portal
+            ./gradlew publishToMavenCentral --no-daemon --stacktrace
+          fi
+        shell: bash


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Adds the core atomic publication workflow that publishes Viaduct artifacts from a given branch ref in either snapshot or release mode. This is the foundation that downstream orchestration workflows (nightly-build, demoapps-nightly-check, and eventually the release flow) will call to close the mavenLocal/Maven Central gap — where CI can be green but real publication fails.

**Key Changes**

- **New workflow: `.github/workflows/publish-branch.yml`**
  - Dual trigger: `workflow_dispatch` (manual) + `workflow_call` (reusable)
  - Inputs: `mode` (snapshot/release), `ref`, `run_checks`, `confirm_versions`
  - 4-job pipeline: `validate` → `confirm-versions` (optional) / `check` (optional) → `publish`
  - Validation gate via `validate_release_state.py` (Slice 8) — fails early on invalid branch/version state
  - Version confirmation via `confirmDemoAppVersions` Gradle task (Slice 6)
  - Snapshot mode publishes to Sonatype OSSRH only; release mode publishes to both Maven Central and Gradle Plugin Portal
  - `RELEASE` env var controls GPG signing (same mechanism as `release.yml`)
  - Outputs `source_sha`, `version`, `snapshot_tag` for orchestration consumers
  - Least-privilege permissions (`contents: read`), concurrency group with `cancel-in-progress: false`
- **No modifications to existing files**

## How was it tested?  What documentation was provided?

- `actionlint` passes locally with zero errors
- Triggered `publish-branch.yml` in snapshot mode on `main` via `gh workflow run` — validate, confirm-versions, check, and publish jobs all succeeded; snapshot artifacts visible on Sonatype OSSRH