### PR TITLE
feat(engine): strict missing-resolver validation at startup

### DIFF
--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/DispatcherRegistryFactory.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/DispatcherRegistryFactory.kt
@@ -33,6 +33,7 @@ class DispatcherRegistryFactory(
     private val checkerExecutorFactory: CheckerExecutorFactory,
     private val resolverInstrumentation: ViaductResolverInstrumentation = ViaductResolverInstrumentation.DEFAULT,
     private val proxyResolverFactory: ProxyResolverFactory = ProxyResolverFactory.NO_OP,
+    private val missingResolverValidator: Validator<MissingResolverValidationCtx> = Validator.Unvalidated,
 ) {
     companion object {
         private fun log() = getLogger(this::class.java.name.substringBefore("\$Companion"))
@@ -129,6 +130,9 @@ class DispatcherRegistryFactory(
                 dispatcherRegistry, // need requiredSelectionSetRegistry on dispatcherRegistry for validation
             )
         )
+
+        missingResolverValidator.validate(MissingResolverValidationCtx(dispatcherRegistry))
+
         return dispatcherRegistry
     }
 }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/MissingResolverValidator.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/MissingResolverValidator.kt
@@ -1,0 +1,66 @@
+package viaduct.engine.runtime.tenantloading
+
+import graphql.schema.GraphQLObjectType
+import viaduct.engine.api.ViaductSchema
+import viaduct.engine.runtime.DispatcherRegistry
+import viaduct.engine.runtime.validation.Validator
+
+/**
+ * Validates that every @resolver-annotated field and object type in the schema
+ * has a corresponding dispatcher registered in the [DispatcherRegistry].
+ */
+class MissingResolverValidator(
+    private val schema: ViaductSchema,
+) : Validator<MissingResolverValidationCtx> {
+
+    override fun validate(ctx: MissingResolverValidationCtx) {
+        val missingFieldResolvers = mutableListOf<String>()
+        val missingNodeResolvers = mutableListOf<String>()
+
+        schema.schema.allTypesAsList.forEach { type ->
+            if (type !is GraphQLObjectType || type.name.startsWith("__")) return@forEach
+
+            if (type.hasAppliedDirective(RESOLVER_DIRECTIVE)) {
+                if (ctx.dispatcherRegistry.getNodeResolverDispatcher(type.name) == null) {
+                    missingNodeResolvers.add(type.name)
+                }
+            }
+
+            type.fieldDefinitions.forEach { field ->
+                if (field.name.startsWith("__")) return@forEach
+                if (field.hasAppliedDirective(RESOLVER_DIRECTIVE)) {
+                    if (ctx.dispatcherRegistry.getFieldResolverDispatcher(type.name, field.name) == null) {
+                        missingFieldResolvers.add("${type.name}.${field.name}")
+                    }
+                }
+            }
+        }
+
+        if (missingFieldResolvers.isNotEmpty() || missingNodeResolvers.isNotEmpty()) {
+            throw MissingResolversException(missingFieldResolvers, missingNodeResolvers)
+        }
+    }
+
+    companion object {
+        private const val RESOLVER_DIRECTIVE = "resolver"
+    }
+}
+
+data class MissingResolverValidationCtx(
+    val dispatcherRegistry: DispatcherRegistry,
+)
+
+class MissingResolversException(
+    val missingFieldResolvers: List<String>,
+    val missingNodeResolvers: List<String>,
+) : RuntimeException(
+    buildString {
+        append("Missing resolver implementations for @resolver-annotated schema elements. ")
+        if (missingFieldResolvers.isNotEmpty()) {
+            append("Fields without resolvers: ${missingFieldResolvers.sorted().joinToString(", ")}. ")
+        }
+        if (missingNodeResolvers.isNotEmpty()) {
+            append("Types without node resolvers: ${missingNodeResolvers.sorted().joinToString(", ")}.")
+        }
+    }
+)

