### PR TITLE
fix(ci): fix alert delivery condition in post-alerts.yml

### DIFF
--- a/.github/workflows/post-alerts.yml
+++ b/.github/workflows/post-alerts.yml
@@ -92,7 +92,7 @@ jobs:
 
   post-call:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_call'
+    if: inputs.text != ''
     steps:
       - name: Post to Slack
         env:


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

CI failure alerts were never being delivered to Slack/Discord for push-triggered runs on main. The post-call job in post-alerts.yml used if: github.event_name == 'workflow_call', but GitHub Actions sets github.event_name to the original triggering event (push) even inside reusable workflows called via uses:. The condition was always false, silently skipping all alert delivery.

**Key Changes**

- `.github/workflows/post-alerts.yml` — Replace `if: github.event_name == 'workflow_call'` with `if: inputs.text != ''`. This correctly distinguishes workflow_call invocations (where `inputs.text` is always provided) from workflow_dispatch (where only `mode` exists, so `inputs.text` is empty).

## How was it tested?  What documentation was provided?

- actionlint passes on the modified workflow
- Full validation after merge: trigger post-alerts.yml via workflow_dispatch with mode: test-posts to confirm test alerts still work, then observe next CI failure delivers to Slack/Discord