### PR TITLE
fix(ci): make dokka job non-blocking for overall CI status

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -313,6 +313,7 @@ jobs:
 
   dokka:
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       matrix:
         os: ${{ inputs.os && fromJSON(format('["{0}"]', fromJSON(inputs.os)[0])) || fromJSON('["ubuntu-latest"]') }}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Dokka documentation generation failures were causing the entire `build-and-test` workflow to report `failure`, triggering alerts and blocking PRs even when all build and test jobs passed. Dokka failures are informational — they mean docs need fixing, not that the code is broken.

**Key Changes**

- `.github/workflows/build-and-test.yml` — Add `continue-on-error: true` to the `dokka` job. Failures still appear as orange annotations in the workflow UI but no longer cause the overall workflow to fail

## How was it tested?  What documentation was provided?

- `actionlint` passes on the modified workflow
- Behavior validated by GitHub Actions semantics: `continue-on-error: true` causes job failures to report as `neutral` rather than `failure` to the parent workflow