--- a/core/engine/runtime/src/test/kotlin/viaduct/engine/runtime/tenantloading/MissingResolverValidatorTest.kt
+++ b/core/engine/runtime/src/test/kotlin/viaduct/engine/runtime/tenantloading/MissingResolverValidatorTest.kt
@@ -1,0 +1,233 @@
+package viaduct.engine.runtime.tenantloading
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import viaduct.engine.api.mocks.MockFieldUnbatchedResolverExecutor
+import viaduct.engine.api.mocks.MockNodeBatchResolverExecutor
+import viaduct.engine.api.mocks.MockSchema
+import viaduct.engine.runtime.DispatcherRegistry
+import viaduct.engine.runtime.FieldResolverDispatcherImpl
+import viaduct.engine.runtime.NodeResolverDispatcherImpl
+
+class MissingResolverValidatorTest {
+
+    @Test
+    fun `passes when all resolver fields have dispatchers`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                greeting: String @resolver
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = mapOf(
+                ("Query" to "greeting") to FieldResolverDispatcherImpl(
+                    MockFieldUnbatchedResolverExecutor(resolverId = "Query.greeting")
+                )
+            ),
+            nodeResolverDispatchers = emptyMap(),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        assertDoesNotThrow {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+    }
+
+    @Test
+    fun `throws when field resolver is missing`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                greeting: String @resolver
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = emptyMap(),
+            nodeResolverDispatchers = emptyMap(),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        val exception = assertThrows<MissingResolversException> {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+        assertEquals(listOf("Query.greeting"), exception.missingFieldResolvers)
+        assertTrue(exception.missingNodeResolvers.isEmpty())
+    }
+
+    @Test
+    fun `throws when node resolver is missing`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                user: User
+            }
+            type User @resolver {
+                id: ID!
+                name: String
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = emptyMap(),
+            nodeResolverDispatchers = emptyMap(),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        val exception = assertThrows<MissingResolversException> {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+        assertEquals(listOf("User"), exception.missingNodeResolvers)
+        assertTrue(exception.missingFieldResolvers.isEmpty())
+    }
+
+    @Test
+    fun `reports both missing field and node resolvers`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                greeting: String @resolver
+                user: User
+            }
+            type User @resolver {
+                id: ID!
+                name: String
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = emptyMap(),
+            nodeResolverDispatchers = emptyMap(),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        val exception = assertThrows<MissingResolversException> {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+        assertEquals(listOf("Query.greeting"), exception.missingFieldResolvers)
+        assertEquals(listOf("User"), exception.missingNodeResolvers)
+    }
+
+    @Test
+    fun `skips introspection types`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                greeting: String @resolver
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = mapOf(
+                ("Query" to "greeting") to FieldResolverDispatcherImpl(
+                    MockFieldUnbatchedResolverExecutor(resolverId = "Query.greeting")
+                )
+            ),
+            nodeResolverDispatchers = emptyMap(),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        assertDoesNotThrow {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+    }
+
+    @Test
+    fun `passes when node resolver is registered`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                user: User
+            }
+            type User @resolver {
+                id: ID!
+                name: String
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = emptyMap(),
+            nodeResolverDispatchers = mapOf(
+                "User" to NodeResolverDispatcherImpl(MockNodeBatchResolverExecutor("User"))
+            ),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        assertDoesNotThrow {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+    }
+
+    @Test
+    fun `fields without resolver directive are not checked`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                greeting: String @resolver
+                plainField: Int
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = mapOf(
+                ("Query" to "greeting") to FieldResolverDispatcherImpl(
+                    MockFieldUnbatchedResolverExecutor(resolverId = "Query.greeting")
+                )
+            ),
+            nodeResolverDispatchers = emptyMap(),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        assertDoesNotThrow {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+    }
+
+    @Test
+    fun `exception message includes sorted field and type names`() {
+        val schema = MockSchema.mk(
+            """
+            extend type Query {
+                zebra: String @resolver
+                alpha: String @resolver
+                user: User
+            }
+            type User @resolver {
+                id: ID!
+            }
+            """
+        )
+        val registry = DispatcherRegistry.Impl(
+            fieldResolverDispatchers = emptyMap(),
+            nodeResolverDispatchers = emptyMap(),
+            fieldCheckerDispatchers = emptyMap(),
+            typeCheckerDispatchers = emptyMap(),
+        )
+        val validator = MissingResolverValidator(schema)
+
+        val exception = assertThrows<MissingResolversException> {
+            validator.validate(MissingResolverValidationCtx(registry))
+        }
+        assertTrue(exception.message!!.contains("Query.alpha, Query.zebra"))
+        assertTrue(exception.message!!.contains("User"))
+    }
+}

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/SchemaScopedModule.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/SchemaScopedModule.kt
@@ -5,6 +5,7 @@ import com.google.inject.Exposed
 import com.google.inject.PrivateModule
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import javax.inject.Named
 import javax.inject.Qualifier
 import viaduct.engine.EngineConfiguration
 import viaduct.engine.EngineFactory
@@ -19,6 +20,9 @@ import viaduct.engine.runtime.RequiredSelectionSetRegistry
 import viaduct.engine.runtime.execution.TenantNameResolver
 import viaduct.engine.runtime.tenantloading.DispatcherRegistryFactory
 import viaduct.engine.runtime.tenantloading.ExecutorValidator
