### PR TITLE
fix(engine): align override nullability with graphql-java 26 signatures

### DIFF
--- a/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/IViaductInstrumentation.kt
+++ b/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/IViaductInstrumentation.kt
@@ -56,7 +56,7 @@ interface IViaductInstrumentation {
     fun beginParse(
         parameters: InstrumentationExecutionParameters,
         state: InstrumentationState?
-    ): InstrumentationContext<Document?>? = default.beginParse(parameters, state)
+    ): InstrumentationContext<Document>? = default.beginParse(parameters, state)
 
     fun beginValidation(
         parameters: InstrumentationValidationParameters,

--- a/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/ViaductInstrumentationAdapter.kt
+++ b/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/ViaductInstrumentationAdapter.kt
@@ -48,7 +48,7 @@ open class ViaductInstrumentationAdapter(
     override fun beginParse(
         parameters: InstrumentationExecutionParameters,
         state: InstrumentationState?
-    ): InstrumentationContext<Document?>? = viaductInstrumentation.beginParse(parameters, state)
+    ): InstrumentationContext<Document>? = viaductInstrumentation.beginParse(parameters, state)
 
     override fun beginValidation(
         parameters: InstrumentationValidationParameters,

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/FieldWithMetadata.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/FieldWithMetadata.kt
@@ -58,7 +58,7 @@ class FieldWithMetadata(
             '}'
     }
 
-    override fun transform(builderConsumer: Consumer<Builder>?): Field {
+    override fun transform(builderConsumer: Consumer<Builder>): Field {
         return super.transform(builderConsumer).let {
             fromFieldWithMetadata(it, metadata)
         }

--- a/core/service/runtime/src/test/kotlin/viaduct/service/runtime/StandardViaductTest.kt
+++ b/core/service/runtime/src/test/kotlin/viaduct/service/runtime/StandardViaductTest.kt
@@ -72,7 +72,7 @@ class StandardViaductTest {
     internal class SuccessfulExecutionResult : ExecutionResult {
         override fun getErrors(): MutableList<GraphQLError> = mutableListOf()
 
-        override fun <T : Any?> getData() = null
+        override fun <T : Any> getData(): T? = null
 
         override fun isDataPresent() = true
 

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/ViaductQueryTraverser.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/ViaductQueryTraverser.kt
@@ -179,7 +179,7 @@ class ViaductQueryTraverser private constructor(
     ): T? {
         var acc: T? = initialValue
         visitPostOrder(object : QueryVisitorStub() {
-            override fun visitField(env: QueryVisitorFieldEnvironment?) {
+            override fun visitField(env: QueryVisitorFieldEnvironment) {
                 acc = queryReducer.reduceField(env, acc)
             }
         })
@@ -201,7 +201,7 @@ class ViaductQueryTraverser private constructor(
     ): T? {
         var acc: T? = initialValue
         visitPreOrder(object : QueryVisitorStub() {
-            override fun visitField(env: QueryVisitorFieldEnvironment?) {
+            override fun visitField(env: QueryVisitorFieldEnvironment) {
                 acc = queryReducer.reduceField(env, acc)
             }
         })

--- a/core/shared/graphql/src/test/kotlin/viaduct/graphql/utils/ValueExtensionsTest.kt
+++ b/core/shared/graphql/src/test/kotlin/viaduct/graphql/utils/ValueExtensionsTest.kt
@@ -876,13 +876,13 @@ class ValueExtensionsTest {
             }
 
             override fun accept(
-                context: TraverserContext<Node<Node<*>>>?,
-                visitor: NodeVisitor?
+                context: TraverserContext<Node<Node<*>>>,
+                visitor: NodeVisitor
             ): TraversalControl {
                 TODO("Not yet implemented")
             }
 
-            override fun withNewChildren(newChildren: NodeChildrenContainer?): UnknownValue {
+            override fun withNewChildren(newChildren: NodeChildrenContainer): UnknownValue {
                 TODO("Not yet implemented")
             }
         }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Kotlin 2.x will promote KT-36770 nullability-mismatch-in-overrides from a warning to a hard compiler error. This fixes all six occurrences in the codebase where Kotlin override signatures declared parameters or type arguments as nullable when the graphql-java 26 parent declares them as non-null.

**Key Changes**

- `ViaductQueryTraverser.kt` — changed `visitField(env: QueryVisitorFieldEnvironment?)` to non-nullable `env` in both `reducePostOrder` and `reducePreOrder` (graphql-java's `QueryVisitorStub.visitField` takes non-null)
- `IViaductInstrumentation.kt` / `ViaductInstrumentationAdapter.kt` — changed `beginParse` return type from `InstrumentationContext<Document?>?` to `InstrumentationContext<Document>?` (graphql-java's `Instrumentation.beginParse` returns `InstrumentationContext<Document>`)
- `FieldWithMetadata.kt` — changed `transform(builderConsumer: Consumer<Builder>?)` to non-nullable parameter (graphql-java's `Field.transform` takes non-null `Consumer`)
- `ValueExtensionsTest.kt` — removed nullable `?` from `accept` and `withNewChildren` override parameters
- `StandardViaductTest.kt` — fixed `getData` type parameter bound from `<T : Any?>` to `<T : Any>` to match `ExecutionResult.getData`

## How was it tested?  What documentation was provided?

- `./gradlew :core:shared:graphql:compileKotlin :core:engine:api:compileKotlin :core:engine:runtime:compileKotlin :core:shared:graphql:compileTestKotlin :core:service:runtime:compileTestKotlin` — BUILD SUCCESSFUL, zero KT-36770 warnings remaining

No behavioral change — these parameters were never actually null at runtime; the nullable declarations were just overly conservative.