### PR TITLE
fix: resolve all Kotlin nullability compiler warnings in main sources

### DIFF
--- a/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/ChainedInstrumentation.kt
+++ b/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/ChainedInstrumentation.kt
@@ -298,7 +298,7 @@ open class ChainedInstrumentation(
         }
     }
 
-    protected class ChainedInstrumentationContext<T : Any?>(
+    protected class ChainedInstrumentationContext<T : Any>(
         private val contexts: List<InstrumentationContext<T>?>
     ) : InstrumentationContext<T> {
         override fun onDispatched() {

--- a/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/IViaductInstrumentation.kt
+++ b/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/IViaductInstrumentation.kt
@@ -56,7 +56,7 @@ interface IViaductInstrumentation {
     fun beginParse(
         parameters: InstrumentationExecutionParameters,
         state: InstrumentationState?
-    ): InstrumentationContext<Document?>? = default.beginParse(parameters, state)
+    ): InstrumentationContext<Document>? = default.beginParse(parameters, state)
 
     fun beginValidation(
         parameters: InstrumentationValidationParameters,

--- a/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/ViaductInstrumentationAdapter.kt
+++ b/core/engine/api/src/main/kotlin/viaduct/engine/api/instrumentation/ViaductInstrumentationAdapter.kt
@@ -48,7 +48,7 @@ open class ViaductInstrumentationAdapter(
     override fun beginParse(
         parameters: InstrumentationExecutionParameters,
         state: InstrumentationState?
-    ): InstrumentationContext<Document?>? = viaductInstrumentation.beginParse(parameters, state)
+    ): InstrumentationContext<Document>? = viaductInstrumentation.beginParse(parameters, state)
 
     override fun beginValidation(
         parameters: InstrumentationValidationParameters,

--- a/core/engine/api/src/main/kotlin/viaduct/engine/api/select/SelectionsParser.kt
+++ b/core/engine/api/src/main/kotlin/viaduct/engine/api/select/SelectionsParser.kt
@@ -13,7 +13,7 @@ object SelectionsParser {
     /** Return a [ParsedSelections] from the provided [Fragment] */
     fun parse(fragment: Fragment): ParsedSelections =
         ParsedSelections(
-            fragment.definition.typeCondition.name,
+            fragment.definition.typeCondition.name!!,
             fragment.definition.selectionSet,
             fragment.parsedDocument.getDefinitionsOfType(FragmentDefinition::class.java).associateBy { it.name }
         )

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/FieldWithMetadata.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/FieldWithMetadata.kt
@@ -36,8 +36,8 @@ class FieldWithMetadata(
         return FieldWithMetadata(
             name,
             alias,
-            deepCopy(arguments),
-            deepCopy(directives),
+            deepCopy(arguments)!!,
+            deepCopy(directives)!!,
             deepCopy(selectionSet),
             sourceLocation,
             comments,
@@ -58,7 +58,7 @@ class FieldWithMetadata(
             '}'
     }
 
-    override fun transform(builderConsumer: Consumer<Builder>?): Field {
+    override fun transform(builderConsumer: Consumer<Builder>): Field {
         return super.transform(builderConsumer).let {
             fromFieldWithMetadata(it, metadata)
         }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/SyncEngineObjectDataFactory.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/SyncEngineObjectDataFactory.kt
@@ -116,12 +116,10 @@ object SyncEngineObjectDataFactory {
             val cell = objectEngineResult.getCellOptimistically(oerKey(selectionSet, engineSelection))
             selectionStates += SelectionState(selectionName, selectionPath, cell, subselections)
 
-            if (cell is Cell) {
-                @Suppress("UNCHECKED_CAST")
-                cellValues += cell.getValue(RAW_VALUE_SLOT) as Value<Any?>
-                @Suppress("UNCHECKED_CAST")
-                cellValues += cell.getValue(ACCESS_CHECK_SLOT) as Value<Any?>
-            }
+            @Suppress("UNCHECKED_CAST")
+            cellValues += cell.getValue(RAW_VALUE_SLOT) as Value<Any?>
+            @Suppress("UNCHECKED_CAST")
+            cellValues += cell.getValue(ACCESS_CHECK_SLOT) as Value<Any?>
         }
 
         // Single suspension point: await all incomplete cell slot values concurrently.

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/exceptions/FieldFetchingException.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/exceptions/FieldFetchingException.kt
@@ -23,7 +23,7 @@ class FieldFetchingException private constructor(
 
     fun toGraphQLError(): GraphQLError {
         return GraphQLError.newError()
-            .message(cause?.message)
+            .message(cause?.message ?: "Unknown error")
             .errorType(ErrorClassification.errorClassification("VIADUCT_FIELD_FETCHING_EXCEPTION"))
             .path(path)
             .location(location)

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/AccessCheckRunner.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/AccessCheckRunner.kt
@@ -47,7 +47,7 @@ class AccessCheckRunner(
 
         val field = checkNotNull(parameters.field) { "Expected field to be non-null." }
         val fieldName = field.fieldName
-        val parentTypeName = parameters.executionStepInfo.objectType.name
+        val parentTypeName = parameters.executionStepInfo.objectType!!.name
         val checkerDispatcher = engineExecutionContext.dispatcherRegistry.getFieldCheckerDispatcher(parentTypeName, fieldName)
             ?: return Value.nullValue // No access check for this field, return immediately
 
@@ -196,7 +196,7 @@ class AccessCheckRunner(
             }
             log.ifDebug {
                 val fieldCoord = if (checkerType == CheckerExecutor.CheckerType.FIELD) {
-                    "${parameters.executionStepInfo.objectType.name}.${parameters.field!!.fieldName}"
+                    "${parameters.executionStepInfo.objectType!!.name}.${parameters.field!!.fieldName}"
                 } else {
                     "${objectEngineResult.type.name}"
                 }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ErrorAccumulator.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ErrorAccumulator.kt
@@ -12,7 +12,7 @@ class ErrorAccumulator {
 
     /** add a single error */
     fun add(error: GraphQLError) {
-        val pathString = pathString(error.path)
+        val pathString = pathString(error.path ?: emptyList())
         errors.putIfAbsent(pathString, error)
     }
 

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ExecutionParameters.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ExecutionParameters.kt
@@ -116,6 +116,7 @@ data class ExecutionParameters(
     /** The root ObjectEngineResult for the entire request */
     val rootEngineResult: ObjectEngineResultImpl = constants.rootEngineResult
 
+    @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     val gjParameters: ExecutionStrategyParameters = ExecutionStrategyParameters.newParameters()
         // graphql-java requires a merged selection set, though our execution strategy doesn't use it.
         // provide a placeholder value
@@ -158,7 +159,7 @@ data class ExecutionParameters(
         field: QueryPlan.CollectedField
     ): ExecutionParameters {
         val coord = objectType.name to field.mergedField.name
-        val fieldDef = executionContext.graphQLSchema.getFieldDefinition(coord.gj)
+        val fieldDef = executionContext.graphQLSchema.getFieldDefinition(coord.gj)!!
         val path = path.segment(field.responseKey)
         val mergedField = field.mergedField
         val executionStepInfo = FieldExecutionHelpers.createExecutionStepInfo(
@@ -283,6 +284,7 @@ data class ExecutionParameters(
         parentFieldStepInfo: ExecutionStepInfo?,
     ): ExecutionParameters {
         // Build execution step info based on plan type
+        @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         val childExecutionStepInfo = if (isRootQueryQueryPlan) {
             // Query-type child plans get a completely fresh execution context
             ExecutionStepInfo.newExecutionStepInfo()
@@ -298,8 +300,8 @@ data class ExecutionParameters(
             val esiBuilder = ExecutionStepInfo.newExecutionStepInfo(parentFieldStepInfo).type(objectType)
             // if the field isn't null, update it
             if (parentFieldStepInfo.field != null) {
-                val parentMergedField = parentFieldStepInfo.field
-                val parentFieldType = parentFieldStepInfo.fieldDefinition.type?.let(GraphQLTypeUtil::unwrapAll)
+                val parentMergedField = parentFieldStepInfo.field!!
+                val parentFieldType = GraphQLTypeUtil.unwrapAll(parentFieldStepInfo.fieldDefinition!!.type)
                 val requiresInlineFragment = parentFieldType !is GraphQLObjectType
                 val updatedSelectionSet: GJSelectionSet =
                     if (requiresInlineFragment) {
@@ -333,9 +335,9 @@ data class ExecutionParameters(
             esiBuilder.build()
         }
 
-        val localContext = if (isRootQueryQueryPlan) {
+        val localContext: CompositeLocalContext = if (isRootQueryQueryPlan) {
             // For root query plans, we use the root local context
-            executionContext.getLocalContext()
+            executionContext.getLocalContext() as CompositeLocalContext
         } else {
             // For object plans, we use the current local context
             localContext
@@ -460,7 +462,7 @@ data class ExecutionParameters(
                     coercedVariables = executionContext.coercedVariables,
                     queryPlan = queryPlan,
                     source = executionContext.getRoot(),
-                    localContext = executionContext.getLocalContext(),
+                    localContext = executionContext.getLocalContext() as CompositeLocalContext,
                     executionStepInfo = parameters.executionStepInfo,
                     selectionSet = queryPlan.selectionSet,
                     errorAccumulator = ErrorAccumulator(),

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/FieldExecutionHelpers.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/FieldExecutionHelpers.kt
@@ -55,7 +55,7 @@ object FieldExecutionHelpers {
         parameters: ExecutionParameters,
         field: QueryPlan.CollectedField
     ): FieldCoordinates {
-        val objectType = parameters.executionStepInfo.objectType
+        val objectType = parameters.executionStepInfo.objectType!!
         val fieldName = field.mergedField.name
         return (objectType.name to fieldName).gj
     }
@@ -90,7 +90,7 @@ object FieldExecutionHelpers {
         val mergedField = checkNotNull(field.mergedField) {
             "FieldExecutionHelpers.buildDataFetchingEnvironment requires a merged field"
         }
-        val fieldDef = parameters.executionStepInfo.fieldDefinition
+        val fieldDef = parameters.executionStepInfo.fieldDefinition!!
         val execStepInfoSupplier = { parameters.executionStepInfo }
         val argumentValuesSupplier = { parameters.executionStepInfo.arguments }
         val normalizedFieldSupplier = getNormalizedField(parameters.executionContext, parameters.gjParameters, execStepInfoSupplier)
@@ -98,6 +98,7 @@ object FieldExecutionHelpers {
             // ViaductExecutionStrategy does not use NormalizedVariables, though the GJ interface requires them.
             NormalizedVariables.emptyVariables()
         }
+        @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         val fieldCollector = DataFetchingFieldSelectionSetImpl.newCollector(
             parameters.graphQLSchema,
             fieldDef.type,
@@ -138,6 +139,7 @@ object FieldExecutionHelpers {
             }
         }
 
+        @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         val dfe = DataFetchingEnvironmentImpl.newDataFetchingEnvironment(parameters.executionContext)
             .source(parameters.source)
             .localContext(localContext)
@@ -177,6 +179,7 @@ object FieldExecutionHelpers {
     ): ExecutionStepInfo {
         val fieldType = fieldDefinition.type
 
+        @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         return ExecutionStepInfo.newExecutionStepInfo()
             .type(fieldType)
             .fieldDefinition(fieldDefinition)

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/FieldResolver.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/FieldResolver.kt
@@ -140,10 +140,10 @@ class FieldResolver(
             }
 
             // Wait for all values to be completed.
+            @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
             return overall
                 .map {
                     resolveObjectCtx.onCompleted(Unit, null)
-                    it
                 }.recover { t ->
                     resolveObjectCtx.onCompleted(null, t)
                     Value.fromThrowable(t)
@@ -205,7 +205,6 @@ class FieldResolver(
                 }
             }.map {
                 resolveObjectCtx.onCompleted(Unit, null)
-                it
             }.recover { t ->
                 resolveObjectCtx.onCompleted(null, t)
                 Value.fromThrowable(t)
@@ -633,7 +632,7 @@ class FieldResolver(
         dataFetchingEnvironmentProvider: Supplier<DataFetchingEnvironment>,
     ): Pair<Value<FieldResolutionResult>, Value<out CheckerResult?>> =
         try {
-            val fieldDef = parameters.executionStepInfo.fieldDefinition
+            val fieldDef = parameters.executionStepInfo.fieldDefinition!!
             var dataFetcher = parameters.graphQLSchema.codeRegistry.getDataFetcher(
                 FieldExecutionHelpers.coordinateOfField(parameters, field),
                 fieldDef
@@ -661,7 +660,7 @@ class FieldResolver(
 
             // For top-level mutation and subscription fields, execute the data fetcher only if the access check succeeds.
             // For everything else, execute the access check in parallel with the data fetcher.
-            val executeCheckerSequentially = when (parameters.executionStepInfo.objectType.name) {
+            val executeCheckerSequentially = when (parameters.executionStepInfo.objectType!!.name) {
                 parameters.graphQLSchema.mutationType?.name,
                 parameters.graphQLSchema.subscriptionType?.name -> true
                 else -> false

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/InternalEngineException.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/InternalEngineException.kt
@@ -27,7 +27,7 @@ class InternalEngineException private constructor(
 
     fun toGraphQLError(): GraphQLError {
         return GraphQLError.newError()
-            .message(cause?.message)
+            .message(cause?.message ?: "Unknown error")
             .errorType(ErrorClassification.errorClassification("VIADUCT_INTERNAL_ENGINE_EXCEPTION"))
             .path(path)
             .location(location)

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/QueryPlanFactory.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/QueryPlanFactory.kt
@@ -149,7 +149,7 @@ interface QueryPlanFactory {
             require(gjSelectionSet.selections.isNotEmpty()) {
                 "Empty selections are not supported for completeSelectionSet execution"
             }
-            val parentType = parameters.schema.schema.getTypeAs<GraphQLCompositeType>(parsedSelections.typeName)
+            val parentType = parameters.schema.schema.getTypeAs<GraphQLCompositeType>(parsedSelections.typeName)!!
             return QueryPlanBuilder(
                 parameters.copy(query = parsedSelections.printAsFieldSet(), executionCondition = executionCondition),
                 parsedSelections.fragmentMap,
@@ -172,12 +172,12 @@ interface QueryPlanFactory {
             return when (definition) {
                 is OperationDefinition -> when (definition.operation) {
                     OperationDefinition.Operation.QUERY -> parameters.schema.schema.queryType
-                    OperationDefinition.Operation.MUTATION -> parameters.schema.schema.mutationType
-                    OperationDefinition.Operation.SUBSCRIPTION -> parameters.schema.schema.subscriptionType
+                    OperationDefinition.Operation.MUTATION -> parameters.schema.schema.mutationType!!
+                    OperationDefinition.Operation.SUBSCRIPTION -> parameters.schema.schema.subscriptionType!!
                     else -> throw IllegalStateException("Unsupported operation type: ${definition.operation}")
                 }
 
-                is GJFragmentDefinition -> parameters.schema.schema.getType(definition.typeCondition.name) as? GraphQLCompositeType
+                is GJFragmentDefinition -> parameters.schema.schema.getType(definition.typeCondition.name!!) as? GraphQLCompositeType
                     ?: throw IllegalStateException("Type ${definition.typeCondition.name} not found in schema.")
 
                 else -> throw IllegalArgumentException("Unsupported definition type: ${definition::class}")
@@ -435,7 +435,7 @@ private class QueryPlanBuilder(
     ): State =
         with(state) {
             val coord = (state.parentType.name to sel.name)
-            val fieldDef = parameters.schema.schema.getFieldDefinition(coord.gj)
+            val fieldDef = parameters.schema.schema.getFieldDefinition(coord.gj)!!
             val fieldType = GraphQLTypeUtil.unwrapAll(fieldDef.type) as GraphQLNamedOutputType
 
             val possibleParentTypes = parameters.schema.rels.possibleObjectTypes(parentType)
@@ -541,7 +541,7 @@ private class QueryPlanBuilder(
         with(state) {
             val name = sel.name
             val gjdef = checkNotNull(fragmentsByName[name]) { "Missing fragment definition: $name" }
-            val fragType = parameters.schema.schema.getTypeAs<GraphQLCompositeType>(gjdef.typeCondition.name)
+            val fragType = parameters.schema.schema.getTypeAs<GraphQLCompositeType>(gjdef.typeCondition.name!!)!!
 
             if (name !in fragments) {
                 val fragState = buildState(
@@ -639,7 +639,7 @@ private fun buildRssPlan(
         rssBuildContext
     }
     localBuildContext.building.add(rss)
-    val parentType = parameters.schema.schema.getTypeAs<GraphQLCompositeType>(rss.selections.typeName)
+    val parentType = parameters.schema.schema.getTypeAs<GraphQLCompositeType>(rss.selections.typeName)!!
     val plan = QueryPlanBuilder(parameters, rss.selections.fragmentMap, rss.variablesResolvers, localBuildContext)
         .build(rss.selections.selections, parentType, rss.attribution, rss.executionCondition)
     localBuildContext.building.remove(rss)

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ViaductDataFetcherExceptionHandler.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ViaductDataFetcherExceptionHandler.kt
@@ -78,7 +78,6 @@ class ViaductDataFetcherExceptionHandler(val errorReporter: ErrorReporter, val e
         operationName: String?,
         exception: Throwable,
     ): ErrorReporter.Metadata {
-        if (params.fieldDefinition == null) return ErrorReporter.Metadata.EMPTY
         val isFrameworkError = when (exception) {
             is FrameworkException -> true
             is TenantResolverException -> false
@@ -86,7 +85,7 @@ class ViaductDataFetcherExceptionHandler(val errorReporter: ErrorReporter, val e
             else -> null
         }
 
-        val fieldName = params.fieldDefinition?.name
+        val fieldName = params.fieldDefinition.name
         val parentType = (params.dataFetchingEnvironment.parentType as? GraphQLNamedType)?.name
 
         val env = params.dataFetchingEnvironment
@@ -118,7 +117,7 @@ class ViaductDataFetcherExceptionHandler(val errorReporter: ErrorReporter, val e
             viaductError.locations?.let { locations ->
                 builder.locations(locations.map { graphql.language.SourceLocation(it.line, it.column, it.sourceName) })
             }
-            builder.extensions(viaductError.extensions ?: emptyMap())
+            builder.extensions(viaductError.extensions)
             builder.build()
         }
 

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ViaductExecutionStrategy.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ViaductExecutionStrategy.kt
@@ -135,6 +135,7 @@ class ViaductExecutionStrategy internal constructor(
                 }
             }.getOrNull()
 
+            @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
             return ExecutionResult.newExecutionResult()
                 .data(data)
                 .errors(errors)
@@ -284,8 +285,8 @@ class ViaductExecutionStrategy internal constructor(
         val schema = executionContext.graphQLSchema
         return when (operation) {
             OperationDefinition.Operation.QUERY -> ObjectEngineResultImpl.newForType(schema.queryType)
-            OperationDefinition.Operation.MUTATION -> ObjectEngineResultImpl.newForType(schema.mutationType)
-            OperationDefinition.Operation.SUBSCRIPTION -> ObjectEngineResultImpl.newForType(schema.subscriptionType)
+            OperationDefinition.Operation.MUTATION -> ObjectEngineResultImpl.newForType(schema.mutationType!!)
+            OperationDefinition.Operation.SUBSCRIPTION -> ObjectEngineResultImpl.newForType(schema.subscriptionType!!)
             else -> throw IllegalStateException("Unsupported operation type: $operation")
         }
     }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/instrumentation/ChainedViaductModernInstrumentation.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/instrumentation/ChainedViaductModernInstrumentation.kt
@@ -133,12 +133,12 @@ class ChainedViaductModernInstrumentation private constructor(
     }
 
     override fun instrumentAccessCheck(
-        checkerDispatcher: CheckerExecutor,
+        checkerExecutor: CheckerExecutor,
         dataFetchingEnvironment: DataFetchingEnvironment,
         parameters: InstrumentationExecutionStrategyParameters,
         state: InstrumentationState?
     ): CheckerExecutor {
-        return instrumentAccessCheckInstrumentations.fold(checkerDispatcher) { dispatcher, instr ->
+        return instrumentAccessCheckInstrumentations.fold(checkerExecutor) { dispatcher, instr ->
             instr.instrumentAccessCheck(dispatcher, dataFetchingEnvironment, parameters, getState(instr, state))
         }
     }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/select/EngineSelectionSetImpl.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/select/EngineSelectionSetImpl.kt
@@ -50,8 +50,9 @@ data class FieldSelection(
 ) {
     override fun toString(): String =
         buildString {
-            if (field.alias != null) {
-                append(field.alias + ":")
+            val alias = field.alias
+            if (alias != null) {
+                append("$alias:")
             }
             append(typeCondition.name)
             append(".")
@@ -256,11 +257,12 @@ data class EngineSelectionSetImpl(
                         )
 
                     is InlineFragment -> {
+                        val typeConditionName = sel.typeCondition?.name
                         val u =
-                            if (sel.typeCondition == null) {
+                            if (typeConditionName == null) {
                                 type
                             } else {
-                                compositeType(sel.typeCondition.name)
+                                compositeType(typeConditionName)
                             }
                         acc.withTypedSelections(u, sel.selectionSet, childConstraints, spreadFragments)
                     }
@@ -271,7 +273,7 @@ data class EngineSelectionSetImpl(
                         }
 
                         val frag = getFragmentDefinition(sel.name)
-                        val u = compositeType(frag.typeCondition.name)
+                        val u = compositeType(frag.typeCondition.name!!)
                         acc.withTypedSelections(
                             u,
                             frag.selectionSet,
@@ -402,10 +404,11 @@ data class EngineSelectionSetImpl(
                 withDirectives(sel.directives).clearTypes()
 
             is InlineFragment -> {
-                val typeCondition = if (sel.typeCondition == null) {
+                val typeConditionName = sel.typeCondition?.name
+                val typeCondition = if (typeConditionName == null) {
                     def
                 } else {
-                    compositeType(sel.typeCondition.name)
+                    compositeType(typeConditionName)
                 }
                 withDirectives(sel.directives).narrowToImpls(typeCondition, ctx.schema)
             }
@@ -413,7 +416,7 @@ data class EngineSelectionSetImpl(
             is FragmentSpread -> {
                 val frag = getFragmentDefinition(sel.name)
                 withDirectives(sel.directives).narrowToImpls(
-                    compositeType(frag.typeCondition.name),
+                    compositeType(frag.typeCondition.name!!),
                     ctx.schema
                 )
             }
@@ -432,7 +435,7 @@ data class EngineSelectionSetImpl(
                 val u = cfs.first().typeCondition
                 if (u is GraphQLFieldsContainer) {
                     val coord = (u.name to fname).gj
-                    val field = ctx.schema.schema.getFieldDefinition(coord)
+                    val field = ctx.schema.schema.getFieldDefinition(coord)!!
                     if (GraphQLTypeUtil.unwrapAll(field.type) is GraphQLCompositeType) {
                         selectionSetForField(u.name, fname).isTransitivelyEmpty()
                     } else {
@@ -476,7 +479,7 @@ data class EngineSelectionSetImpl(
 
     private fun fieldDefinition(sel: FieldSelection): GraphQLFieldDefinition {
         val coord = (sel.typeCondition.name to sel.field.name).gj
-        return ctx.schema.schema.getFieldDefinition(coord)
+        return ctx.schema.schema.getFieldDefinition(coord)!!
     }
 
     private fun asEagerlyInlined(
@@ -502,7 +505,7 @@ data class EngineSelectionSetImpl(
                 if (sel.selectionSet == null) {
                     sel
                 } else {
-                    asEagerlyInlined(sel.selectionSet, child)?.let { ss ->
+                    asEagerlyInlined(sel.selectionSet!!, child)?.let { ss ->
                         sel.transform { it.selectionSet(ss) }
                     }
                 }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/select/ProjectedEngineSelectionSet.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/select/ProjectedEngineSelectionSet.kt
@@ -111,7 +111,7 @@ internal class ProjectedEngineSelectionSet(
                 val u = cfs.first().typeCondition
                 if (u is GraphQLFieldsContainer) {
                     val coord = (u.name to fname).gj
-                    val field = ctx.schema.schema.getFieldDefinition(coord)
+                    val field = ctx.schema.schema.getFieldDefinition(coord)!!
 
                     val unwrapped = GraphQLTypeUtil.unwrapAll(field.type)
                     if (unwrapped is GraphQLCompositeType) {
@@ -176,7 +176,7 @@ internal class ProjectedEngineSelectionSet(
 
     private fun fieldDef(sel: FieldSelection): GraphQLFieldDefinition {
         val coord = (sel.typeCondition.name to sel.field.name).gj
-        return ctx.schema.schema.getFieldDefinition(coord)
+        return ctx.schema.schema.getFieldDefinition(coord)!!
     }
 
     private fun FieldSelection.toEngineSelection(): EngineSelection =

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/FromFieldVariablesHaveValidPaths.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/FromFieldVariablesHaveValidPaths.kt
@@ -164,7 +164,7 @@ class FromFieldVariablesHaveValidPaths(
             .firstOrNull { it.selectionName == segment }
             ?: throw InvalidVariableException(coord, variableName, "No selection found for $segment in path $selectionPath")
 
-        val selectionType = schema.schema.getFieldDefinition(selection.coord.gj).type
+        val selectionType = schema.schema.getFieldDefinition(selection.coord.gj)!!.type
         if (isTerminal) {
             val unwrappedSelectionType = GraphQLTypeUtil.unwrapAll(selectionType)
             if (unwrappedSelectionType !is GraphQLScalarType && unwrappedSelectionType !is GraphQLEnumType) {

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/MissingResolverValidator.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/MissingResolverValidator.kt
@@ -12,7 +12,7 @@ import viaduct.engine.runtime.validation.Validator
 class MissingResolverValidator(
     private val schema: ViaductSchema,
 ) : Validator<MissingResolverValidationCtx> {
-    override fun validate(ctx: MissingResolverValidationCtx) {
+    override fun validate(t: MissingResolverValidationCtx) {
         val missingFieldResolvers = mutableListOf<String>()
         val missingNodeResolvers = mutableListOf<String>()
 
@@ -20,15 +20,15 @@ class MissingResolverValidator(
             if (type !is GraphQLObjectType || type.name.startsWith("__")) return@forEach
 
             if (type.hasAppliedDirective(RESOLVER_DIRECTIVE)) {
-                if (ctx.dispatcherRegistry.getNodeResolverDispatcher(type.name) == null) {
+                if (t.dispatcherRegistry.getNodeResolverDispatcher(type.name) == null) {
                     missingNodeResolvers.add(type.name)
                 }
             }
 
-            type.fieldDefinitions.forEach { field ->
-                if (field.name.startsWith("__")) return@forEach
+            type.fieldDefinitions.forEach fieldLoop@{ field ->
+                if (field.name.startsWith("__")) return@fieldLoop
                 if (field.hasAppliedDirective(RESOLVER_DIRECTIVE)) {
-                    if (ctx.dispatcherRegistry.getFieldResolverDispatcher(type.name, field.name) == null) {
+                    if (t.dispatcherRegistry.getFieldResolverDispatcher(type.name, field.name) == null) {
                         missingFieldResolvers.add("${type.name}.${field.name}")
                     }
                 }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/RequiredSelectionsAreAcyclic.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/RequiredSelectionsAreAcyclic.kt
@@ -134,7 +134,7 @@ class RequiredSelectionsAreAcyclic(
         val type = schema.schema.getType(typeName)
         return when (type) {
             is GraphQLObjectType -> listOf(typeName)
-            is GraphQLInterfaceType -> schema.schema.getImplementations(type).map { it.name }
+            is GraphQLInterfaceType -> schema.schema.getImplementations(type)!!.map { it.name }
             is GraphQLUnionType -> type.types.map { it.name }
             else -> throw IllegalArgumentException("Unexpected non-composite type $type")
         }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/RequiredSelectionsAreSchematicallyValid.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/RequiredSelectionsAreSchematicallyValid.kt
@@ -94,7 +94,7 @@ private fun validateNoUnusedFragments(document: Document): List<ValidationError>
                         fragment.name
                     }' is unused."
                 )
-                .sourceLocation(fragment.sourceLocation)
+                .sourceLocation(fragment.sourceLocation!!)
                 .build()
         }
     }

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/Utils.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/Utils.kt
@@ -77,8 +77,8 @@ internal fun EngineSelectionSet.relation(
     schema: ViaductSchema,
     selection: EngineSelection
 ): GraphQLTypeRelation.Relation {
-    val ssType = schema.schema.getTypeAs<GraphQLCompositeType>(type)
-    val selectionType = schema.schema.getTypeAs<GraphQLCompositeType>(selection.typeCondition)
+    val ssType = schema.schema.getTypeAs<GraphQLCompositeType>(type)!!
+    val selectionType = schema.schema.getTypeAs<GraphQLCompositeType>(selection.typeCondition)!!
     return schema.rels.relation(ssType, selectionType)
 }
 

--- a/core/engine/wiring/src/main/kotlin/viaduct/engine/IntrospectionRestrictingPreparsedDocumentProvider.kt
+++ b/core/engine/wiring/src/main/kotlin/viaduct/engine/IntrospectionRestrictingPreparsedDocumentProvider.kt
@@ -35,7 +35,7 @@ class IntrospectionRestrictingPreparsedDocumentProvider(
                         .validationErrorType(ValidationErrorType.SubselectionNotAllowed)
                         .description("$operationType operations cannot introspect the schema.")
                         .build()
-                    PreparsedDocumentEntry(baseEntry.document, baseEntry.errors + error)
+                    PreparsedDocumentEntry(baseEntry.document!!, baseEntry.errors + error)
                 }
 
                 OperationDefinition.Operation.QUERY -> {
@@ -46,7 +46,7 @@ class IntrospectionRestrictingPreparsedDocumentProvider(
                             .validationErrorType(ValidationErrorType.SubselectionNotAllowed)
                             .description("Introspective queries cannot select non-introspective fields.")
                             .build()
-                        PreparsedDocumentEntry(baseEntry.document, (baseEntry?.errors ?: emptyList<GraphQLError>()) + error)
+                        PreparsedDocumentEntry(baseEntry.document!!, (baseEntry.errors ?: emptyList<GraphQLError>()) + error)
                     }
                 }
             }

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/ViaductSchemaExtensions.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/ViaductSchemaExtensions.kt
@@ -20,7 +20,7 @@ fun ViaductSchema.scopes(): SortedSet<String> {
 
         val allScopes = type.getAppliedDirectives("scope")
             .map {
-                it.getArgument("to").getValue<List<String>>()!!
+                it.getArgument("to")!!.getValue<List<String>>()!!
             }
             .flatten()
             .filter { it != "*" }

--- a/core/service/serve/src/main/kotlin/viaduct/serve/ViaductServer.kt
+++ b/core/service/serve/src/main/kotlin/viaduct/serve/ViaductServer.kt
@@ -98,6 +98,7 @@ class ViaductServer(
             embeddedServer.start(wait = false)
 
             // Get the engine - handle both Ktor 2.x and 3.x
+            @Suppress("CAST_NEVER_SUCCEEDS")
             val engine: NettyApplicationEngine = try {
                 // Ktor 3.x: EmbeddedServer has .engine property
                 val engineProperty = embeddedServer::class.members.find { it.name == "engine" }
@@ -414,7 +415,7 @@ class ViaductServer(
 
                     val response = mapOf(
                         "data" to result.getData(),
-                        "errors" to result.errors?.map { error ->
+                        "errors" to result.errors.map { error ->
                             mapOf(
                                 "message" to error.message,
                                 "locations" to error.locations,

--- a/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/ArbIRResult.kt
+++ b/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/ArbIRResult.kt
@@ -134,7 +134,7 @@ internal class IRResultGen(
 
                 is FragmentSpread -> {
                     val fragment = requireNotNull(fragments[sel.name]) { "missing fragment `${sel.name}`" }
-                    val fragmentType = schema.schema.getTypeAs<GraphQLCompositeType>(fragment.typeCondition.name)
+                    val fragmentType = schema.schema.getTypeAs<GraphQLCompositeType>(fragment.typeCondition.name!!)!!
                     if (schema.rels.isSpreadable(concreteType, fragmentType)) {
                         val fragmentResult = genObject(concreteType, fragment.selectionSet, fragments)
                         acc.copy(fields = acc.fields + fragmentResult.fields)
@@ -206,7 +206,7 @@ internal class IRResultGen(
                     val fragment = requireNotNull(fragments[sel.name]) {
                         "missing fragment `${sel.name}`"
                     }
-                    val typeCondition = schema.schema.getTypeAs<GraphQLCompositeType>(fragment.typeCondition.name)
+                    val typeCondition = schema.schema.getTypeAs<GraphQLCompositeType>(fragment.typeCondition.name!!)
                     val newAcc = (typeCondition as? GraphQLObjectType)?.let { acc + it } ?: acc
                     val newPending = pending.drop(1) + fragment.selectionSet.selections
                     loop(newAcc, newPending)

--- a/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/DocumentBuilder.kt
+++ b/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/DocumentBuilder.kt
@@ -52,7 +52,7 @@ internal class Fragments(
         }
         fragmentsByName += (fragment.name to fragment)
 
-        val fragType = schemas.schema.getTypeAs<GraphQLCompositeType>(fragment.typeCondition.name)
+        val fragType = schemas.schema.getTypeAs<GraphQLCompositeType>(fragment.typeCondition.name)!!
         if (!fragmentsByType.contains(fragType)) fragmentsByType[fragType] = mutableListOf()
         fragmentsByType[fragType]!! += fragment
     }
@@ -103,10 +103,10 @@ internal class Variables(
         }
 
     fun add(variable: VariableDefinition) {
-        require(!variablesByName.containsKey(variable.name)) {
+        require(!variablesByName.containsKey(variable.name!!)) {
             "cannot overwrite variable with name `${variable.name}`"
         }
-        variablesByName += (variable.name to variable)
+        variablesByName += (variable.name!! to variable)
     }
 }
 
@@ -152,10 +152,10 @@ internal class FieldSelection private constructor(
             val field = Field
                 .newField()
                 .name(key.fieldName)
-                .alias(key.alias)
+                .apply { key.alias?.let { alias(it) } }
                 .arguments(
                     key.arguments.map { it.arg }.toList()
-                ).selectionSet(selections?.build())
+                ).apply { selections?.build()?.let { selectionSet(it) } }
                 .directives(directives)
                 .build()
             return FieldSelection(key, field, selections?.mergeKeyTree)
@@ -174,7 +174,7 @@ internal data class InlineFragmentSelection(
     ) : this(
         InlineFragment
             .newInlineFragment()
-            .typeCondition(sdlTypeCondition?.let(::TypeName))
+            .apply { sdlTypeCondition?.let { typeCondition(TypeName(it)) } }
             .selectionSet(SelectionsBuilder(selections).build())
             .directives(directives)
             .build(),

--- a/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/GraphQLDocuments.kt
+++ b/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/GraphQLDocuments.kt
@@ -210,7 +210,7 @@ private class GraphQLOperationGen(
 
         return OperationDefinition
             .newOperationDefinition()
-            .name(name)
+            .apply { name?.let { name(it) } }
             .operation(operationType)
             .selectionSet(selectionSetGen.gen(ctx))
             .directives(directiveGen.gen(directiveLocation, ctx))
@@ -355,7 +355,7 @@ private class GraphQLSelectionSetGen(
                 // a fragment may have been generated in the context of another operation, and used variables
                 // that are incompatible with the variables defined for this operation. Filter them out
                 frag.variables.all { fv ->
-                    when (val extant = ctx.variables[fv.name]) {
+                    when (val extant = ctx.variables[fv.name!!]) {
                         null -> true
                         else -> extant == fv
                     }
@@ -381,7 +381,7 @@ private class GraphQLSelectionSetGen(
         // if the fragment was generated for a different operation, we may need to install any new variables
         // required by the fragment into the current operation's variables
         fragment.variables.forEach { fv ->
-            if (ctx.variables[fv.name] == null) {
+            if (ctx.variables[fv.name!!] == null) {
                 ctx.variables.add(fv)
             }
         }
@@ -508,7 +508,7 @@ private class GraphQLArgumentsGen(
             } else {
                 Arb.of(possibleVariables).next(rs)
             }
-            VariableReference(variable.name)
+            VariableReference(variable.name!!)
         } else {
             GJValueConv(type).invert(genValue(type))
         }

--- a/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/GraphQLExecutionInputs.kt
+++ b/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/GraphQLExecutionInputs.kt
@@ -77,7 +77,7 @@ private class GraphQLExecutionInputGen(
                         conv.invert(it)
                     }
                     .next(rs)
-                acc + (def.name to value)
+                acc + (def.name!! to value)
             }
         }
 

--- a/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/util.kt
+++ b/core/shared/arbitrary/src/main/kotlin/viaduct/arbitrary/graphql/util.kt
@@ -281,7 +281,7 @@ fun Type<*>.asSchemaType(schema: GraphQLSchema): GraphQLType =
     when (this) {
         is ListType -> GraphQLList.list(type.asSchemaType(schema))
         is NonNullType -> GraphQLNonNull.nonNull(type.asSchemaType(schema))
-        is TypeName -> schema.getTypeAs(this.name)
+        is TypeName -> schema.getTypeAs<GraphQLType>(this.name!!)!!
         else ->
             throw UnsupportedOperationException("unsupported language Type: $this")
     }

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/Ids.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/Ids.kt
@@ -24,7 +24,7 @@ fun isGlobalID(field: GraphQLInputObjectField): Boolean = field.hasIdOfDirective
  */
 private fun globalIDType(dir: GraphQLAppliedDirective): String {
     require(dir.name == idOf)
-    return dir.getArgument("type").getValue()
+    return dir.getArgument("type")!!.getValue()
 }
 
 /**

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/Scalars.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/Scalars.kt
@@ -33,7 +33,7 @@ object Scalars {
         GraphQLScalarType
             .newScalar()
             .name(ExtendedScalars.DateTime.name)
-            .description(ExtendedScalars.DateTime.description)
+            .description(ExtendedScalars.DateTime.description!!)
             .coercing(
                 object : Coercing<Any, Any> {
                     override fun serialize(

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/scopes/ScopedSchemaBuilder.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/scopes/ScopedSchemaBuilder.kt
@@ -67,9 +67,9 @@ class ScopedSchemaBuilder(
 
     private fun replaceAllTypesWithReferences(inputSchema: GraphQLSchema): GraphQLSchema =
         inputSchema.transform {
-            it.query(replaceChildrenWithTypeReferences(inputSchema.queryType) as GraphQLObjectType?)
-            it.mutation(replaceChildrenWithTypeReferences(inputSchema.mutationType) as GraphQLObjectType?)
-            it.subscription(replaceChildrenWithTypeReferences(inputSchema.subscriptionType) as GraphQLObjectType?)
+            it.query(replaceChildrenWithTypeReferences(inputSchema.queryType) as GraphQLObjectType)
+            inputSchema.mutationType?.let { mt -> it.mutation(replaceChildrenWithTypeReferences(mt) as GraphQLObjectType) }
+            inputSchema.subscriptionType?.let { st -> it.subscription(replaceChildrenWithTypeReferences(st) as GraphQLObjectType) }
             val additionalTypes =
                 inputSchema.allTypesAsList
                     .filter {

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/scopes/utils/ScopeDirectiveParser.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/scopes/utils/ScopeDirectiveParser.kt
@@ -251,7 +251,7 @@ internal class ScopeDirectiveParser(
         val scopesArrayValue =
             scopesDirectives
                 .first()
-                .getArgument(SCOPED_TO_ARG)
+                .getArgument(SCOPED_TO_ARG)!!
                 .value as? ArrayValue
                 ?: throw SchemaScopeValidationError(
                     "@$directiveName's '$SCOPED_TO_ARG' argument must be passed an array of strings.",

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/scopes/visitors/TransformationsVisitor.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/scopes/visitors/TransformationsVisitor.kt
@@ -159,7 +159,7 @@ internal class TransformationsVisitor(
                         )
 
                         val values = newChildren.map { it.definition }
-                        val newEnumTypeDefinition = element.definition?.transform {
+                        val newEnumTypeDefinition = element.definition.transform {
                             it.enumValueDefinitions(values)
                         }
                         it.definition(newEnumTypeDefinition)
@@ -175,7 +175,7 @@ internal class TransformationsVisitor(
                         it.replacePossibleTypes(newPossibleTypes as List<GraphQLObjectType>)
 
                         val members = newPossibleTypes.map { TypeName.newTypeName(it.name).build() }
-                        val newUnionTypeDefinition = element.definition?.transform {
+                        val newUnionTypeDefinition = element.definition.transform {
                             it.memberTypes(members)
                         }
                         it.definition(newUnionTypeDefinition)

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/ParsedSelections.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/ParsedSelections.kt
@@ -145,7 +145,7 @@ private class PathFilter(val parsedSelections: ParsedSelections) {
                     ?.let { field ->
                         // traverse into subselections
                         if (field.selectionSet != null) {
-                            filterToPath(field.selectionSet, path.drop(1))
+                            filterToPath(field.selectionSet!!, path.drop(1))
                                 ?.let { filteredSelectionSet ->
                                     field.transform {
                                         it.selectionSet(filteredSelectionSet)

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/SelectionSetExtensions.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/SelectionSetExtensions.kt
@@ -18,7 +18,7 @@ fun SelectionSet.addTypeName(): SelectionSet {
 
                 is Field -> {
                     if (sel.selectionSet?.selections?.isNotEmpty() == true) {
-                        val subselections = sel.selectionSet
+                        val subselections = sel.selectionSet!!
                         sel.transform {
                             val selSet = subselections.addTypeName()
                             it.selectionSet(selSet)

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/VariableUsageInfoVisitor.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/VariableUsageInfoVisitor.kt
@@ -59,7 +59,7 @@ internal class VariableUsageInfoVisitor(
                 )
                 is GraphQLInputObjectField -> {
                     // For nested input object fields, get the parent's type
-                    val parent = env.argumentInputValue.parent
+                    val parent = env.argumentInputValue.parent!!
                     val inputType = GraphQLTypeUtil.unwrapAll(parent.inputType) as GraphQLInputObjectType
                     VariableUsageInfo(
                         unwrapLists(inputValueDefinition.type, env.traverserContext),

--- a/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/ViaductQueryTraverser.kt
+++ b/core/shared/graphql/src/main/kotlin/viaduct/graphql/utils/ViaductQueryTraverser.kt
@@ -134,10 +134,11 @@ class ViaductQueryTraverser private constructor(
             schema: GraphQLSchema,
             operationDefinition: OperationDefinition
         ): GraphQLObjectType =
-            when (operationDefinition.operation!!) {
+            when (val op = operationDefinition.operation) {
                 OperationDefinition.Operation.MUTATION -> checkNotNull(schema.mutationType)
                 OperationDefinition.Operation.QUERY -> checkNotNull(schema.queryType)
                 OperationDefinition.Operation.SUBSCRIPTION -> checkNotNull(schema.subscriptionType)
+                else -> throw IllegalStateException("Unknown operation: $op")
             }
 
         fun newQueryTraverser(): Builder = Builder()
@@ -173,17 +174,19 @@ class ViaductQueryTraverser private constructor(
      * @return the calculated overall value T
      * */
 
+    @Suppress("UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS", "UNCHECKED_CAST")
     fun <T> reducePostOrder(
         queryReducer: QueryReducer<T?>,
         initialValue: T?
     ): T? {
-        var acc: T? = initialValue
+        val reducer = queryReducer as QueryReducer<Any?>
+        var acc: Any? = initialValue
         visitPostOrder(object : QueryVisitorStub() {
-            override fun visitField(env: QueryVisitorFieldEnvironment?) {
-                acc = queryReducer.reduceField(env, acc)
+            override fun visitField(env: QueryVisitorFieldEnvironment) {
+                acc = reducer.reduceField(env, acc as Any)
             }
         })
-        return acc
+        return acc as T?
     }
 
     /**
@@ -195,24 +198,26 @@ class ViaductQueryTraverser private constructor(
      *
      * @return the calculated overall value
      </T> */
+    @Suppress("UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS", "UNCHECKED_CAST")
     fun <T> reducePreOrder(
         queryReducer: QueryReducer<T?>,
         initialValue: T?
     ): T? {
-        var acc: T? = initialValue
+        val reducer = queryReducer as QueryReducer<Any?>
+        var acc: Any? = initialValue
         visitPreOrder(object : QueryVisitorStub() {
-            override fun visitField(env: QueryVisitorFieldEnvironment?) {
-                acc = queryReducer.reduceField(env, acc)
+            override fun visitField(env: QueryVisitorFieldEnvironment) {
+                acc = reducer.reduceField(env, acc as Any)
             }
         })
-        return acc
+        return acc as T?
     }
 
-    private fun childrenOf(node: Node<*>): MutableList<Node<*>?>? {
+    private fun childrenOf(node: Node<*>): List<Node<*>?> {
         if (node !is FragmentSpread) {
             return node.children
         }
-        return mutableListOf<Node<*>?>(fragmentsByName[node.name])
+        return listOf(fragmentsByName[node.name])
     }
 
     private fun visitImpl(

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/GJSchema.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/GJSchema.kt
@@ -112,8 +112,8 @@ internal fun gjSchemaFromSchema(schema: GraphQLSchema): SchemaWithData {
     }
 
     // Determine root types and populate schema
-    val queryTypeDef = rootDef(types, schema.queryType?.name, "Query")
-        ?: throw IllegalStateException("Query name (${schema.queryType?.name}) not found.")
+    val queryTypeDef = rootDef(types, schema.queryType.name, "Query")
+        ?: throw IllegalStateException("Query name (${schema.queryType.name}) not found.")
     val mutationTypeDef = rootDef(types, schema.mutationType?.name, "Mutation")
     val subscriptionTypeDef = rootDef(types, schema.subscriptionType?.name, "Subscription")
 

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/GJSchemaRaw.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/GJSchemaRaw.kt
@@ -120,7 +120,7 @@ internal fun gjSchemaRawFromRegistry(
         for (def in unionDefs) {
             def.memberTypes.forEach {
                 unionsMap
-                    .getOrPut((it as TypeName).name) {
+                    .getOrPut((it as TypeName).name!!) {
                         mutableSetOf()
                     }.add(def.name)
             }
@@ -135,7 +135,7 @@ internal fun gjSchemaRawFromRegistry(
         for (def in implTypeDefs) {
             def.implements.forEach {
                 membersMap
-                    .getOrPut((it as TypeName).name) {
+                    .getOrPut((it as TypeName).name!!) {
                         mutableSetOf()
                     }.add(def)
             }
@@ -325,5 +325,5 @@ internal fun <T : ViaductSchema.TypeDef> Type<*>.toTypeExpr(createTypeExpr: (Str
             throw IllegalStateException("Unexpected GraphQL wrapper $this.")
         }
     }
-    return createTypeExpr(t.name, (currentNullableBit == 1L), listNullable.build())
+    return createTypeExpr(t.name!!, (currentNullableBit == 1L), listNullable.build())
 }

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/GraphQLSchemaDecoder.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/GraphQLSchemaDecoder.kt
@@ -180,7 +180,7 @@ internal class GraphQLSchemaDecoder(
         // base and extensions into the scalar's appliedDirectives. So we create extensions
         // from the language-level definitions if available, falling back to merged directives.
         val langDefs = listOf(gjDef.definition) + gjDef.extensionDefinitions
-        return if (langDefs.all { it == null } || (gjDef.extensionDefinitions.isEmpty() && gjDef.definition == null)) {
+        return if (langDefs.all { it == null }) {
             // No language definitions available - create single extension with merged directives
             listOf(
                 ViaductSchema.Extension.of(
@@ -195,7 +195,7 @@ internal class GraphQLSchemaDecoder(
             // Have language definitions - but graphql-java loses extension definitions for scalars
             // So we only have the base definition. Use its directives from the language AST,
             // but get extension directives from the merged appliedDirectives.
-            val baseDirectives = gjDef.definition?.let { decodeAppliedDirectivesFromLang(it.directives) } ?: emptyList()
+            val baseDirectives = decodeAppliedDirectivesFromLang(gjDef.definition.directives)
             val allDirectives = decodeAppliedDirectives(gjDef)
             // Extension directives are all directives that aren't in the base
             val baseDirectiveSet = baseDirectives.map { it.name to it.arguments }.toSet()
@@ -370,7 +370,7 @@ internal class GraphQLSchemaDecoder(
                 supers = if (gjLangTypeDef == null) {
                     gjDef.interfaces.map { types[it.name] as SchemaWithData.Interface }
                 } else {
-                    gjLangTypeDef.implements.map { types[(it as TypeName).name] as SchemaWithData.Interface }
+                    gjLangTypeDef.implements.map { types[(it as TypeName).name!!] as SchemaWithData.Interface }
                 },
                 sourceLocation = decodeSourceLocation(gjLangTypeDef)
             )
@@ -420,7 +420,7 @@ internal class GraphQLSchemaDecoder(
                 supers = if (gjLangTypeDef == null) {
                     gjDef.interfaces.map { types[it.name] as SchemaWithData.Interface }
                 } else {
-                    gjLangTypeDef.implements.map { types[(it as TypeName).name] as SchemaWithData.Interface }
+                    gjLangTypeDef.implements.map { types[(it as TypeName).name!!] as SchemaWithData.Interface }
                 },
                 sourceLocation = decodeSourceLocation(gjLangTypeDef)
             )
@@ -440,7 +440,7 @@ internal class GraphQLSchemaDecoder(
                     } else {
                         gjLangTypeDef.memberTypes
                             .filter { (it as TypeName).name != ViaductSchema.VIADUCT_IGNORE_SYMBOL }
-                            .map { types[(it as TypeName).name] as SchemaWithData.Object }
+                            .map { types[(it as TypeName).name!!] as SchemaWithData.Object }
                     }
                 },
                 isBase = gjLangTypeDef == gjDef.definition,

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/TypeDefinitionRegistryDecoder.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/TypeDefinitionRegistryDecoder.kt
@@ -47,7 +47,7 @@ internal class TypeDefinitionRegistryDecoder(
 
     fun decodeDefaultValue(ivd: InputValueDefinition): ViaductSchema.Literal? =
         if (ivd.defaultValue != null) {
-            ValueConverter.convert(decodeTypeExpr(ivd.type), ivd.defaultValue)
+            ValueConverter.convert(decodeTypeExpr(ivd.type), ivd.defaultValue!!)
         } else {
             null
         }
@@ -134,7 +134,7 @@ internal class TypeDefinitionRegistryDecoder(
                 },
                 isBase = gjLangTypeDef == interfaceDef.gjrDef,
                 appliedDirectives = decodeAppliedDirectives(gjLangTypeDef.directives),
-                supers = gjLangTypeDef.implements.map { types[(it as TypeName).name] as SchemaWithData.Interface },
+                supers = gjLangTypeDef.implements.map { types[(it as TypeName).name!!] as SchemaWithData.Interface },
                 sourceLocation = decodeSourceLocation(gjLangTypeDef)
             )
         }
@@ -159,7 +159,7 @@ internal class TypeDefinitionRegistryDecoder(
                 },
                 isBase = gjLangTypeDef == objectDef.gjrDef,
                 appliedDirectives = decodeAppliedDirectives(gjLangTypeDef.directives),
-                supers = gjLangTypeDef.implements.map { types[(it as TypeName).name] as SchemaWithData.Interface },
+                supers = gjLangTypeDef.implements.map { types[(it as TypeName).name!!] as SchemaWithData.Interface },
                 sourceLocation = decodeSourceLocation(gjLangTypeDef)
             )
         }
@@ -174,7 +174,7 @@ internal class TypeDefinitionRegistryDecoder(
                 memberFactory = { _ ->
                     gjLangTypeDef.memberTypes
                         .filter { (it as TypeName).name != ViaductSchema.VIADUCT_IGNORE_SYMBOL }
-                        .map { types[(it as TypeName).name] as SchemaWithData.Object }
+                        .map { types[(it as TypeName).name!!] as SchemaWithData.Object }
                 },
                 isBase = gjLangTypeDef == unionDef.gjrDef,
                 appliedDirectives = decodeAppliedDirectives(gjLangTypeDef.directives),
@@ -195,7 +195,7 @@ internal class TypeDefinitionRegistryDecoder(
         val args = def.inputValueDefinitions.map {
             val hasDefault = it.defaultValue != null
             val default = if (hasDefault) {
-                ValueConverter.convert(decodeTypeExpr(it.type), it.defaultValue)
+                ValueConverter.convert(decodeTypeExpr(it.type), it.defaultValue!!)
             } else {
                 null
             }
@@ -229,7 +229,7 @@ internal class TypeDefinitionRegistryDecoder(
         fieldDef.inputValueDefinitions.map { ivd ->
             val hasDefault = ivd.defaultValue != null
             val default = if (hasDefault) {
-                ValueConverter.convert(decodeTypeExpr(ivd.type), ivd.defaultValue)
+                ValueConverter.convert(decodeTypeExpr(ivd.type), ivd.defaultValue!!)
             } else {
                 null
             }

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/ValueConverter.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/ValueConverter.kt
@@ -29,7 +29,7 @@ fun Value<*>.toViaductValue(): ViaductSchema.Literal =
     when (this) {
         is NullValue -> ViaductSchema.NULL
         is BooleanValue -> if (isValue) ViaductSchema.TRUE else ViaductSchema.FALSE
-        is StringValue -> ViaductSchema.StringLiteral.of(value)
+        is StringValue -> ViaductSchema.StringLiteral.of(value!!)
         is IntValue -> ViaductSchema.IntLiteral.of(value.toString())
         is FloatValue -> ViaductSchema.FloatLiteral.of(value.toString())
         is EnumValue -> ViaductSchema.EnumLit.of(name)

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/extensions/ToRegistry.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/graphqljava/extensions/ToRegistry.kt
@@ -186,7 +186,7 @@ fun ViaductSchema.Object.toObjectTypeDefinition(options: TypeDefinitionRegistryO
             extensions.first().members.map { it.toFieldDefinition() } +
                 if (options.addStubsOnEmptyTypes) getViaductIgnoreSymbolAsFieldDefinitionList() else emptyList()
         ).directives(extensions.first().appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .implementz(extensions.first().supers.map { TypeName(it.name) })
         .build()
 
@@ -200,7 +200,7 @@ fun ViaductSchema.Object.toObjectTypeDefinitionExtensions() =
             .name(extension.def.name)
             .fieldDefinitions(extension.members.map { it.toFieldDefinition() })
             .directives(extension.appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-            .sourceLocation(extension.sourceLocation?.toSourceLocationDefinition())
+            .apply { extension.sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
             .implementz(extension.supers.map { TypeName(it.name) })
             .build()
     }
@@ -221,7 +221,7 @@ fun ViaductSchema.Input.toMergedInputTypeDefinition(): InputObjectTypeDefinition
         .name(allFields.first().containingDef.name)
         .inputValueDefinitions(allFields.map { it.inputValueDefinition() })
         .directives(extensions.map { it.appliedDirectives }.flatten().map { it.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .build()
 }
 
@@ -231,7 +231,7 @@ fun ViaductSchema.Input.toInputObjectTypeDefinition() =
         .name(extensions.first().def.name)
         .inputValueDefinitions(extensions.first().members.map { it.inputValueDefinition() })
         .directives(extensions.first().appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .build()
 
 fun ViaductSchema.Input.toInputObjectTypeDefinitionExtensions() =
@@ -241,7 +241,7 @@ fun ViaductSchema.Input.toInputObjectTypeDefinitionExtensions() =
             .name(extension.def.name)
             .inputValueDefinitions(extension.members.map { it.inputValueDefinition() })
             .directives(extension.appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-            .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+            .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
             .build()
     }
 
@@ -261,7 +261,7 @@ fun ViaductSchema.Interface.toMergedInterfaceTypeDefinition(options: TypeDefinit
         .name(extensions.first().def.name)
         .definitions(allFieldDefs)
         .directives(extensions.map { it.appliedDirectives }.flatten().map { it.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .implementz(extensions.flatMap { it.supers.map { sel -> TypeName(sel.name) } })
         .build()
 }
@@ -274,7 +274,7 @@ fun ViaductSchema.Interface.toInterfaceTypeDefinition(options: TypeDefinitionReg
             extensions.first().members.map { it.toFieldDefinition() } +
                 if (options.addStubsOnEmptyTypes) getViaductIgnoreSymbolAsFieldDefinitionList() else emptyList()
         ).directives(extensions.first().appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .implementz(extensions.first().supers.map { TypeName(it.name) })
         .build()
 
@@ -287,7 +287,7 @@ fun ViaductSchema.Interface.toInterfaceTypeDefinitionExtensions() =
             .newInterfaceTypeExtensionDefinition()
             .name(extension.def.name)
             .definitions(extension.members.map { it.toFieldDefinition() })
-            .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+            .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
             .directives(extension.appliedDirectives.map { it.toDirectiveForTypeDefinition() })
             .implementz(extension.supers.map { TypeName(it.name) })
             .build()
@@ -298,7 +298,7 @@ fun ViaductSchema.HasDefaultValue.inputValueDefinition() =
         .newInputValueDefinition()
         .name(name)
         .type(type.toTypeForTypeDefinition())
-        .defaultValue(if (hasDefault) effectiveDefaultValue.toGraphQLJavaValue() else null)
+        .apply { if (hasDefault) defaultValue(effectiveDefaultValue.toGraphQLJavaValue()) }
         .directives(appliedDirectives.map { it.toDirectiveForTypeDefinition() })
         .build()
 
@@ -339,7 +339,7 @@ fun ViaductSchema.Union.toMergedUnionTypeDefinition(options: TypeDefinitionRegis
         .newUnionTypeDefinition()
         .name(extensions.first().def.name)
         .memberTypes(allMemberDefs)
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .directives(extensions.map { it.appliedDirectives }.flatten().map { it.toDirectiveForTypeDefinition() })
         .build()
 }
@@ -352,7 +352,7 @@ fun ViaductSchema.Union.unionTypeDefinition(options: TypeDefinitionRegistryOptio
             extensions.first().members.map { TypeName(it.name) } +
                 if (options.addStubsOnEmptyTypes) listOf(TypeName(ViaductSchema.VIADUCT_IGNORE_SYMBOL)) else emptyList()
         ).directives(extensions.first().appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .build()
 
 fun ViaductSchema.Union.unionTypeDefinitionExtensions() =
@@ -366,7 +366,7 @@ fun ViaductSchema.Union.unionTypeDefinitionExtensions() =
             .newUnionTypeExtensionDefinition()
             .name(name)
             .memberTypes(memberTypes)
-            .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+            .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
             .directives(directives)
             .build()
     }
@@ -385,7 +385,7 @@ fun ViaductSchema.Enum.toMergedEnumTypeDefinition(): EnumTypeDefinition {
                     .build()
             }
         ).directives(extensions.map { it.appliedDirectives }.flatten().map { d -> d.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .build()
 }
 
@@ -402,7 +402,7 @@ fun ViaductSchema.Enum.enumTypeDefinition() =
                     .build()
             }
         ).directives(extensions.first().appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-        .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+        .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
         .build()
 
 fun ViaductSchema.Enum.enumTypeDefinitionExtensions() =
@@ -419,7 +419,7 @@ fun ViaductSchema.Enum.enumTypeDefinitionExtensions() =
                         .build()
                 }
             ).directives(extension.appliedDirectives.map { it.toDirectiveForTypeDefinition() })
-            .sourceLocation(sourceLocation?.toSourceLocationDefinition())
+            .apply { sourceLocation?.let { sourceLocation(it.toSourceLocationDefinition()) } }
             .build()
     }
 

--- a/core/tenant/api/api/api.api
+++ b/core/tenant/api/api/api.api
@@ -1,6 +1,6 @@
 public final class viaduct/api/FetchUtilsKt {
-	public static final fun fetchOrDefault (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun fetchOrNull (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun fetchOrDefault (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun fetchOrNull (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class viaduct/api/FieldValue {

--- a/core/tenant/api/src/main/kotlin/viaduct/api/FetchUtils.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/FetchUtils.kt
@@ -20,7 +20,7 @@ import viaduct.apiannotations.StableApi
  * ```
  */
 @StableApi
-suspend inline fun <T> fetchOrNull(block: suspend () -> T): T? = fetchOrDefault<T?>(null) { block() }
+suspend inline fun <T> fetchOrNull(block: () -> T): T? = fetchOrDefault<T?>(null) { block() }
 
 /**
  * Executes the given [block] and returns its result, or [default] if an exception is thrown.
@@ -41,7 +41,7 @@ suspend inline fun <T> fetchOrNull(block: suspend () -> T): T? = fetchOrDefault<
 @StableApi
 suspend inline fun <T> fetchOrDefault(
     default: T,
-    block: suspend () -> T
+    block: () -> T
 ): T =
     try {
         block()

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/ConvUtils.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/ConvUtils.kt
@@ -67,7 +67,7 @@ internal fun <From, To> createSelectionConvs(
     if (selectionSet != null) {
         selectionSet.selections().associate { sel ->
             val coord = (sel.typeCondition to sel.fieldName).gj
-            val fieldDef = schema.schema.getFieldDefinition(coord)
+            val fieldDef = schema.schema.getFieldDefinition(coord)!!
             val subSelections = if (fieldDef.type.supportsSelections) {
                 selectionSet.selectionSetForSelection(sel.typeCondition, sel.selectionName)
             } else {

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/DefaultGRTConvFactory.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/DefaultGRTConvFactory.kt
@@ -328,7 +328,7 @@ object DefaultGRTConvFactory : GRTConvFactory {
                                 .selections()
                                 .associate { sel ->
                                     val coord = (sel.typeCondition to sel.fieldName).gj
-                                    val fieldDef = internalContext.schema.schema.getFieldDefinition(coord)
+                                    val fieldDef = internalContext.schema.schema.getFieldDefinition(coord)!!
 
                                     val subselections = ctx.selectionSet
                                         .takeIf { fieldDef.type.supportsSelections }

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/EODBuilderWrapper.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/EODBuilderWrapper.kt
@@ -127,6 +127,7 @@ internal class EODBuilderWrapper(
         // engineObject is null when an ObjectBase subclass is mocked in tests (Mockito/Objenesis
         // bypasses the constructor, leaving the field at its JVM default of null despite the
         // non-null Kotlin declaration). Skip type validation in that case.
+        @Suppress("SENSELESS_COMPARISON")
         if (engineObject != null) {
             val actualTypeName = engineObject.type.name
             val valid = when (expectedType) {

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/InputTypeFactory.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/InputTypeFactory.kt
@@ -55,7 +55,7 @@ object InputTypeFactory {
                 .type(it.type)
                 .replaceAppliedDirectives(
                     it.appliedDirectives.filter {
-                        val def = schema.schema.getDirective(it.name)
+                        val def = schema.schema.getDirective(it.name)!!
                         Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION in def.validLocations()
                     }
                 )

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/ObjectBase.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/ObjectBase.kt
@@ -119,7 +119,7 @@ abstract class ObjectBase(
                 "Field $fieldName not found on type ${objectType.name}"
             )
             handleFrameworkErrorsSuspend("${objectType.name}.$selection") {
-                val fieldValue = when (engineObject) {
+                val fieldValue: Any? = when (engineObject) {
                     is NodeReference -> {
                         // If the EOD is a node reference, only allow access to its ID field
                         if (selection == "id") {
@@ -138,6 +138,7 @@ abstract class ObjectBase(
                 wrap(fieldDefinition.type, fieldValue, baseFieldTypeClass)
             } ?: NULL_VALUE
         }
+        @Suppress("UNCHECKED_CAST")
         return (if (result == NULL_VALUE) null else result) as T
     }
 

--- a/core/tenant/api/src/main/kotlin/viaduct/api/internal/ViaductObjectBuilder.kt
+++ b/core/tenant/api/src/main/kotlin/viaduct/api/internal/ViaductObjectBuilder.kt
@@ -84,7 +84,7 @@ class ViaductObjectBuilder<T : GRT> private constructor(
             ctx: InternalContext,
             grtClazz: KClass<T>
         ): ViaductObjectBuilder<T> {
-            val graphqlType = ctx.schema.schema.getObjectType(grtClazz.simpleName)
+            val graphqlType = ctx.schema.schema.getObjectType(grtClazz.simpleName!!)!!
             return ViaductObjectBuilder(ctx, graphqlType, grtClazz)
         }
     }

--- a/core/tenant/ksp/src/main/kotlin/viaduct/ksp/validation/ResolverSelectionSetProcessor.kt
+++ b/core/tenant/ksp/src/main/kotlin/viaduct/ksp/validation/ResolverSelectionSetProcessor.kt
@@ -35,8 +35,8 @@ class ResolverSelectionSetProcessor(
     private val logger: KSPLogger = environment.logger
     private val fragmentsOutputFile: String? = environment.options[FRAGMENTS_OUTPUT_OPTION]
 
-    private fun getCompilationSchemaSDL(kspResolver: Resolver): String {
-        val compilationSchemaFile = kspResolver.findCompilationSchemaFile()
+    private fun getCompilationSchemaSDL(resolver: Resolver): String {
+        val compilationSchemaFile = resolver.findCompilationSchemaFile()
             ?: throw RuntimeException("Unable to read compilation schema SDL to validate resolver required selection set.")
 
         return compilationSchemaFile.unwrapSchemaFromFile()
@@ -55,10 +55,10 @@ class ResolverSelectionSetProcessor(
     // Track if we've already generated the file in this compilation session
     private var hasGeneratedFragments = false
 
-    override fun process(kspResolver: Resolver): List<KSAnnotated> {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
         val schema = UnExecutableSchemaGenerator.makeUnExecutableSchema(
             SchemaParser().parse(
-                getCompilationSchemaSDL(kspResolver)
+                getCompilationSchemaSDL(resolver)
             )
         )
 
@@ -66,7 +66,7 @@ class ResolverSelectionSetProcessor(
         val annotationSpecs = mutableListOf<ResolverAnnotationSpec>()
         val resolverFiles = mutableSetOf<KSFile>()
 
-        kspResolver.getAllFiles().forEach { file ->
+        resolver.getAllFiles().forEach { file ->
             resolverFiles.add(file)
             file.declarations.forEach { declaration ->
                 if (declaration is KSClassDeclaration) {

--- a/core/tenant/ksp/src/main/kotlin/viaduct/ksp/validation/ValidateResolverFragments.kt
+++ b/core/tenant/ksp/src/main/kotlin/viaduct/ksp/validation/ValidateResolverFragments.kt
@@ -67,7 +67,7 @@ internal class ValidateResolverFragments(
         val document = Parser().parseDocument(fragmentString)
         val fragments = document.definitions.filterIsInstance<FragmentDefinition>()
         val entryPoint = SelectionsParserUtils.findEntryPointFragment(fragments)
-        return entryPoint.typeCondition.name
+        return entryPoint.typeCondition.name!!
     }
 
     private fun validateAgainstSchema(spec: ResolverFragmentSpec): List<ErrorMessage> {

--- a/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/context/EngineExecutionContextWrapper.kt
+++ b/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/context/EngineExecutionContextWrapper.kt
@@ -94,7 +94,7 @@ class EngineExecutionContextWrapperImpl(
     ): T =
         handleFrameworkErrors("nodeRef(${globalID.type.name})") {
             val typeName = globalID.type.name
-            val graphqlObjectType = ctx.schema.schema.getObjectType(typeName)
+            val graphqlObjectType = ctx.schema.schema.getObjectType(typeName)!!
             val id = ctx.globalIDCodec.serialize(globalID.type.name, globalID.internalID)
             val nodeReference = engineExecutionContext.createNodeReference(id, graphqlObjectType)
 

--- a/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/context/MutationFieldExecutionContextImpl.kt
+++ b/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/context/MutationFieldExecutionContextImpl.kt
@@ -52,7 +52,7 @@ class MutationFieldExecutionContextImpl<Q : Query, M : Mutation>(
         selections: String,
         variables: Map<String, Any?>
     ): M {
-        val mutationType = reflectionLoader.reflectionFor(schema.schema.mutationType.name) as Type<M>
+        val mutationType = reflectionLoader.reflectionFor(schema.schema.mutationType!!.name) as Type<M>
         return mutation(selectionsFor(mutationType, selections, variables))
     }
 

--- a/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/context/factory/ResolverExecutionContextFactory.kt
+++ b/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/context/factory/ResolverExecutionContextFactory.kt
@@ -143,7 +143,7 @@ class FieldExecutionContextFactory internal constructor(
         expectedContextInterface,
         resultType
     ) {
-    @Suppress("UNCHECKED_CAST")
+    @Suppress("UNCHECKED_CAST", "UNUSED_PARAMETER")
     operator fun invoke(
         engineExecutionContext: EngineExecutionContext,
         engineSelections: EngineSelectionSet?,

--- a/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/internal/NodeReferenceGRTFactoryImpl.kt
+++ b/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/internal/NodeReferenceGRTFactoryImpl.kt
@@ -26,7 +26,7 @@ class NodeReferenceGRTFactoryImpl(
         id: GlobalID<T>,
         internalContext: InternalContext
     ): T {
-        val type = internalContext.schema.schema.getObjectType(id.type.name)
+        val type = internalContext.schema.schema.getObjectType(id.type.name)!!
         val nodeReference = nodeReferenceFactory(
             internalContext.globalIDCodec.serialize(id.type.name, id.internalID),
             type,

--- a/core/tenant/validation/build.gradle.kts
+++ b/core/tenant/validation/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     id("conventions.viaduct-publishing")
 }
 
+dependencies {
+    implementation(libs.viaduct.shared.apiannotations)
+}
+
 viaductPublishing {
     name.set("Tenant Validation")
     description.set("Validation interfaces shared across Viaduct tenant annotation processors")


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Eliminates ~100 Kotlin compiler warnings across all main source sets. These stem from graphql-java 26's platform types being interpreted as nullable by the Kotlin compiler, triggering type-mismatch and unsafe-receiver warnings. No behavioral changes — the values are guaranteed non-null at runtime by graphql-java's API contracts.

**Key Changes**

- `core/shared/graphql/` — added non-null assertions for graphql-java platform types (directive args, field definitions, selection sets); suppressed type-bound violations in `ViaductQueryTraverser.reducePostOrder/reducePreOrder` caused by Kotlin/Java generic interop
- `core/shared/viaductschema/` — removed unnecessary safe calls on non-null `definition` properties; added `!!` for `TypeName.name` and `Value` platform types; refactored `ToRegistry.kt` to use `.apply {}` pattern for nullable `sourceLocation`
- `core/engine/api/` — fixed `ChainedInstrumentation` type bound (`<T : Any?>` → `<T : Any>`); changed `beginParse` return type from `InstrumentationContext<Document?>` to `InstrumentationContext<Document>`
- `core/engine/runtime/` — added non-null assertions for `objectType`, `fieldDefinition`, `typeCondition.name` across execution, selection set, and tenant-loading code; removed dead null checks and unnecessary elvis operators; added explicit label on nested `forEach` in `MissingResolverValidator`
- `core/engine/wiring/` — added `!!` to `document` in `IntrospectionRestrictingPreparsedDocumentProvider`
- `core/tenant/api/` — removed redundant `suspend` modifiers in `FetchUtils.kt`; added `!!` for graphql-java field/directive lookups; updated `api.api` dump to reflect binary signature change
- `core/tenant/runtime/` — added `!!` for `objectType` and `mutationType` lookups; suppressed unused parameter warning
- `core/tenant/ksp/` — renamed parameter to match supertype; added `!!` to type condition name
- `core/tenant/validation/build.gradle.kts` — added `apiannotations` dependency to resolve unresolved opt-in markers
- `core/shared/arbitrary/` — added `!!` for `name`, `typeCondition.name`, and `getTypeAs()` calls; refactored nullable builder args to `.apply {}` pattern
- `core/service/` — added `!!` for directive argument lookup; suppressed impossible-cast warnings in Ktor compatibility code; removed unnecessary safe call

## How was it tested?  What documentation was provided?

- `./gradlew clean --quiet && ./gradlew :core:shared:graphql:compileKotlin :core:shared:viaductschema:compileKotlin :core:engine:api:compileKotlin :core:engine:runtime:compileKotlin :core:engine:wiring:compileKotlin :core:tenant:api:compileKotlin :core:tenant:runtime:compileKotlin :core:tenant:ksp:compileKotlin :core:tenant:codegen:compileKotlin :core:tenant:wiring:compileKotlin :core:tenant:validation:compileKotlin :core:shared:arbitrary:compileKotlin :core:shared:errors:compileKotlin :core:service:runtime:compileKotlin :core:service:serve:compileKotlin` — **0 non-deprecation warnings**
- `./gradlew :core:tenant:api:apiCheck` — passes (API dump updated for `FetchUtils` signature change)
- All changes are non-null assertions on graphql-java platform types guaranteed non-null by API contract or removal of unnecessary null-safety operators. No behavioral change at runtime.