### PR TITLE
fix(ci): gate javaapi publications behind publishMinimal flag

### DIFF
--- a/publications/settings.gradle.kts
+++ b/publications/settings.gradle.kts
@@ -18,5 +18,7 @@ include(":runtime")
 include(":buildtime")
 include(":test-fixtures")
 include(":bom")
-include(":javaapi-api")
-include(":javaapi-codegen")
+if (!providers.gradleProperty("publishMinimal").isPresent) {
+    include(":javaapi-api")
+    include(":javaapi-codegen")
+}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The `demoapps-ci-check` workflow fails because `publications/settings.gradle.kts` unconditionally includes `:javaapi-api` and `:javaapi-codegen` but `-PpublishMinimal` excludes their source modules from `core/settings.gradle.kts`. Without the source modules in the composite build, auto-substitution can't resolve `com.airbnb.viaduct.javaapi:api:INCLUDED` and the build fails.

**Key Changes**

- `publications/settings.gradle.kts` — Gate `:javaapi-api` and `:javaapi-codegen` includes behind the same `publishMinimal` property check used in `core/settings.gradle.kts` so both builds agree on which javaapi modules exist

## How was it tested?  What documentation was provided?

- `actionlint` passes on the modified workflow
