### PR TITLE
fix: use Central Portal snapshot endpoint for snapshot publications

### DIFF
--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           set -euo pipefail
           # Use build-shared as the canary artifact (coordinates: com.airbnb.viaduct:build-shared)
-          URL="https://s01.oss.sonatype.org/content/repositories/snapshots/com/airbnb/viaduct/build-shared/${VERSION}/"
+          URL="https://central.sonatype.com/repository/maven-snapshots/com/airbnb/viaduct/build-shared/${VERSION}/"
           echo "Waiting for ${URL} to return 200..."
           for i in $(seq 1 30); do
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -173,9 +173,9 @@ jobs:
           else
             echo "Publishing SNAPSHOT artifacts..."
             export RELEASE=false
-            # Snapshots go to Sonatype OSSRH (s01.oss.sonatype.org), not Central Portal.
-            # The vanniktech plugin v0.34.0 uses Central Portal which doesn't support snapshots,
-            # so we publish to a standard Maven repository configured as 'sonatypeSnapshots'.
-            ./gradlew publishToSonatypeSnapshots --no-daemon --stacktrace
+            # Snapshots go to Central Portal's snapshot endpoint (central.sonatype.com/repository/maven-snapshots/).
+            # The vanniktech plugin v0.34.0 doesn't route snapshots automatically, so we use a
+            # separate orchestrated task that publishes to a standard Maven repository.
+            ./gradlew publishToSnapshots --no-daemon --stacktrace
           fi
         shell: bash

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -173,7 +173,9 @@ jobs:
           else
             echo "Publishing SNAPSHOT artifacts..."
             export RELEASE=false
-            # Snapshots only go to Sonatype OSSRH, not Gradle Plugin Portal
-            ./gradlew publishToMavenCentral --no-daemon --stacktrace
+            # Snapshots go to Sonatype OSSRH (s01.oss.sonatype.org), not Central Portal.
+            # The vanniktech plugin v0.34.0 uses Central Portal which doesn't support snapshots,
+            # so we publish to a standard Maven repository configured as 'sonatypeSnapshots'.
+            ./gradlew publishToSonatypeSnapshots --no-daemon --stacktrace
           fi
         shell: bash

--- a/build-logic/shared/build.gradle.kts
+++ b/build-logic/shared/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
     kotlin("jvm")
