### PR TITLE
feat(ci): add ci-trigger, demoapps-nightly-check and nightly-build orchestration workflows

### DIFF
--- a/.github/impldocs/actions-arch.md
+++ b/.github/impldocs/actions-arch.md
@@ -63,7 +63,10 @@ An orchestrator composes atomics (and possibly inline jobs) into a higher-level 
 
 | Workflow | Purpose | Runs on |
 |---|---|---|
-| `ci-manual-trigger.yml` | Full CI suite: build-and-test + demoapp tests + API compat check | PR, merge to main, daily schedule (via periodic-green-check), manual |
+| `ci-manual-trigger.yml` | Full CI suite: build-and-test + standalone-demoapp-tests + API compat check | PR, merge to main, daily schedule (via periodic-green-check), manual |
+| `ci-trigger.yml` | Full CI suite: build-and-test + demoapps-ci-check + API compat check | manual, workflow_call (push/PR triggers to be added when `ci-manual-trigger.yml` is deleted) |
+| `demoapps-nightly-check.yml` | End-to-end snapshot validation: publish → push → wait → verify → cleanup | manual, workflow_call |
+| `nightly-build.yml` | Nightly cron wrapper, delegates to `demoapps-nightly-check.yml` | weekday schedule (6am UTC), manual |
 | `periodic-green-check.yml` | Scheduled CI health check + branch staleness detection | daily schedule, manual |
 
 ### Orchestrator Helpers
