### PR TITLE
build: add CI watchdog to alert on workflow startup failures

### DIFF
--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -1,0 +1,39 @@
+name: CI Watchdog
+# Catches workflow startup failures that prevent in-workflow alert jobs
+# from running. Kept intentionally minimal to avoid failing itself.
+
+on:
+  workflow_run:
+    workflows: ["CI Check", "Nightly Build", "Periodic Green Check", "Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  format-alerts:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'startup_failure'
+    outputs:
+      text: ${{ steps.fmt.outputs.text }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Format alert
+        id: fmt
+        uses: ./.github/actions/collect-failure-info
+        with:
+          jobs_json: '[{"name": "${{ github.event.workflow_run.name }}", "run_id": "${{ github.event.workflow_run.id }}"}]'
+          branch: ${{ github.event.workflow_run.head_branch }}
+          server_url: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          actor: ${{ github.event.workflow_run.actor.login }}
+
+  post:
+    needs: [format-alerts]
+    if: always() && needs.format-alerts.result == 'success'
+    uses: ./.github/workflows/post-alerts.yml
+    with:
+      text: ${{ needs.format-alerts.outputs.text }}
+    secrets: inherit


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Adds a watchdog workflow that alerts to Slack/Discord when a monitored workflow fails to start. This closes the gap where a bad YAML syntax or workflow script error prevents the workflow's own alert jobs from running, resulting in silent failures.

**Key Changes**

- New `.github/workflows/ci-watchdog.yml` — uses the `workflow_run` event to monitor CI Check, Nightly Build, Periodic Green Check and Release workflows
- Triggers only on `startup_failure` conclusion — normal failures are already handled by in-workflow alert jobs
- Reuses `collect-failure-info` action and `post-alerts.yml` for consistent alert formatting and delivery

**Caveat:** `workflow_run` only fires for workflows on the default branch. Release branch failures are covered by the periodic green check

## How was it tested?  What documentation was provided?

- `actionlint .github/workflows/ci-watchdog.yml` — passed
- Full testing requires merge to default branch (`workflow_run` only fires on main)