### PR TITLE
docs: fix @backingData directive example to use Film.castData

### DIFF
--- a/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/models/FilmCastData.kt
+++ b/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/models/FilmCastData.kt
@@ -8,4 +8,5 @@ package com.example.starwars.modules.filmography.films.models
  * [FilmIsEnsembleCastResolver], so a single query asking for both fields
  * causes only one repository call per film.
  */
+// tag::backing_data_class[1]
 data class FilmCastData(val characterIds: List<String>)

--- a/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCastDataResolver.kt
+++ b/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCastDataResolver.kt
@@ -16,6 +16,7 @@ import viaduct.api.Resolver
  * Viaduct guarantees this resolver runs at most once per Film, regardless of
  * how many of those fields appear in the query.
  */
+// tag::backing_data_resolver[12]
 @Resolver(objectValueFragment = "fragment _ on Film { id }")
 class FilmCastDataResolver
     @Inject

--- a/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCharacterCountSummaryResolver.kt
+++ b/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCharacterCountSummaryResolver.kt
@@ -13,6 +13,7 @@ import viaduct.api.Resolver
  * When both `characterCountSummary` and `characters` are requested for the same film,
  * the repository is called once instead of twice.
  */
+// tag::backing_data_consumer_2[17]
 @Resolver(
     """
     fragment _ on Film {

--- a/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCharactersResolver.kt
+++ b/demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCharactersResolver.kt
@@ -16,6 +16,7 @@ import viaduct.api.grts.Character
  * When both `characters` and `characterCountSummary` are requested for the same film,
  * the repository is called once instead of twice.
  */
+// tag::backing_data_consumer[15]
 @Resolver(objectValueFragment = "fragment _ on Film { castData }")
 class FilmCharactersResolver
     @Inject

--- a/demoapps/starwars/modules/filmography/src/main/viaduct/schema/Film.graphqls
+++ b/demoapps/starwars/modules/filmography/src/main/viaduct/schema/Film.graphqls
@@ -86,6 +86,7 @@ type Film implements Node @scope(to: ["default"]) @resolver {
   """
   mainCharacters: [Character] @resolver(isBatching: true)
 
+  # tag::backing_data_schema[8] @backingData directive usage
   """
   Character IDs fetched once from the film-character relationship store.
   Shared by the characters and characterCountSummary resolvers so both

--- a/docs/docs/getting_started/starwars/directives/backing_data.md
+++ b/docs/docs/getting_started/starwars/directives/backing_data.md
@@ -1,49 +1,73 @@
 ---
 title: backingData Directive
-description: Specify backing data classes for fields to separate transformation logic from retrieval.
+description: Share pre-fetched data between sibling field resolvers to avoid duplicate calls.
 ---
 
 
-The `@backingData` directive binds a **field** to a backing data class that performs transformation, shaping, or
-preparation of data before it is exposed by GraphQL. It complements `@resolver`: the resolver wires the field into
-execution, while the backing data class centralizes the mapping logic that would otherwise live inside the resolver.
+The `@backingData` directive declares a field whose sole purpose is to fetch data once and share it with other
+resolvers on the same object. Viaduct guarantees the backing resolver runs **at most once** per parent object,
+regardless of how many sibling fields consume it.
 
-## Basic usage
+Use `@backingData` when two or more field resolvers on the same type need the same upstream data and you want to
+avoid duplicate calls.
 
-Apply `@backingData` on a field (often together with `@resolver`) and point to a Kotlin class that implements the
-backing logic.
+## Schema declaration
 
-
-{{ codetag("demoapps/starwars/modules/filmography/src/main/viaduct/schema/Character.graphqls", "all_characters", lang="kotlin") }}
-
-
-In this demo, the class
-`com.example.starwars.modules.filmography.characters.queries.AllCharactersQueryResolver`
-is responsible for shaping the list of `Character` items returned by `allCharacters`.
-
-## How it integrates at runtime
-
-1. **Execution plan:** Viaduct identifies that `allCharacters` is a resolver-backed field with a backing data class.
-2. **Resolver step:** the resolver coordinates arguments and orchestration (for example, reads the `limit`).
-3. **Backing step:** the backing class transforms raw domain models into GraphQL objects (builders), applying any
-   mapping, filtering, or normalization rules required by the schema.
-4. **Result:** the field returns objects that already match the schema’s expectations (IDs, formatting, minimal fields).
-
-### With `@backingData` (mapping lives in a backing class)
+Apply `@backingData` on a field typed as `BackingData` (a Viaduct built-in marker type, never exposed to clients).
+The `class` argument points to the Kotlin data class that holds the fetched data:
 
 
-{{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/characters/queries/AllCharactersQueryResolver.kt", "resolver_example", lang="kotlin") }}
+{{ codetag("demoapps/starwars/modules/filmography/src/main/viaduct/schema/Film.graphqls", "backing_data_schema", lang="graphql") }}
 
 
-Pros: fewer moving parts.
-Cons: resolver grows, mapping is harder to share or test in isolation.
+## The backing data class
+
+A simple data class holding the pre-fetched data. Keep it minimal, shared state only:
+
+
+{{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/models/FilmCastData.kt", "backing_data_class", lang="kotlin") }}
+
+
+## The backing data resolver
+
+A resolver that fetches the data once per parent object. It reads the parent's ID from the object value and calls
+the repository:
+
+
+{{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCastDataResolver.kt", "backing_data_resolver", lang="kotlin") }}
+
+
+## Consuming the backing data
+
+Other resolvers declare `castData` in their `objectValueFragment` to receive the pre-fetched data. Viaduct
+automatically ensures the backing resolver completes before these consumers run:
+
+
+{{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCharactersResolver.kt", "backing_data_consumer", lang="kotlin") }}
+
+
+Multiple resolvers can share the same backing data, each declares it in their fragment, but the fetch happens
+only once:
+
+
+{{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/films/resolvers/FilmCharacterCountSummaryResolver.kt", "backing_data_consumer_2", lang="kotlin") }}
+
+
+## How it works at runtime
+
+1. A client queries both `characters` and `characterCountSummary` on a Film.
+2. Viaduct sees both resolvers need `castData` in their `objectValueFragment`.
+3. `FilmCastDataResolver` runs **once**, fetching character IDs from the repository.
+4. The result (`FilmCastData`) is injected into both consuming resolvers via `ctx.getObjectValue().get(...)`.
+5. Each consumer uses the shared data without any additional repository call.
 
 ## Design guidelines
 
-- Keep resolvers **thin**; put mapping/formatting in the backing data class.
-- Generate `id` values with `ctx.globalIDFor(Type.Reflection, internalId)`.
-- Request only the minimal fields you need; defer relationships to field/batch resolvers.
-- Prefer immutable outputs from the backing class (builders with final values).
+- Use `@backingData` when two or more sibling resolvers need the same upstream data.
+- Keep the data class minimal — only the shared state needed by consumers.
+- The backing resolver should do I/O; consumers should do transformation only.
+- The field type must be `BackingData` — this is a Viaduct marker type that is never exposed in the client schema.
 
+## Related
 
-
+- [Field resolvers](../core/field_resolvers.md) — `@backingData` fields always also carry `@resolver`; see field resolvers for the general resolver pattern

--- a/docs/docs/getting_started/starwars/directives/index.md
+++ b/docs/docs/getting_started/starwars/directives/index.md
@@ -9,7 +9,7 @@ directives used in the Star Wars demo and links to focused pages for details and
 
 ## What you will find here
 
-- **`@backingData`** — bind a field to a backing data class for transformation logic.
+- **`@backingData`** — share pre-fetched data between sibling field resolvers to avoid duplicate calls.
 - **`@scope`** — expose types/fields only to specific scopes (multi-module boundaries).
 - **`@idOf`** — mark `ID` fields/args with their GraphQL type for type-safe Global ID handling.
 - **`@oneOf`** — enforce exactly one non-null field in an input object (union-like inputs).


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The `@backingData` docs page referenced `allCharacters` from `Character.graphqls` and `AllCharactersQueryResolver` — neither of which use `@backingData`. Replaced with the actual backing data example: `Film.castData`, which demonstrates the full pattern of fetching data once and sharing it across sibling resolvers.

**Key Changes**

- `docs/docs/getting_started/starwars/directives/backing_data.md` — rewrote page to walk through the correct 4-file `castData` pattern: schema declaration, data class, backing resolver, and two consuming resolvers that share the pre-fetched data
- `docs/docs/getting_started/starwars/directives/index.md` — updated `@backingData` one-liner to match the corrected description
- `demoapps/starwars/modules/filmography/` — added `tag::` comments to 5 source files (`Film.graphqls`, `FilmCastData.kt`, `FilmCastDataResolver.kt`, `FilmCharactersResolver.kt`, `FilmCharacterCountSummaryResolver.kt`) so the MkDocs `codetag` macro  can extract code snippets into the docs page

## How was it tested?  What documentation was provided?

Ran MkDocs locally and verified the rendered page:

```bash
cd docs
python3 -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt
mkdocs serve
```
Confirmed all 5 codetag snippets render correctly and the "Related" link resolves.