@@ -261,6 +264,53 @@ periodic-green-check.yml  [orchestrator]
                format-alert --> send-staleness-alert --> post-alerts.yml [helper] --> Slack + Discord
 ```
 
+### Nightly Build (6am UTC weekdays)
+
+```
+schedule / manual dispatch
+  |
+  v
+nightly-build.yml  [orchestrator, thin wrapper]
+  |
+  v
+demoapps-nightly-check.yml  [orchestrator]
+  |
+  |--- ci-precheck (if run_ci_check)
+  |      v
+  |    demoapps-ci-check.yml  [atomic]
+  |
+  |--- publish-snapshot
+  |      v
+  |    publish-branch.yml  [atomic, mode=snapshot]
+  |
+  |--- push-demoapps (parallel)       wait-for-publication (parallel)
+  |      v                               v
+  |    push-demoapps.yml  [atomic]     (poll Sonatype until 200)
+  |
+  |--- check-demoapps
+  |      v
+  |    check-published-demoapps.yml  [atomic]
+  |
+  '--- cleanup (if tmp/* branch)
+         delete tmp branches from viaduct-dev/* repos
+```
+
+### CI Check (via `ci-trigger.yml`)
+
+```
+manual dispatch / workflow_call
+  |
+  v
+ci-trigger.yml  [orchestrator]
+  |
+  |--- build-and-test.yml  [atomic]
+  |--- demoapps-ci-check.yml  [atomic]
+  |--- bcv-api-check.yml  [atomic]
+  |
+  '--- [if any atomic failed && send_alerts]
+         format-alerts --> send-alerts --> post-alerts.yml [helper] --> Slack + Discord
+```
+
 ### Manual Dispatch
 
 Every workflow supports `workflow_dispatch` so it can be run by hand independently. This serves two purposes: **testing** (validate a workflow change on a branch before merging) and **on-demand execution** (run a check or suite without waiting for its automatic trigger).
@@ -272,7 +322,10 @@ Notifications are suppressed on manual dispatch — the person who triggered the
 | `build-and-test.yml` | Test a specific OS/Java combination | `os`, `java_versions` |
 | `standalone-demoapp-tests.yml` | Test demoapps against a specific OS/Java combination | `os`, `java_versions` |
 | `bcv_api_check.yaml` | Check API compatibility on a branch | — |
-| `ci-manual-trigger.yml` | Run the full CI suite on demand | `send_alerts` (default: off) |
+| `ci-manual-trigger.yml` | Run the full CI suite on demand (legacy) | `send_alerts` (default: off) |
+| `ci-trigger.yml` | Run the full CI suite using new atomics | `send_alerts` (default: off) |
+| `demoapps-nightly-check.yml` | Run the end-to-end snapshot validation loop | `ref`, `run_ci_check` (default: off) |
+| `nightly-build.yml` | Trigger the nightly validation without waiting for cron | — |
 | `periodic-green-check.yml` | Run scheduled checks without waiting for cron | `branch`, `mode` (ci-check / staleness-check / all) |
 | `post-alerts.yml` | Verify Slack and Discord connectivity | `mode: test-posts` |
 | `conventional-commit.yml` | Test the PR title validator itself | — |

--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -1,16 +1,99 @@
-name: CI
-# Stub — logic will be migrated from ci-manual-trigger.yml in a follow-up PR.
+name: CI Check
+# Orchestrator that composes CI atomics into a single "run everything" check.
+# Replaces ci-manual-trigger.yml — push/PR triggers will be added in Slice 14
+# when ci-manual-trigger.yml is deleted.
 
 on:
   workflow_dispatch:
+    inputs:
+      send_alerts:
+        description: "Send Slack/Discord alerts on failure"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
+    inputs:
+      send_alerts:
+        description: "Send Slack/Discord alerts on failure"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
 
 permissions:
   contents: read
 
 jobs:
-  placeholder:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+
+  demoapps-ci-check:
+    uses: ./.github/workflows/demoapps-ci-check.yml
+
+  bcv-api-check:
+    uses: ./.github/workflows/bcv-api-check.yml
+
+  format-alerts:
+    needs: [build-and-test, demoapps-ci-check, bcv-api-check]
     runs-on: ubuntu-latest
+    if: >-
+      always()
+      && (needs.build-and-test.result == 'failure'
+          || needs.demoapps-ci-check.result == 'failure'
+          || needs.bcv-api-check.result == 'failure')
+      && inputs.send_alerts == true
+    outputs:
+      text: ${{ steps.fmt.outputs.text }}
     steps:
-      - run: echo "placeholder — logic not yet migrated from ci-manual-trigger.yml"
+      - uses: actions/checkout@v6
+
+      - name: Format alert
+        id: fmt
+        env:
+          BRANCH: ${{ github.ref_name }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          BAT_RESULT: ${{ needs.build-and-test.result }}
+          BAT_RUN_ID: ${{ needs.build-and-test.outputs.run_id }}
+          DCC_RESULT: ${{ needs.demoapps-ci-check.result }}
+          DCC_RUN_ID: ${{ needs.demoapps-ci-check.outputs.run_id }}
+          BCV_RESULT: ${{ needs.bcv-api-check.result }}
+          BCV_RUN_ID: ${{ needs.bcv-api-check.outputs.run_id }}
+        run: |
+          jobs_json='[]'
+          if [ "$BAT_RESULT" = "failure" ]; then
+            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Build and Test" --arg run_id "$BAT_RUN_ID" '. + [{"name": $name, "run_id": $run_id}]')
+          fi
+          if [ "$DCC_RESULT" = "failure" ]; then
+            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Demo App Tests" --arg run_id "$DCC_RUN_ID" '. + [{"name": $name, "run_id": $run_id}]')
+          fi
+          if [ "$BCV_RESULT" = "failure" ]; then
+            jobs_json=$(echo "$jobs_json" | jq -c --arg name "API Compatibility" --arg run_id "$BCV_RUN_ID" '. + [{"name": $name, "run_id": $run_id}]')
+          fi
+          text=$(jq -n \
+            --arg branch "$BRANCH" \
+            --arg server_url "$SERVER_URL" \
+            --arg repository "$REPOSITORY" \
+            --arg sha "$SHA" \
+            --arg actor "$ACTOR" \
+            --argjson jobs "$jobs_json" \
+            '{"branch": $branch, "server_url": $server_url, "repository": $repository, "sha": $sha, "actor": $actor, "jobs": $jobs}' | \
+            python3 .github/scripts/format_alert.py)
+          {
+            echo "text<<ALERT_EOF"
+            echo "$text"
+            echo "ALERT_EOF"
+          } >> "$GITHUB_OUTPUT"
         shell: bash
+
+  send-alerts:
+    needs: [format-alerts]
+    if: always() && needs.format-alerts.result == 'success'
+    uses: ./.github/workflows/post-alerts.yml
+    with:
+      text: ${{ needs.format-alerts.outputs.text }}
+    secrets: inherit

--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -1,0 +1,143 @@
+name: Demoapp Nightly Check
+# End-to-end snapshot validation orchestrator.
+# Exercises the exact artifact path downstream users consume:
+#   publish snapshots -> push demoapps -> wait for visibility -> verify standalone repos
+#
+# This is the centerpiece of RFC-267 — it closes the mavenLocal/Maven Central gap.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to validate"
+        required: true
+        type: string
+        default: main
+      run_ci_check:
+        description: "Run CI precheck before snapshot publication"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      run_ci_check:
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-check-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Optional CI precheck — stop early if mavenLocal tests are broken
+  # ---------------------------------------------------------------------------
+  ci-precheck:
+    if: inputs.run_ci_check
+    uses: ./.github/workflows/demoapps-ci-check.yml
+
+  # ---------------------------------------------------------------------------
+  # Publish snapshot artifacts to Sonatype OSSRH
+  # ---------------------------------------------------------------------------
+  publish-snapshot:
+    needs: [ci-precheck]
+    if: always() && (needs.ci-precheck.result == 'success' || needs.ci-precheck.result == 'skipped')
+    uses: ./.github/workflows/publish-branch.yml
+    with:
+      mode: snapshot
+      ref: ${{ inputs.ref }}
+      run_checks: false
+      confirm_versions: true
+    secrets: inherit
+
+  # ---------------------------------------------------------------------------
+  # Push demoapp code to viaduct-dev/* repos via Copybara
+  # Runs in parallel with wait-for-publication (both depend on publish-snapshot)
+  # ---------------------------------------------------------------------------
+  push-demoapps:
+    needs: [publish-snapshot]
+    uses: ./.github/workflows/push-demoapps.yml
+    with:
+      ref: ${{ inputs.ref }}
+      release_mode: false
+    secrets: inherit
+
+  # ---------------------------------------------------------------------------
+  # Poll Sonatype until snapshot artifacts are visible
+  # Runs in parallel with push-demoapps
+  # ---------------------------------------------------------------------------
+  wait-for-publication:
+    needs: [publish-snapshot]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Sonatype snapshot visibility
+        env:
+          VERSION: ${{ needs.publish-snapshot.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Use build-shared as the canary artifact (coordinates: com.airbnb.viaduct:build-shared)
+          URL="https://s01.oss.sonatype.org/content/repositories/snapshots/com/airbnb/viaduct/build-shared/${VERSION}/"
+          echo "Waiting for ${URL} to return 200..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+            if [ "$STATUS" = "200" ]; then
+              echo "Artifacts visible after ${i} attempts"
+              exit 0
+            fi
+            echo "Attempt ${i}: HTTP ${STATUS}, waiting 30s..."
+            sleep 30
+          done
+          echo "::error::Timed out waiting for Sonatype snapshot visibility after 15 minutes"
+          exit 1
+        shell: bash
+
+  # ---------------------------------------------------------------------------
+  # Verify standalone repos build against published snapshot artifacts
+  # ---------------------------------------------------------------------------
+  check-demoapps:
+    needs: [push-demoapps, wait-for-publication]
+    uses: ./.github/workflows/check-published-demoapps.yml
+    with:
+      ref: ${{ needs.push-demoapps.outputs.destination_branch }}
+
+  # ---------------------------------------------------------------------------
+  # Delete temporary branches in viaduct-dev/* repos (ephemeral refs only)
+  # ---------------------------------------------------------------------------
+  cleanup:
+    needs: [push-demoapps, check-demoapps]
+    if: always() && needs.push-demoapps.result == 'success' && startsWith(needs.push-demoapps.outputs.destination_branch, 'tmp/')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demoapp: [cli-starter, jetty-starter, ktor-starter, micronaut-starter, starwars]
+    name: Cleanup ${{ matrix.demoapp }}
+    steps:
+      - name: Delete temporary branch
+        env:
+          GH_TOKEN: ${{ secrets.VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN }}
+          DEST_BRANCH: ${{ needs.push-demoapps.outputs.destination_branch }}
+          DEMOAPP: ${{ matrix.demoapp }}
+        run: |
+          set -euo pipefail
+          echo "Deleting branch '${DEST_BRANCH}' from viaduct-dev/${DEMOAPP}..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X DELETE \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/viaduct-dev/${DEMOAPP}/git/refs/heads/${DEST_BRANCH}")
+          if [ "$STATUS" = "204" ]; then
+            echo "Deleted successfully"
+          elif [ "$STATUS" = "422" ]; then
+            echo "Branch already deleted or never existed — skipping"
+          else
+            echo "::warning::Unexpected status ${STATUS} deleting branch"
+          fi
+        shell: bash

--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -112,7 +112,7 @@ jobs:
   # ---------------------------------------------------------------------------
   cleanup:
     needs: [push-demoapps, check-demoapps]
-    if: always() && needs.push-demoapps.result == 'success' && startsWith(needs.push-demoapps.outputs.destination_branch, 'tmp/')
+    if: always() && startsWith(needs.push-demoapps.outputs.destination_branch, 'tmp/')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -127,17 +127,23 @@ jobs:
           DEMOAPP: ${{ matrix.demoapp }}
         run: |
           set -euo pipefail
-          echo "Deleting branch '${DEST_BRANCH}' from viaduct-dev/${DEMOAPP}..."
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X DELETE \
-            -H "Authorization: token ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/viaduct-dev/${DEMOAPP}/git/refs/heads/${DEST_BRANCH}")
-          if [ "$STATUS" = "204" ]; then
-            echo "Deleted successfully"
-          elif [ "$STATUS" = "422" ]; then
-            echo "Branch already deleted or never existed — skipping"
-          else
-            echo "::warning::Unexpected status ${STATUS} deleting branch"
+
+          # Defense-in-depth: verify this is a tmp/ branch
+          if [[ "$DEST_BRANCH" != tmp/* ]]; then
+            echo "::error::Refusing to delete non-temporary branch '${DEST_BRANCH}'"
+            exit 1
           fi
+
+          # Log current SHA for recovery before deleting
+          SHA=$(gh api "repos/viaduct-dev/${DEMOAPP}/git/refs/heads/${DEST_BRANCH}" \
+            --jq '.object.sha' 2>/dev/null || echo "")
+          if [ -z "$SHA" ]; then
+            echo "Branch '${DEST_BRANCH}' does not exist in viaduct-dev/${DEMOAPP} — skipping"
+            exit 0
+          fi
+          echo "Branch '${DEST_BRANCH}' in viaduct-dev/${DEMOAPP} points to ${SHA}"
+
+          # Delete the branch
+          gh api -X DELETE "repos/viaduct-dev/${DEMOAPP}/git/refs/heads/${DEST_BRANCH}"
+          echo "Deleted successfully (recoverable via: git update-ref refs/heads/${DEST_BRANCH} ${SHA})"
         shell: bash

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,23 @@
+name: Nightly Build
+# Thin cron wrapper — delegates to demoapps-nightly-check.yml.
+# No domain logic belongs here. This is just a scheduling entrypoint.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1-5'  # 6 AM UTC, weekdays
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/demoapps-nightly-check.yml
+    with:
+      ref: main
+      run_ci_check: true
+    secrets: inherit


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Adds three orchestration workflows that compose the atomic workflows (push-demoapps, check-published-demoapps, publish-branch, demoapps-ci-check) into end-to-end automation flows. The centerpiece is the nightly check, which publishes snapshots to Sonatype, pushes demoapp code to the standalone viaduct-dev repos, waits for artifact visibility, and then verifies the standalone repos actually build — closing the gap where CI could be green via mavenLocal while real Maven Central publication was broken.

**Key Changes**

- `.github/workflows/ci-trigger.yml` — Fills the existing stub with a CI orchestrator that calls build-and-test, demoapps-ci-check, and bcv-api-check, with Slack/Discord alert formatting on failure. Uses workflow_dispatch/workflow_call only (push/PR triggers deferred to avoid duplicate runs with ci-manual-trigger.yml).
- `.github/workflows/demoapps-nightly-check.yml` — New end-to-end snapshot validation orchestrator: optional CI precheck → publish snapshots → push demoapps + wait for Sonatype visibility (in parallel) → verify standalone repos → cleanup tmp branches for ephemeral refs.
- `.github/workflows/nightly-build.yml` — Thin weekday cron wrapper (6am UTC) that delegates to demoapps-nightly-check with ref=main and run_ci_check=true. Contains no domain logic.
- `.github/impldocs/actions-arch.md` — Documents the three new orchestrators in the workflow taxonomy tables and adds flow diagrams for the nightly build and CI check paths.


## How was it tested?  What documentation was provided?

**Static validation:**
- `actionlint` passes on all three workflow files (ci-trigger.yml, demoapps-nightly-check.yml, nightly-build.yml). Temporary stubs were created for slice 9/10 dependencies (publish-branch.yml, demoapps-ci-check.yml) to unblock validation since those PRs haven't merged yet.

**Local verification of alert pipeline:**
- The `format-alerts` jq construction in ci-trigger.yml was tested locally with simulated single-job and multi-job failure payloads piped through `format_alert.py`.
- Confirmed `jq -c` produces compact single-line JSON and the heredoc pattern writes multi-line alert text safely to `$GITHUB_OUTPUT`.

**Requires real GitHub Actions runs after dependencies merge (slices 9, 10, 11):**
- `gh workflow run ci-trigger.yml` — compare signal with ci-manual-trigger.yml
- `gh workflow run demoapps-nightly-check.yml -f ref=main -f run_ci_check=false` — full snapshot → push → verify loop
- `gh workflow run nightly-build.yml` — end-to-end cron path

  **Documentation:**
- `.github/impldocs/actions-arch.md` updated with orchestrator taxonomy entries, nightly build flow diagram, and CI check flow diagram