### PR TITLE
feat(ci): add push-demoapps and check-published-demoapps atomic workflows

### DIFF
--- a/.github/workflows/check-published-demoapps.yml
+++ b/.github/workflows/check-published-demoapps.yml
@@ -30,9 +30,12 @@ jobs:
     name: Test ${{ matrix.demoapp }}
     steps:
       - name: Clone standalone repo
+        env:
+          REF: ${{ inputs.ref }}
+          DEMOAPP: ${{ matrix.demoapp }}
         run: |
-          git clone --branch "${{ inputs.ref }}" --depth 1 \
-            "https://github.com/viaduct-dev/${{ matrix.demoapp }}.git" app
+          git clone --branch "$REF" --depth 1 \
+            "https://github.com/viaduct-dev/${DEMOAPP}.git" app
         shell: bash
 
       - uses: actions/setup-java@v5

--- a/.github/workflows/check-published-demoapps.yml
+++ b/.github/workflows/check-published-demoapps.yml
@@ -1,0 +1,52 @@
+name: Check Published Demo Apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch in viaduct-dev/* repos to test (NOT an airbnb/viaduct ref)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-demoapps-${{ inputs.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demoapp: [cli-starter, jetty-starter, ktor-starter, micronaut-starter, starwars]
+    name: Test ${{ matrix.demoapp }}
+    steps:
+      - name: Clone standalone repo
+        run: |
+          git clone --branch "${{ inputs.ref }}" --depth 1 \
+            "https://github.com/viaduct-dev/${{ matrix.demoapp }}.git" app
+        shell: bash
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          build-root-directory: app
+
+      - name: Test ${{ matrix.demoapp }}
+        working-directory: app
+        env:
+          USE_VIADUCT_SNAPSHOT_REPO: ${{ inputs.ref != 'main' && 'true' || 'false' }}
+        run: ./gradlew test --no-daemon
+        shell: bash

--- a/.github/workflows/push-demoapps.yml
+++ b/.github/workflows/push-demoapps.yml
@@ -24,7 +24,7 @@ on:
     outputs:
       destination_branch:
         description: "Branch pushed to in viaduct-dev repos"
-        value: ${{ jobs.push.outputs.destination_branch }}
+        value: ${{ jobs.compute-dest.outputs.destination_branch }}
     secrets:
       VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN:
         required: true
@@ -37,33 +37,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  push:
+  compute-dest:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.release_mode && 'release' || '' }}
     outputs:
       destination_branch: ${{ steps.compute-dest.outputs.destination_branch }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref }}
-
-      - uses: ./.github/actions/setup-build
-        with:
-          java-version: '21'
-
       - name: Compute destination branch
         id: compute-dest
+        env:
+          REF: ${{ inputs.ref }}
+          RELEASE_MODE: ${{ inputs.release_mode }}
         run: |
           set -euo pipefail
-          REF="${{ inputs.ref }}"
-          RELEASE_MODE="${{ inputs.release_mode }}"
 
           if [ "$REF" = "main" ]; then
             DEST_BRANCH="snapshot"
           elif [[ "$REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$RELEASE_MODE" = "true" ]; then
             DEST_BRANCH="main"
-          elif [[ "$REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            DEST_BRANCH="tmp/${REF}"
           else
+            # Non-release refs and release refs without release_mode both go to tmp/
             DEST_BRANCH="tmp/${REF}"
           fi
 
@@ -76,16 +69,29 @@ jobs:
           echo "Destination branch: ${DEST_BRANCH}"
         shell: bash
 
-      - name: Push demo apps via Copybara
+  push:
+    needs: compute-dest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demoapp: [cli-starter, jetty-starter, ktor-starter, micronaut-starter, starwars]
+    name: Push ${{ matrix.demoapp }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Push ${{ matrix.demoapp }} via Copybara
         env:
           VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN: ${{ secrets.VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN }}
+          SOURCE_REF: ${{ inputs.ref }}
+          DEST_BRANCH: ${{ needs.compute-dest.outputs.destination_branch }}
         run: |
-          set -euo pipefail
-          DEST_BRANCH="${{ steps.compute-dest.outputs.destination_branch }}"
-
-          for APP in cli-starter jetty-starter ktor-starter micronaut-starter starwars; do
-            echo "::group::Pushing ${APP} to ${DEST_BRANCH}"
-            .github/copydemoapps/copy "$APP" "${{ inputs.ref }}" --target-ref="${DEST_BRANCH}"
-            echo "::endgroup::"
-          done
+          .github/copydemoapps/copy "${{ matrix.demoapp }}" "$SOURCE_REF" --target-ref="${DEST_BRANCH}"
         shell: bash

--- a/.github/workflows/push-demoapps.yml
+++ b/.github/workflows/push-demoapps.yml
@@ -1,0 +1,91 @@
+name: Push Demo Apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref in airbnb/viaduct to copy from"
+        required: true
+        type: string
+      release_mode:
+        description: "If true and ref is release/vX.Y.Z, pushes to main in viaduct-dev"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      release_mode:
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      destination_branch:
+        description: "Branch pushed to in viaduct-dev repos"
+        value: ${{ jobs.push.outputs.destination_branch }}
+    secrets:
+      VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: push-demoapps-${{ inputs.ref }}-${{ inputs.release_mode }}
+  cancel-in-progress: false
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    outputs:
+      destination_branch: ${{ steps.compute-dest.outputs.destination_branch }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '21'
+
+      - name: Compute destination branch
+        id: compute-dest
+        run: |
+          set -euo pipefail
+          REF="${{ inputs.ref }}"
+          RELEASE_MODE="${{ inputs.release_mode }}"
+
+          if [ "$REF" = "main" ]; then
+            DEST_BRANCH="snapshot"
+          elif [[ "$REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$RELEASE_MODE" = "true" ]; then
+            DEST_BRANCH="main"
+          elif [[ "$REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            DEST_BRANCH="tmp/${REF}"
+          else
+            DEST_BRANCH="tmp/${REF}"
+          fi
+
+          if [ -z "$DEST_BRANCH" ]; then
+            echo "::error::Failed to compute destination branch"
+            exit 1
+          fi
+
+          echo "destination_branch=${DEST_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Destination branch: ${DEST_BRANCH}"
+        shell: bash
+
+      - name: Push demo apps via Copybara
+        env:
+          VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN: ${{ secrets.VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          DEST_BRANCH="${{ steps.compute-dest.outputs.destination_branch }}"
+
+          for APP in cli-starter jetty-starter ktor-starter micronaut-starter starwars; do
+            echo "::group::Pushing ${APP} to ${DEST_BRANCH}"
+            .github/copydemoapps/copy "$APP" "${{ inputs.ref }}" --target-ref="${DEST_BRANCH}"
+            echo "::endgroup::"
+          done
+        shell: bash


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Automates the two manual steps of the demo app release process: pushing demo app code to `viaduct-dev/*` repos via Copybara, and verifying the standalone repos actually build against published artifacts. These are atomic workflows designed to be triggered manually or composed by orchestration workflows.

**Key Changes**

- `.github/workflows/push-demoapps.yml` — New workflow that runs Copybara for all 5 demo apps with an opinionated branch policy: `main`→`snapshot`, `release/vX.Y.Z`+`release_mode`→`main`, `otherwise`→`tmp/<ref>`. Exposes `destination_branch` as a `workflow_call` output for downstream orchestration.
- `.github/workflows/check-published-demoapps.yml` — New workflow that clones each `viaduct-dev/*` repo at a given ref and runs `./gradlew test` in a 5-app matrix. Automatically sets `USE_VIADUCT_SNAPSHOT_REPO=true` for non-`main` refs so tests resolve from Sonatype snapshots.

## How was it tested?  What documentation was provided?

- `actionlint` passes on both new workflow files
- Branch policy logic verified locally against all 8 input combinations (main, release with/without release_mode, feature branches)
- Copybara dry-run tested locally via `.github/copydemoapps/copy starwars main --target-ref=snapshot --dry-run`