@@ -33,10 +32,7 @@ kotlin {
 
 mavenPublishing {
     val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
-    publishToMavenCentral(
-        host = if (isRelease) SonatypeHost.CENTRAL_PORTAL else SonatypeHost.S01,
-        automaticRelease = true
-    )
+    publishToMavenCentral(automaticRelease = true)
     if (isRelease) signAllPublications()
     configure(JavaLibrary(javadocJar = JavadocJar.Empty(), sourcesJar = false))
     coordinates("com.airbnb.viaduct", "build-shared", version.toString())
@@ -47,3 +43,23 @@ mavenPublishing {
 }
 
 apply(from = rootDir.resolve("gradle/viaduct-maven-central.gradle.kts"))
+
+// For snapshot publications, add the Sonatype OSSRH snapshots repository.
+// See conventions/viaduct-publishing.gradle.kts for the full explanation.
+run {
+    val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
+    if (!isRelease) {
+        publishing {
+            repositories {
+                maven {
+                    name = "sonatypeSnapshots"
+                    url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                    credentials {
+                        username = providers.gradleProperty("mavenCentralUsername").orNull
+                        password = providers.gradleProperty("mavenCentralPassword").orNull
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/shared/build.gradle.kts
+++ b/build-logic/shared/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
     kotlin("jvm")
@@ -32,7 +33,10 @@ kotlin {
 
 mavenPublishing {
     val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
-    publishToMavenCentral(automaticRelease = true)
+    publishToMavenCentral(
+        host = if (isRelease) SonatypeHost.CENTRAL_PORTAL else SonatypeHost.S01,
+        automaticRelease = true
+    )
     if (isRelease) signAllPublications()
     configure(JavaLibrary(javadocJar = JavadocJar.Empty(), sourcesJar = false))
     coordinates("com.airbnb.viaduct", "build-shared", version.toString())

--- a/build-logic/shared/build.gradle.kts
+++ b/build-logic/shared/build.gradle.kts
@@ -44,16 +44,15 @@ mavenPublishing {
 
 apply(from = rootDir.resolve("gradle/viaduct-maven-central.gradle.kts"))
 
-// For snapshot publications, add the Sonatype OSSRH snapshots repository.
-// See conventions/viaduct-publishing.gradle.kts for the full explanation.
+// For snapshot publications — see conventions/viaduct-publishing.gradle.kts for explanation.
 run {
     val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
     if (!isRelease) {
         publishing {
             repositories {
                 maven {
-                    name = "sonatypeSnapshots"
-                    url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                    name = "snapshots"
+                    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                     credentials {
                         username = providers.gradleProperty("mavenCentralUsername").orNull
                         password = providers.gradleProperty("mavenCentralPassword").orNull

--- a/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
+++ b/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
@@ -193,9 +193,9 @@ registerSubprojectAggregate(
     taskNames = setOf("publishAllPublicationsToMavenCentralRepository")
 )
 registerSubprojectAggregate(
-    aggregateName = "orchestrationPublishAllToSonatypeSnapshots",
-    description = "[orchestration] Publishes all publishable SUBPROJECTS in THIS build to Sonatype OSSRH snapshots.",
-    taskNames = setOf("publishAllPublicationsToSonatypeSnapshotsRepository")
+    aggregateName = "orchestrationPublishAllToSnapshots",
+    description = "[orchestration] Publishes all publishable SUBPROJECTS in THIS build to Central Portal snapshots.",
+    taskNames = setOf("publishAllPublicationsToSnapshotsRepository")
 )
 
 // ---------------- In INCLUDED BUILDS: alias conventional tasks to aggregates ----------------
@@ -238,10 +238,10 @@ if (gradle.parent != null) {
         description = "Publishes all publishable subprojects in this included build to Maven Central."
     )
     aliasConventionalTaskToAggregate(
-        conventionalName = "publishToSonatypeSnapshots",
-        aggregateName = "orchestrationPublishAllToSonatypeSnapshots",
+        conventionalName = "publishToSnapshots",
+        aggregateName = "orchestrationPublishAllToSnapshots",
         group = "publishing",
-        description = "Publishes all publishable subprojects in this included build to Sonatype OSSRH snapshots."
+        description = "Publishes all publishable subprojects in this included build to Central Portal snapshots."
     )
     aliasConventionalTaskToAggregate(
         conventionalName = "detekt",
@@ -297,9 +297,9 @@ if (gradle.parent == null) {
     }
 
     // publish snapshots: root subprojects + included builds' aggregate
-    ensureTask("publishToSonatypeSnapshots", "publishing", "Publishes root subprojects + participating included builds to Sonatype OSSRH snapshots.") {
-        dependsOn(tasksNamedInSubprojects("publishAllPublicationsToSonatypeSnapshotsRepository"))
-        dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationPublishAllToSonatypeSnapshots") })
+    ensureTask("publishToSnapshots", "publishing", "Publishes root subprojects + participating included builds to Central Portal snapshots.") {
+        dependsOn(tasksNamedInSubprojects("publishAllPublicationsToSnapshotsRepository"))
+        dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationPublishAllToSnapshots") })
     }
 
     // detekt: root subprojects + included builds' aggregate

--- a/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
+++ b/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
@@ -192,6 +192,11 @@ registerSubprojectAggregate(
     description = "[orchestration] Publishes all publishable SUBPROJECTS in THIS build to Maven Central.",
     taskNames = setOf("publishAllPublicationsToMavenCentralRepository")
 )
+registerSubprojectAggregate(
+    aggregateName = "orchestrationPublishAllToSonatypeSnapshots",
+    description = "[orchestration] Publishes all publishable SUBPROJECTS in THIS build to Sonatype OSSRH snapshots.",
+    taskNames = setOf("publishAllPublicationsToSonatypeSnapshotsRepository")
+)
 
 // ---------------- In INCLUDED BUILDS: alias conventional tasks to aggregates ----------------
 
@@ -231,6 +236,12 @@ if (gradle.parent != null) {
         aggregateName = "orchestrationPublishAllToMavenCentral",
         group = "publishing",
         description = "Publishes all publishable subprojects in this included build to Maven Central."
+    )
+    aliasConventionalTaskToAggregate(
+        conventionalName = "publishToSonatypeSnapshots",
+        aggregateName = "orchestrationPublishAllToSonatypeSnapshots",
+        group = "publishing",
+        description = "Publishes all publishable subprojects in this included build to Sonatype OSSRH snapshots."
     )
     aliasConventionalTaskToAggregate(
         conventionalName = "detekt",
@@ -283,6 +294,12 @@ if (gradle.parent == null) {
     ensureTask("publishToMavenCentral", "publishing", "Publishes root subprojects + participating included builds to Maven Central.") {
         dependsOn(tasksNamedInSubprojects("publishAllPublicationsToMavenCentralRepository"))
         dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationPublishAllToMavenCentral") })
+    }
+
+    // publish snapshots: root subprojects + included builds' aggregate
+    ensureTask("publishToSonatypeSnapshots", "publishing", "Publishes root subprojects + participating included builds to Sonatype OSSRH snapshots.") {
+        dependsOn(tasksNamedInSubprojects("publishAllPublicationsToSonatypeSnapshotsRepository"))
+        dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationPublishAllToSonatypeSnapshots") })
     }
 
     // detekt: root subprojects + included builds' aggregate

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -41,7 +41,10 @@ apply(from = generateSequence(gradle) { it.parent }.last()
 
 mavenPublishing {
     val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
-    publishToMavenCentral(automaticRelease = true)
+    publishToMavenCentral(
+        host = if (isRelease) SonatypeHost.CENTRAL_PORTAL else SonatypeHost.S01,
+        automaticRelease = true
+    )
     if (isRelease) {
         signAllPublications()
     }

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -41,10 +41,7 @@ apply(from = generateSequence(gradle) { it.parent }.last()
 
 mavenPublishing {
     val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
-    publishToMavenCentral(
-        host = if (isRelease) SonatypeHost.CENTRAL_PORTAL else SonatypeHost.S01,
-        automaticRelease = true
-    )
+    publishToMavenCentral(automaticRelease = true)
     if (isRelease) {
         signAllPublications()
     }
@@ -55,6 +52,29 @@ mavenPublishing {
             javadocJar = if (publishMinimal) JavadocJar.Empty() else JavadocJar.Dokka("dokkaGeneratePublicationJavadoc"),
             sourcesJar = !publishMinimal
         ))
+    }
+}
+
+// For snapshot publications, add the Sonatype OSSRH snapshots repository.
+// The vanniktech plugin v0.34.0 uses Central Portal which doesn't support SNAPSHOT versions.
+// This adds a standard Maven repository so `publishAllPublicationsToSonatypeSnapshotsRepository`
+// can publish snapshots to OSSRH. The workflow calls this task instead of `publishToMavenCentral`
+// when in snapshot mode.
+run {
+    val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
+    if (!isRelease) {
+        publishing {
+            repositories {
+                maven {
+                    name = "sonatypeSnapshots"
+                    url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                    credentials {
+                        username = providers.gradleProperty("mavenCentralUsername").orNull
+                        password = providers.gradleProperty("mavenCentralPassword").orNull
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -55,10 +55,11 @@ mavenPublishing {
     }
 }
 
-// For snapshot publications, add the Sonatype OSSRH snapshots repository.
-// The vanniktech plugin v0.34.0 uses Central Portal which doesn't support SNAPSHOT versions.
-// This adds a standard Maven repository so `publishAllPublicationsToSonatypeSnapshotsRepository`
-// can publish snapshots to OSSRH. The workflow calls this task instead of `publishToMavenCentral`
+// For snapshot publications, add the Central Portal snapshots repository.
+// The vanniktech plugin v0.34.0 uses Central Portal for releases but doesn't route -SNAPSHOT
+// versions to the snapshot endpoint. This adds a standard Maven repository so
+// `publishAllPublicationsToSnapshotsRepository` can publish snapshots to Central Portal.
+// The workflow calls `publishToSnapshots` (orchestrated) instead of `publishToMavenCentral`
 // when in snapshot mode.
 run {
     val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
@@ -66,8 +67,8 @@ run {
         publishing {
             repositories {
                 maven {
-                    name = "sonatypeSnapshots"
-                    url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                    name = "snapshots"
+                    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                     credentials {
                         username = providers.gradleProperty("mavenCentralUsername").orNull
                         password = providers.gradleProperty("mavenCentralPassword").orNull

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,13 +24,11 @@ tasks.named("publishToMavenCentral") {
 }
 
 // Snapshot publication: wire build-shared into the snapshot publish aggregate.
-// The sonatypeSnapshots repo and publishToSonatypeSnapshots task are created by the
-// orchestration plugin when RELEASE != true.
 val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
 if (!isRelease) {
     tasks.configureEach {
-        if (name == "publishToSonatypeSnapshots") {
-            dependsOn(gradle.includedBuild("build-logic").task(":build-shared:publishAllPublicationsToSonatypeSnapshotsRepository"))
+        if (name == "publishToSnapshots") {
+            dependsOn(gradle.includedBuild("build-logic").task(":build-shared:publishAllPublicationsToSnapshotsRepository"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,18 @@ tasks.named("publishToMavenCentral") {
     dependsOn(gradle.includedBuild("build-logic").task(":build-shared:publishAllPublicationsToMavenCentralRepository"))
 }
 
+// Snapshot publication: wire build-shared into the snapshot publish aggregate.
+// The sonatypeSnapshots repo and publishToSonatypeSnapshots task are created by the
+// orchestration plugin when RELEASE != true.
+val isRelease = providers.environmentVariable("RELEASE").orElse("false").get().toBoolean()
+if (!isRelease) {
+    tasks.configureEach {
+        if (name == "publishToSonatypeSnapshots") {
+            dependsOn(gradle.includedBuild("build-logic").task(":build-shared:publishAllPublicationsToSonatypeSnapshotsRepository"))
+        }
+    }
+}
+
 // Jacoco configuration
 jacoco {
     toolVersion = libs.versions.jacoco.get()

--- a/demoapps/cli-starter/settings.gradle.kts
+++ b/demoapps/cli-starter/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
         repositories {
             if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
             if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-                maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                maven("https://central.sonatype.com/repository/maven-snapshots/")
             }
             mavenCentral()
             gradlePluginPortal()
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
     repositories {
         if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
         if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-            maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            maven("https://central.sonatype.com/repository/maven-snapshots/")
         }
         mavenCentral()
         gradlePluginPortal()

--- a/demoapps/jetty-starter/settings.gradle.kts
+++ b/demoapps/jetty-starter/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
         repositories {
             if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
             if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-                maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                maven("https://central.sonatype.com/repository/maven-snapshots/")
             }
             mavenCentral()
             gradlePluginPortal()
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
     repositories {
         if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
         if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-            maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            maven("https://central.sonatype.com/repository/maven-snapshots/")
         }
         mavenCentral()
         gradlePluginPortal()

--- a/demoapps/ktor-starter/settings.gradle.kts
+++ b/demoapps/ktor-starter/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
         repositories {
             if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
             if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-                maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                maven("https://central.sonatype.com/repository/maven-snapshots/")
             }
             mavenCentral()
             gradlePluginPortal()
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
     repositories {
         if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
         if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-            maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            maven("https://central.sonatype.com/repository/maven-snapshots/")
         }
         mavenCentral()
         gradlePluginPortal()

--- a/demoapps/micronaut-starter/settings.gradle.kts
+++ b/demoapps/micronaut-starter/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
         repositories {
             if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
             if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-                maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                maven("https://central.sonatype.com/repository/maven-snapshots/")
             }
             mavenCentral()
             gradlePluginPortal()
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
     repositories {
         if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
         if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-            maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            maven("https://central.sonatype.com/repository/maven-snapshots/")
         }
         mavenCentral()
         gradlePluginPortal()

--- a/demoapps/starwars/settings.gradle.kts
+++ b/demoapps/starwars/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
         repositories {
             if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
             if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-                maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                maven("https://central.sonatype.com/repository/maven-snapshots/")
             }
             mavenCentral()
             gradlePluginPortal()
@@ -21,7 +21,7 @@ dependencyResolutionManagement {
     repositories {
         if (System.getenv("USE_MAVEN_LOCAL")?.toBoolean() == true) mavenLocal()
         if (System.getenv("USE_VIADUCT_SNAPSHOT_REPO")?.toBoolean() == true) {
-            maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            maven("https://central.sonatype.com/repository/maven-snapshots/")
         }
         mavenCentral()
         gradlePluginPortal()


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Snapshot publications silently fail because the vanniktech `gradle-maven-publish-plugin` v0.34.0 uses Central Portal by default but doesn't route `-SNAPSHOT` versions to the snapshot endpoint. The `publishToMavenCentral` Gradle task succeeds (exit 0) but artifacts never reach any snapshot repository — the nightly build's `wait-for-publication` step times out after 15 minutes.

This was discovered during the first real run of the nightly snapshot validation pipeline (`nightly-build.yml`).

**Key Changes**

- `build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts` — Add a `snapshots` Maven repository when `RELEASE != true`, pointing to `central.sonatype.com/repository/maven-snapshots/`. Only registered for snapshot builds.
- `build-logic/shared/build.gradle.kts` — Same snapshot repository for `build-shared`, which has its own publishing block outside the convention plugin.
- `build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts` — Add `publishToSnapshots` orchestration task that aggregates `publishAllPublicationsToSnapshotsRepository` across all subprojects and participating included builds, following the same pattern as `publishToMavenCentral`.
- `build.gradle.kts` (root) — Wire `build-shared` from `build-logic` into `publishToSnapshots`, matching the existing `publishToMavenCentral` wiring.
- `.github/workflows/publish-branch.yml` — Snapshot mode now calls `publishToSnapshots` instead of `publishToMavenCentral`. Release mode is unchanged.
- `.github/workflows/demoapps-nightly-check.yml` — Update polling URL to Central Portal snapshot endpoint.
- `demoapps/*/settings.gradle.kts` (5 files) — Update `USE_VIADUCT_SNAPSHOT_REPO` consumer URL from OSSRH to Central Portal.

## How was it tested?  What documentation was provided?

Local validation: `RELEASE=false ./gradlew publishToSnapshots --dry-run` confirms the task graph resolves correctly with all modules included (api, bom, runtime, test-fixtures, build-shared, core/*, gradle-plugins/*).