### PR TITLE
chore(javaapi): fix all checkstyle violations in Java API module

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -17,6 +17,24 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <!-- Suppress MethodName in test sources to allow underscores (idiomatic Java test naming) -->
+    <module name="SuppressionSingleFilter">
+        <property name="checks" value="MethodName"/>
+        <property name="files" value="src[\\/]test[\\/]"/>
+    </module>
+
+    <!-- Suppress InterfaceIsType for marker interfaces with constants -->
+    <module name="SuppressionSingleFilter">
+        <property name="checks" value="InterfaceIsType"/>
+        <property name="files" value="(CompositeOutput|Arguments)\.java$"/>
+    </module>
+
+    <!-- Suppress ConstantName for intentional marker constants -->
+    <module name="SuppressionSingleFilter">
+        <property name="checks" value="ConstantName"/>
+        <property name="files" value="(CompositeOutput|Arguments)\.java$"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- Checks for Naming Conventions -->
         <module name="ConstantName"/>

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/internal/JavaInputBase.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/internal/JavaInputBase.java
@@ -70,8 +70,12 @@ public abstract class JavaInputBase implements GraphQLInput {
         "JavaInputBase.getScalarList: " + fieldName,
         () -> {
           Object value = inputData.get(fieldName);
-          if (value == null) return null;
-          if (value instanceof List<?>) return (List<T>) value;
+          if (value == null) {
+            return null;
+          }
+          if (value instanceof List<?>) {
+            return (List<T>) value;
+          }
           throw new FrameworkException(
               "Expected List for field '" + fieldName + "', got " + value.getClass().getName(),
               null);
@@ -92,7 +96,9 @@ public abstract class JavaInputBase implements GraphQLInput {
         "JavaInputBase.getScalarList: " + fieldName,
         () -> {
           Object value = inputData.get(fieldName);
-          if (value == null) return null;
+          if (value == null) {
+            return null;
+          }
           if (value instanceof List<?> list) {
             List<Object> coerced = new ArrayList<>(list.size());
             for (Object element : list) {
@@ -118,8 +124,12 @@ public abstract class JavaInputBase implements GraphQLInput {
         "JavaInputBase.getInput: " + fieldName,
         () -> {
           Object value = inputData.get(fieldName);
-          if (value == null) return null;
-          if (value instanceof JavaInputBase) return (T) value;
+          if (value == null) {
+            return null;
+          }
+          if (value instanceof JavaInputBase) {
+            return (T) value;
+          }
           if (value instanceof Map<?, ?> map) {
             return constructor.apply((Map<String, Object>) map);
           }
@@ -138,7 +148,9 @@ public abstract class JavaInputBase implements GraphQLInput {
         "JavaInputBase.getInputList: " + fieldName,
         () -> {
           Object value = inputData.get(fieldName);
-          if (value == null) return null;
+          if (value == null) {
+            return null;
+          }
           if (value instanceof List<?> list) {
             List<T> wrapped = new ArrayList<>(list.size());
             for (Object element : list) {
@@ -169,8 +181,12 @@ public abstract class JavaInputBase implements GraphQLInput {
         "JavaInputBase.getEnum: " + fieldName,
         () -> {
           Object value = inputData.get(fieldName);
-          if (value == null) return null;
-          if (enumClass.isInstance(value)) return (E) value;
+          if (value == null) {
+            return null;
+          }
+          if (enumClass.isInstance(value)) {
+            return (E) value;
+          }
           return Enum.valueOf(enumClass, value.toString());
         });
   }
@@ -183,7 +199,9 @@ public abstract class JavaInputBase implements GraphQLInput {
         "JavaInputBase.getEnumList: " + fieldName,
         () -> {
           Object value = inputData.get(fieldName);
-          if (value == null) return null;
+          if (value == null) {
+            return null;
+          }
           if (value instanceof List<?> list) {
             List<E> wrapped = new ArrayList<>(list.size());
             for (Object element : list) {

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/internal/JavaObjectBase.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/internal/JavaObjectBase.java
@@ -479,7 +479,9 @@ public abstract class JavaObjectBase implements GraphQLObject {
     return HandleErrors.framework(
         "JavaObjectBase.coerceScalar: " + scalarType,
         () -> {
-          if (raw == null || scalarType == null) return raw;
+          if (raw == null || scalarType == null) {
+            return raw;
+          }
           return switch (scalarType) {
             case "DateTime" -> coerceToInstant(raw);
             case "Date" -> coerceToLocalDate(raw);
@@ -494,7 +496,9 @@ public abstract class JavaObjectBase implements GraphQLObject {
    * Instant pass-through, String parsed as ISO_OFFSET_DATE_TIME and converted to Instant.
    */
   private static Instant coerceToInstant(Object value) throws FrameworkException {
-    if (value instanceof Instant instant) return instant;
+    if (value instanceof Instant instant) {
+      return instant;
+    }
     if (value instanceof String s) {
       return OffsetDateTime.parse(s, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant();
     }
@@ -506,8 +510,12 @@ public abstract class JavaObjectBase implements GraphQLObject {
    * LocalDate.parse().
    */
   private static LocalDate coerceToLocalDate(Object value) throws FrameworkException {
-    if (value instanceof LocalDate date) return date;
-    if (value instanceof String s) return LocalDate.parse(s);
+    if (value instanceof LocalDate date) {
+      return date;
+    }
+    if (value instanceof String s) {
+      return LocalDate.parse(s);
+    }
     throw new FrameworkException("Could not convert " + value + " to LocalDate.", null);
   }
 
@@ -516,8 +524,12 @@ public abstract class JavaObjectBase implements GraphQLObject {
    * OffsetTime.parse().
    */
   private static OffsetTime coerceToOffsetTime(Object value) throws FrameworkException {
-    if (value instanceof OffsetTime time) return time;
-    if (value instanceof String s) return OffsetTime.parse(s);
+    if (value instanceof OffsetTime time) {
+      return time;
+    }
+    if (value instanceof String s) {
+      return OffsetTime.parse(s);
+    }
     throw new FrameworkException("Could not convert " + value + " to OffsetTime.", null);
   }
 }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/resolvers/FieldResolverBase.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/resolvers/FieldResolverBase.java
@@ -74,5 +74,5 @@ public interface FieldResolverBase<
    */
   interface Context<
           O extends GraphQLObject, Q extends Query, A extends Arguments, S extends CompositeOutput>
-      extends FieldExecutionContext<O, Q, A, S> {}
+      extends FieldExecutionContext<O, Q, A, S> { }
 }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/resolvers/NodeResolverBase.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/resolvers/NodeResolverBase.java
@@ -66,7 +66,7 @@ import viaduct.java.api.types.NodeObject;
 public interface NodeResolverBase<R extends NodeObject> {
 
   /** Context type alias for node resolvers, providing type-safe access to the node's global ID. */
-  interface Context<R extends NodeObject> extends NodeExecutionContext<R> {}
+  interface Context<R extends NodeObject> extends NodeExecutionContext<R> { }
 
   /**
    * Resolves a single node by its global ID.

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/Arguments.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/Arguments.java
@@ -5,7 +5,7 @@ public interface Arguments extends InputLike {
 
   /** A marker object indicating the lack of schematic arguments. */
   final class None implements Arguments {
-    private None() {}
+    private None() { }
   }
 
   Arguments NoArguments = new None();

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/CompositeOutput.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/CompositeOutput.java
@@ -4,7 +4,7 @@ package viaduct.java.api.types;
 public interface CompositeOutput extends GRT {
 
   final class None implements CompositeOutput {
-    private None() {}
+    private None() { }
   }
 
   /**

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GRT.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GRT.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Base interface for all GraphQL Representational Types (GRTs). */
-public interface GRT {}
+public interface GRT { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLInput.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLInput.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Tagging interface for GraphQL input types. */
-public interface GraphQLInput extends InputLike {}
+public interface GraphQLInput extends InputLike { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLInterface.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLInterface.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Tagging interface for GraphQL interface types. */
-public interface GraphQLInterface extends CompositeOutput {}
+public interface GraphQLInterface extends CompositeOutput { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLObject.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLObject.java
@@ -4,4 +4,4 @@ package viaduct.java.api.types;
  * Tagging interface for GraphQL object types. Renamed from "Object" to avoid confusion with
  * java.lang.Object.
  */
-public interface GraphQLObject extends GraphQLInterface {}
+public interface GraphQLObject extends GraphQLInterface { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLUnion.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/GraphQLUnion.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Tagging interface for GraphQL union types. */
-public interface GraphQLUnion extends CompositeOutput {}
+public interface GraphQLUnion extends CompositeOutput { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/InputLike.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/InputLike.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Tagging interface for input types and virtual input types that wrap field arguments. */
-public interface InputLike extends GRT {}
+public interface InputLike extends GRT { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/Mutation.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/Mutation.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Tagging interface for the root mutation object. */
-public interface Mutation extends GraphQLObject {}
+public interface Mutation extends GraphQLObject { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/NodeCompositeOutput.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/NodeCompositeOutput.java
@@ -4,4 +4,4 @@ package viaduct.java.api.types;
  * Tagging interface for types that implement the Node interface. This includes both Node interfaces
  * and Node object implementations.
  */
-public interface NodeCompositeOutput extends CompositeOutput {}
+public interface NodeCompositeOutput extends CompositeOutput { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/NodeObject.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/NodeObject.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Tagging interface for object types that implement the GraphQL Node interface. */
-public interface NodeObject extends GraphQLObject, NodeCompositeOutput {}
+public interface NodeObject extends GraphQLObject, NodeCompositeOutput { }

--- a/core/x/javaapi/api/src/main/java/viaduct/java/api/types/Query.java
+++ b/core/x/javaapi/api/src/main/java/viaduct/java/api/types/Query.java
@@ -1,4 +1,4 @@
 package viaduct.java.api.types;
 
 /** Tagging interface for the root query object. */
-public interface Query extends GraphQLObject {}
+public interface Query extends GraphQLObject { }

--- a/core/x/javaapi/api/src/test/java/viaduct/java/api/reflect/TypeTest.java
+++ b/core/x/javaapi/api/src/test/java/viaduct/java/api/reflect/TypeTest.java
@@ -8,11 +8,11 @@ import viaduct.java.api.types.GRT;
 
 class TypeTest {
 
-  static class TestGRT implements GRT {}
+  static class TestGRT implements GRT { }
 
-  static class AnotherTestGRT implements GRT {}
+  static class AnotherTestGRT implements GRT { }
 
-  static class NotAGRT {}
+  static class NotAGRT { }
 
   @Test
   void ofClass_returnsTypeWithCorrectName() {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The `core/x/javaapi/api` module produced 85 checkstyle warnings on every build. This eliminates all of them through code formatting fixes and targeted suppressions for intentional patterns that conflict with default rules.

**Key Changes**

- `core/x/javaapi/api/src/main/java/.../types/*.java` — added space inside empty interface bodies (`{}` → `{ }`) to satisfy WhitespaceAround rule
- `core/x/javaapi/api/src/main/java/.../internal/JavaInputBase.java` — expanded bare `if` statements to multi-line braced form to satisfy NeedBraces and LeftCurly rules
- `core/x/javaapi/api/src/main/java/.../internal/JavaObjectBase.java` — same NeedBraces fix for scalar coercion methods
- `core/x/javaapi/api/src/main/java/.../resolvers/*.java` — space inside empty nested interface bodies
- `config/checkstyle/checkstyle.xml` — added SuppressionSingleFilter entries for: MethodName in test sources (allows idiomatic `underscore_style` test names), InterfaceIsType and ConstantName in `CompositeOutput.java`/`Arguments.java` (intentional marker interfaces with semantic constant names like `NotComposite` and `NoArguments`)

## How was it tested?  What documentation was provided?

- `./gradlew :core:x:javaapi:api:checkstyleMain :core:x:javaapi:api:checkstyleTest` — 0 violations
- `./gradlew :core:x:javaapi:api:compileJava :core:x:javaapi:api:compileTestJava` — BUILD SUCCESSFUL

No behavioral changes; all modifications are formatting-only or suppression config.