+import viaduct.engine.runtime.tenantloading.MissingResolverValidationCtx
+import viaduct.engine.runtime.tenantloading.MissingResolverValidator
+import viaduct.engine.runtime.validation.Validator
 import viaduct.service.api.SchemaId
 import viaduct.service.api.spi.TenantAPIBootstrapper as BaseTenantAPIBootstrapper
 import viaduct.utils.slf4j.logger
@@ -106,16 +110,23 @@ internal class SchemaScopedModule(
         schema: ViaductSchema,
         tenantBootstrapper: BaseTenantAPIBootstrapper<TenantModuleBootstrapper>,
         proxyResolverFactory: ProxyResolverFactory,
-        resolverInstrumentation: ViaductResolverInstrumentation
+        resolverInstrumentation: ViaductResolverInstrumentation,
+        @Named("lenientResolverValidation") lenientResolverValidation: Boolean,
     ): DispatcherRegistry {
         log.info("Creating DispatcherRegistry for Viaduct Modern")
         val startTime = System.currentTimeMillis()
+
+        val missingResolverValidator: Validator<MissingResolverValidationCtx> =
+            if (lenientResolverValidation) Validator.Unvalidated
+            else MissingResolverValidator(schema)
+
         val dispatcherRegistry = DispatcherRegistryFactory(
             tenantBootstrapper,
             validator,
             checkerExecutorFactory,
             resolverInstrumentation = resolverInstrumentation,
             proxyResolverFactory = proxyResolverFactory,
+            missingResolverValidator = missingResolverValidator,
         ).create(schema)
         val elapsedTime = System.currentTimeMillis() - startTime
         log.info("Created DispatcherRegistry for Viaduct Modern after [{}] ms", elapsedTime)

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaduct.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaduct.kt
@@ -35,6 +35,7 @@ import viaduct.engine.runtime.execution.DefaultCoroutineInterop
 import viaduct.engine.runtime.execution.TenantNameResolver
 import viaduct.engine.runtime.execution.ViaductDataFetcherExceptionHandler
 import viaduct.engine.runtime.tenantloading.DispatcherRegistryFactory
+import viaduct.engine.runtime.tenantloading.MissingResolversException
 import viaduct.engine.runtime.tenantloading.RequiredSelectionsAreInvalid
 import viaduct.service.api.ExecutionInput
 import viaduct.service.api.ExecutionResult
@@ -129,6 +130,7 @@ class StandardViaduct
             private var allowSubscriptions: Boolean = false
             private var globalIDCodec: GlobalIDCodec? = null
             private var proxyResolverFactory: ProxyResolverFactory? = null
+            private var lenientResolverValidation: Boolean = false
 
             fun enableAirbnbBypassDoNotUse(tenantNameResolver: TenantNameResolver,): Builder =
                 apply {
@@ -278,6 +280,16 @@ class StandardViaduct
                 }
 
             /**
+             * When set to true, suppresses the startup error that occurs when a
+             * @resolver-annotated field or type has no registered resolver.
+             * Default is false (strict: missing resolver = startup error).
+             */
+            fun withLenientResolverValidation(lenient: Boolean = true): Builder =
+                apply {
+                    this.lenientResolverValidation = lenient
+                }
+
+            /**
              * Builds the Guice Module within Viaduct and gets Viaduct from the injector.
              * Uses the factory pattern for proper dependency injection.
              *
@@ -323,6 +335,7 @@ class StandardViaduct
                     checkerExecutorFactoryCreator = checkerExecutorFactoryCreator,
                     documentProviderFactory = documentProviderFactory,
                     proxyResolverFactory = proxyResolverFactory,
+                    lenientResolverValidation = lenientResolverValidation,
                 )
 
                 try {
@@ -375,6 +388,11 @@ class StandardViaduct
              */
             private fun throwDispatcherRegistryError(exception: ProvisionException): GraphQLBuildError {
                 return when (exception.cause) {
+                    is MissingResolversException -> {
+                        val cause = exception.cause as MissingResolversException
+                        GraphQLBuildError(cause.message ?: "Missing resolver implementations", cause)
+                    }
+
                     is RequiredSelectionsAreInvalid -> GraphQLBuildError(
                         "Found GraphQL validation errors: %s".format(
                             (exception.cause as RequiredSelectionsAreInvalid).errors,

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaductModule.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaductModule.kt
@@ -6,6 +6,7 @@ import com.google.inject.AbstractModule
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import com.google.inject.TypeLiteral
+import com.google.inject.name.Names
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.instrumentation.Instrumentation
 import io.micrometer.core.instrument.MeterRegistry
@@ -36,6 +37,7 @@ class StandardViaductModule(
     private val checkerExecutorFactoryCreator: CheckerExecutorFactoryCreator?,
     private val documentProviderFactory: DocumentProviderFactory?,
     private val proxyResolverFactory: ProxyResolverFactory?,
+    private val lenientResolverValidation: Boolean = false,
 ) : AbstractModule() {
     override fun configure() {
         bind(StandardViaduct.Factory::class.java)
@@ -68,6 +70,8 @@ class StandardViaductModule(
         bind(CheckerExecutorFactoryCreator::class.java).toInstance(resolvedCheckerExecutorFactoryCreator)
 
         bind(ProxyResolverFactory::class.java).toInstance(proxyResolverFactory ?: ProxyResolverFactory.NO_OP)
+
+        bindConstant().annotatedWith(Names.named("lenientResolverValidation")).to(lenientResolverValidation)
     }
 
     @Provides

--- a/core/service/runtime/src/test/kotlin/viaduct/service/runtime/ScopeFilteringIntrospectionTest.kt
+++ b/core/service/runtime/src/test/kotlin/viaduct/service/runtime/ScopeFilteringIntrospectionTest.kt
@@ -55,6 +55,7 @@ class ScopeFilteringIntrospectionTest {
         subject = StandardViaduct.Builder()
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withDataFetcherExceptionHandler(mockk())
             .withSchemaConfiguration(schemaConfiguration)
             .build()

--- a/core/service/wiring/api/wiring.api
+++ b/core/service/wiring/api/wiring.api
@@ -64,6 +64,8 @@ public final class viaduct/service/ViaductBuilder {
 	public final fun withDataFetcherExceptionHandler (Lgraphql/execution/DataFetcherExceptionHandler;)Lviaduct/service/ViaductBuilder;
 	public final fun withFlagManager (Lviaduct/service/api/spi/FlagManager;)Lviaduct/service/ViaductBuilder;
 	public final fun withGlobalIDCodec (Lviaduct/service/api/spi/GlobalIDCodec;)Lviaduct/service/ViaductBuilder;
+	public final fun withLenientResolverValidation (Z)Lviaduct/service/ViaductBuilder;
+	public static synthetic fun withLenientResolverValidation$default (Lviaduct/service/ViaductBuilder;ZILjava/lang/Object;)Lviaduct/service/ViaductBuilder;
 	public final fun withMeterRegistry (Lio/micrometer/core/instrument/MeterRegistry;)Lviaduct/service/ViaductBuilder;
 	public final fun withProxyResolverFactory (Lviaduct/engine/api/spi/ProxyResolverFactory;)Lviaduct/service/ViaductBuilder;
 	public final fun withResolverErrorReporter (Lviaduct/service/api/spi/ErrorReporter;)Lviaduct/service/ViaductBuilder;

--- a/core/service/wiring/src/main/kotlin/viaduct/service/ViaductBuilder.kt
+++ b/core/service/wiring/src/main/kotlin/viaduct/service/ViaductBuilder.kt
@@ -147,6 +147,12 @@ class ViaductBuilder {
             builder.withProxyResolverFactory(proxyResolverFactory)
         }
 
+    /** @see StandardViaduct.Builder.withLenientResolverValidation */
+    fun withLenientResolverValidation(lenient: Boolean = true) =
+        apply {
+            builder.withLenientResolverValidation(lenient)
+        }
+
     /**
      * Builds and returns a [Viaduct] instance ready to execute GraphQL operations.
      *

--- a/core/service/wiring/src/test/kotlin/viaduct/service/ViaductBuilderTest.kt
+++ b/core/service/wiring/src/test/kotlin/viaduct/service/ViaductBuilderTest.kt
@@ -11,7 +11,10 @@ import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import viaduct.engine.api.GraphQLBuildError
 import viaduct.engine.api.ViaductSchema
 import viaduct.engine.api.spi.ProxyResolverFactory
 import viaduct.service.api.spi.ErrorReporter
@@ -54,6 +57,7 @@ class ViaductBuilderTest {
         ViaductBuilder()
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withSchemaConfiguration(schemaConfiguration)
             .build().let {
                 assertNotNull(it)
@@ -70,6 +74,7 @@ class ViaductBuilderTest {
         val viaduct = ViaductBuilder()
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withSchemaConfiguration(schemaConfiguration)
             .withMeterRegistry(meterRegistry)
             .build()
@@ -89,6 +94,7 @@ class ViaductBuilderTest {
         val viaduct = ViaductBuilder()
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withSchemaConfiguration(schemaConfiguration)
             .withResolverErrorReporter(errorReporter)
             .build()
@@ -106,6 +112,7 @@ class ViaductBuilderTest {
         val viaduct = ViaductBuilder()
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withSchemaConfiguration(schemaConfiguration)
             .withDataFetcherErrorBuilder(errorBuilder)
             .build()
@@ -129,6 +136,7 @@ class ViaductBuilderTest {
         val viaduct = ViaductBuilder()
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withSchemaConfiguration(schemaConfiguration)
             .withDataFetcherExceptionHandler(exceptionHandler)
             .build()
@@ -157,6 +165,7 @@ class ViaductBuilderTest {
         val result = builder
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withSchemaConfiguration(schemaConfiguration)
             .withMeterRegistry(meterRegistry)
             .withResolverErrorReporter(errorReporter)
@@ -192,6 +201,7 @@ class ViaductBuilderTest {
         val viaduct = ViaductBuilder()
             .withFlagManager(flagManager)
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withSchemaConfiguration(schemaConfiguration)
             .withMeterRegistry(meterRegistry)
             .withResolverErrorReporter(errorReporter)
@@ -216,6 +226,7 @@ class ViaductBuilderTest {
             .withFlagManager(flagManager)
             .withMeterRegistry(meterRegistry) // Observability before other methods
             .withNoTenantAPIBootstrapper()
+            .withLenientResolverValidation()
             .withResolverErrorReporter(errorReporter) // Observability in the middle
             .withSchemaConfiguration(schemaConfiguration)
             .build()
@@ -237,6 +248,22 @@ class ViaductBuilderTest {
         // Verify that the method returns the same builder instance for chaining
         assertSame(builder, returned)
         assertEquals(builder, returned)
+    }
+
+    @Test
+    fun `strict mode rejects missing resolver at build time`() {
+        val schemaConfiguration = SchemaConfiguration.fromSchema(
+            schema,
+            scopes = setOf(SchemaConfiguration.ScopeConfig("public", setOf("publicScope")))
+        )
+        val exception = assertThrows<GraphQLBuildError> {
+            ViaductBuilder()
+                .withFlagManager(flagManager)
+                .withNoTenantAPIBootstrapper()
+                .withSchemaConfiguration(schemaConfiguration)
+                .build()
+        }
+        assertTrue(exception.message!!.contains("helloWorld"))
     }
 
     private fun mkSchema(sdl: String): ViaductSchema = ViaductSchema(SchemaGenerator().makeExecutableSchema(SchemaParser().parse(sdl), RuntimeWiring.MOCKED_WIRING))

--- a/core/tenant/api/src/testFixtures/kotlin/viaduct/api/testing/featureapp/AbstractFeatureAppTestContractBase.kt
+++ b/core/tenant/api/src/testFixtures/kotlin/viaduct/api/testing/featureapp/AbstractFeatureAppTestContractBase.kt
@@ -92,6 +92,7 @@ abstract class AbstractFeatureAppTestContractBase {
         if (!::viaductBuilder.isInitialized) {
             viaductBuilder = ViaductBuilder()
                 .withFlagManager(flagManager)
+                .withLenientResolverValidation()
                 .withTenantAPIBootstrapperBuilder(createBootstrapperBuilder())
         }
     }

--- a/core/tenant/runtime/src/test/kotlin/viaduct/tenant/runtime/featuretests/fixtures/FeatureTestBuilder.kt
+++ b/core/tenant/runtime/src/test/kotlin/viaduct/tenant/runtime/featuretests/fixtures/FeatureTestBuilder.kt
@@ -432,6 +432,7 @@ class FeatureTestBuilder(
         @Suppress("DEPRECATION")
         val standardViaduct = StandardViaduct.Builder()
             .withTenantAPIBootstrapperBuilders(builders)
+            .withLenientResolverValidation()
             .withFlagManager(
                 MockFlagManager.create(
                     Flags.EXECUTE_ACCESS_CHECKS,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Adds startup-time validation that fails if the schema declares `@resolver` on a field/type but no corresponding executor is registered in the DispatcherRegistry. This makes misconfiguration a loud, early failure instead of silent runtime null resolution.

- **Default is strict** — missing resolver = `GraphQLBuildError` at startup
- **Opt-out via `withLenientResolverValidation()`** on `ViaductBuilder` / `StandardViaduct.Builder`
- Test infrastructure opts into lenient mode since contract/feature tests intentionally use partial resolver sets

## How was it tested?  What documentation was provided?

Unit tests for `MissingResolverValidator` (field missing, node missing, both, introspection skipped, sorted output)
Full test suite passes with `./gradlew test`
API dump updated (`apiDump`)