### PR TITLE
chore(api): add missing @InternalApi annotations to satisfy detekt

### DIFF
--- a/core/shared/errors/src/main/kotlin/viaduct/errors/Exceptions.kt
+++ b/core/shared/errors/src/main/kotlin/viaduct/errors/Exceptions.kt
@@ -122,6 +122,7 @@ suspend fun <T> handleFrameworkErrorsSuspend(
  * Use this to wrap calls into tenant code from the framework. Catches any exception and
  * attributes it to tenant code unless it is already a [PassthroughException].
  */
+@InternalApi
 fun <T> handleTenantErrors(
     opName: String,
     block: () -> T,
@@ -138,6 +139,7 @@ fun <T> handleTenantErrors(
 /**
  * Same as [handleTenantErrors] but for suspend functions.
  */
+@InternalApi
 suspend fun <T> handleTenantErrorsSuspend(
     opName: String,
     block: suspend () -> T,

--- a/core/tenant/api/src/main/kotlin/viaduct/api/globalid/GlobalIDImpl.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/globalid/GlobalIDImpl.kt
@@ -4,6 +4,7 @@ import kotlin.reflect.full.isSubclassOf
 import viaduct.api.reflect.Type
 import viaduct.api.types.NodeCompositeOutput
 import viaduct.api.types.NodeObject
+import viaduct.apiannotations.InternalApi
 
 /**
  * Default implementation of GlobalID.
@@ -11,6 +12,7 @@ import viaduct.api.types.NodeObject
  * GlobalIDImpl is a data class that represents a unique identifier for a node object
  * in the Viaduct graph. It contains the type information and internal ID.
  */
+@InternalApi
 data class GlobalIDImpl<T : NodeCompositeOutput>(
     override val type: Type<T>,
     override val internalID: String,

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/GlobalIDCodec.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/GlobalIDCodec.kt
@@ -7,6 +7,7 @@ import viaduct.api.globalid.GlobalIDImpl
 import viaduct.api.reflect.Type
 import viaduct.api.types.NodeCompositeOutput
 import viaduct.api.types.NodeObject
+import viaduct.apiannotations.InternalApi
 import viaduct.errors.TenantUsageException
 import viaduct.service.api.spi.GlobalIDCodec as ServiceGlobalIDCodec
 
@@ -23,6 +24,7 @@ import viaduct.service.api.spi.GlobalIDCodec as ServiceGlobalIDCodec
  * @param serviceGlobalIDCodec The service-level GlobalIDCodec for string-based operations
  * @param reflectionLoader The reflection loader for type reconstruction
  */
+@InternalApi
 class GlobalIDCodec(
     private val serviceGlobalIDCodec: ServiceGlobalIDCodec,
     private val reflectionLoader: ReflectionLoader

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/InternalSelectionSet.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/InternalSelectionSet.kt
@@ -1,10 +1,12 @@
 package viaduct.api.internal
 
+import viaduct.apiannotations.InternalApi
 import viaduct.engine.api.EngineSelectionSet
 
 /**
  * A helper interface for accessing internal selection set data from a tenant-facing type
  */
+@InternalApi
 interface InternalSelectionSet {
     val engineSelectionSet: EngineSelectionSet
 }

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/JsonConv.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/JsonConv.kt
@@ -12,6 +12,7 @@ import graphql.schema.GraphQLType
 import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetTime
+import viaduct.apiannotations.InternalApi
 import viaduct.engine.api.EngineSelectionSet
 import viaduct.engine.api.ViaductSchema
 import viaduct.mapping.graphql.Conv
@@ -23,6 +24,7 @@ import viaduct.mapping.graphql.IR
  *
  * @see JsonConv.invoke
  */
+@InternalApi
 object JsonConv {
     private val objectMapper = ObjectMapper()
     @Suppress("ObjectPropertyNaming")

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/KeyMapping.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/KeyMapping.kt
@@ -1,6 +1,7 @@
 package viaduct.api.internal
 
 import kotlin.collections.Map as KMap
+import viaduct.apiannotations.InternalApi
 import viaduct.engine.api.EngineSelectionSet
 
 /**
@@ -13,6 +14,7 @@ import viaduct.engine.api.EngineSelectionSet
  * A [KeyMapping] is a "type hint" about the nature of an object key, which can be used by
  * a Conv to correctly map object values.
  */
+@InternalApi
 data class KeyMapping(val fromType: KeyType, val toType: KeyType) {
     /** The type of key in an object */
     enum class KeyType {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The `ApiStabilityAnnotationRequired` detekt rule (enabled via `bcv-api` plugin) requires all public declarations in BCV-checked modules to carry an API stability annotation. Seven internal-only declarations were missing `@InternalApi`, causing detekt violations on every build.

**Key Changes**

- `Exceptions.kt` — annotated `handleTenantErrors` and `handleTenantErrorsSuspend` with `@InternalApi` (framework-internal helpers, not tenant-facing)
- `core/tenant/api/.../internal/` — annotated `KeyMapping`, `JsonConv`, `InternalSelectionSet`, and `GlobalIDCodec` with `@InternalApi` (all live in the `internal` package and follow the same pattern as their sibling classes)
- `GlobalIDImpl.kt` — annotated with `@InternalApi` (implementation detail; tenants use `GlobalID` interface via `ExecutionContext` methods)

## How was it tested?  What documentation was provided?

- `./gradlew :core:shared:errors:detekt :core:tenant:api:detekt` — 0 violations (previously 7)
- `./gradlew :core:shared:errors:compileKotlin :core:tenant:api:compileKotlin` — BUILD SUCCESSFUL, no new warnings introduced

These annotations are compile-time metadata only — they don't change runtime behavior. The `@InternalApi` opt-in is already configured project-wide via `kotlin-compile-config.gradle.kts`, so no downstream compilation breaks