### PR TITLE
chore(engine): suppress deprecated API warnings and fix Jackson usage

### DIFF
--- a/core/engine/api/src/main/kotlin/viaduct/engine/api/spi/TenantAPIBootstrapper.kt
+++ b/core/engine/api/src/main/kotlin/viaduct/engine/api/spi/TenantAPIBootstrapper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+
 package viaduct.engine.api.spi
 
 import viaduct.service.api.spi.TenantAPIBootstrapper as BaseTenantAPIBootstrapper

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/AccessCheckRunner.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/AccessCheckRunner.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.engine.runtime.execution
 
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/DefaultCoroutineInterop.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/DefaultCoroutineInterop.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.engine.runtime.execution
 
 import java.util.concurrent.CompletableFuture

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ResolverDataFetcher.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ResolverDataFetcher.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.engine.runtime.execution
 
 import graphql.execution.ResultPath

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ViaductExecutionStrategy.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/ViaductExecutionStrategy.kt
@@ -1,4 +1,5 @@
 @file:OptIn(ExperimentalTime::class)
+@file:Suppress("DEPRECATION")
 
 package viaduct.engine.runtime.execution
 

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/WrappedCoroutineExecutionStrategy.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/execution/WrappedCoroutineExecutionStrategy.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.engine.runtime.execution
 
 import graphql.ExecutionResult

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/instrumentation/ResolverDataFetcherInstrumentation.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/instrumentation/ResolverDataFetcherInstrumentation.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.engine.runtime.instrumentation
 
 import graphql.execution.instrumentation.InstrumentationState

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/DispatcherRegistryFactory.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/DispatcherRegistryFactory.kt
@@ -1,4 +1,4 @@
-@file:Suppress("ForbiddenImport")
+@file:Suppress("ForbiddenImport", "DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package viaduct.engine.runtime.tenantloading
 

--- a/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/ExecutionRegistryTenantAPIBootstrapper.kt
+++ b/core/engine/runtime/src/main/kotlin/viaduct/engine/runtime/tenantloading/ExecutionRegistryTenantAPIBootstrapper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+
 package viaduct.engine.runtime.tenantloading
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/core/engine/wiring/src/main/kotlin/viaduct/engine/ExecutionRegistryBootstrapperFactory.kt
+++ b/core/engine/wiring/src/main/kotlin/viaduct/engine/ExecutionRegistryBootstrapperFactory.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+
 package viaduct.engine
 
 import io.github.classgraph.ClassGraph

--- a/core/engine/wiring/src/main/kotlin/viaduct/engine/SchemaFactory.kt
+++ b/core/engine/wiring/src/main/kotlin/viaduct/engine/SchemaFactory.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.engine
 
 import graphql.schema.GraphQLScalarType

--- a/core/engine/wiring/src/main/kotlin/viaduct/engine/ViaductWiringFactory.kt
+++ b/core/engine/wiring/src/main/kotlin/viaduct/engine/ViaductWiringFactory.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.engine
 
 import graphql.schema.DataFetcher

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/SchemaScopedModule.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/SchemaScopedModule.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.service.runtime
 
 import com.google.inject.AbstractModule

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaductModule.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/StandardViaductModule.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 
 package viaduct.service.runtime
 

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/builtinresolvers/NamespaceTypeResolverModuleBootstrapper.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/builtinresolvers/NamespaceTypeResolverModuleBootstrapper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.service.runtime.builtinresolvers
 
 import graphql.schema.GraphQLObjectType

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/builtinresolvers/ViaductBuiltInResolversBootstrapper.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/builtinresolvers/ViaductBuiltInResolversBootstrapper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+
 package viaduct.service.runtime.builtinresolvers
 
 import viaduct.engine.api.spi.LegacyTenantModuleBootstrapper

--- a/core/service/runtime/src/main/kotlin/viaduct/service/runtime/builtinresolvers/ViaductQueryNodeResolverModuleBootstrapper.kt
+++ b/core/service/runtime/src/main/kotlin/viaduct/service/runtime/builtinresolvers/ViaductQueryNodeResolverModuleBootstrapper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.service.runtime.builtinresolvers
 
 import viaduct.engine.api.Coordinate

--- a/core/service/wiring/src/main/kotlin/viaduct/service/BasicViaductFactory.kt
+++ b/core/service/wiring/src/main/kotlin/viaduct/service/BasicViaductFactory.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.service
 
 import viaduct.api.bootstrap.ViaductTenantAPIBootstrapper

--- a/core/shared/errors/src/main/kotlin/viaduct/errors/UnsetFieldException.kt
+++ b/core/shared/errors/src/main/kotlin/viaduct/errors/UnsetFieldException.kt
@@ -1,3 +1,5 @@
+@file:OptIn(viaduct.apiannotations.InternalApi::class)
+
 package viaduct.errors
 
 import graphql.schema.GraphQLObjectType

--- a/core/shared/utils/src/main/kotlin/viaduct/utils/collections/AsyncExtensions.kt
+++ b/core/shared/utils/src/main/kotlin/viaduct/utils/collections/AsyncExtensions.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+
 package viaduct.utils.collections
 
 import kotlinx.coroutines.CoroutineScope

--- a/core/tenant/codegen/src/main/kotlin/viaduct/tenant/codegen/cli/AssembleTenantModuleConfigFile.kt
+++ b/core/tenant/codegen/src/main/kotlin/viaduct/tenant/codegen/cli/AssembleTenantModuleConfigFile.kt
@@ -3,7 +3,7 @@ package viaduct.tenant.codegen.cli
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -150,9 +150,10 @@ class AssembleTenantModuleConfigFile : CliktCommand(
         // backwards-incompatible way so the bootstrapper can reject stale artifacts.
         const val REGISTRY_VERSION = "1"
 
-        val MAPPER: ObjectMapper = jacksonObjectMapper()
-            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val MAPPER: ObjectMapper = jacksonMapperBuilder()
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .build()
     }
 
     object Main {

--- a/core/tenant/codegen/src/main/kotlin/viaduct/tenant/codegen/ksp/ResolverParamsJsonCodec.kt
+++ b/core/tenant/codegen/src/main/kotlin/viaduct/tenant/codegen/ksp/ResolverParamsJsonCodec.kt
@@ -2,7 +2,8 @@ package viaduct.tenant.codegen.ksp
 
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 
 /**
  * JSON codec for the intermediate file-scoped resolver descriptor.
@@ -20,14 +21,16 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
  * decode path only runs in the CLI (process-isolated worker JVM), never inside KSP.
  */
 internal class ResolverParamsJsonCodec {
-    private val encoder: ObjectMapper = ObjectMapper()
-        .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+    private val encoder: ObjectMapper = JsonMapper.builder()
+        .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+        .build()
 
     private val encoderWriter = encoder.writerWithDefaultPrettyPrinter()
 
     private val decoder: ObjectMapper by lazy {
-        jacksonObjectMapper()
-            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+        jacksonMapperBuilder()
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .build()
     }
 
     fun encode(descriptorFile: ResolverDescriptorFile): String {

--- a/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/bootstrap/ViaductTenantModuleBootstrapper.kt
+++ b/core/tenant/runtime/src/main/kotlin/viaduct/tenant/runtime/bootstrap/ViaductTenantModuleBootstrapper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package viaduct.tenant.runtime.bootstrap
 
 import kotlin.reflect.full.declaredMemberFunctions

--- a/core/tenant/wiring/src/main/kotlin/viaduct/api/bootstrap/ViaductTenantAPIBootstrapper.kt
+++ b/core/tenant/wiring/src/main/kotlin/viaduct/api/bootstrap/ViaductTenantAPIBootstrapper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
+
 package viaduct.api.bootstrap
 
 import kotlinx.coroutines.async


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The build produced ~30 deprecation and opt-in warnings from intentional usage of deprecated internal APIs (`CoroutineInterop`, `LegacyTenantModuleBootstrapper`) and one genuinely fixable deprecation (Jackson's `ObjectMapper.configure`). This eliminates all of them so the build output only contains actionable signal.

**Key Changes**

- `core/engine/runtime/.../execution/` — added `@file:Suppress("DEPRECATION")` for intentional `CoroutineInterop` and `TemporaryBypassAccessCheck` usage (these are part of a planned migration, not accidental)
- `core/engine/wiring/` — same suppression for `CoroutineInterop` and `ExecutionRegistryBootstrapperFactory`
- `core/service/runtime/`, `core/service/wiring/`, `core/tenant/runtime/`, `core/tenant/wiring/` — added `@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")` for `LegacyTenantModuleBootstrapper` and its typealias expansion
- `core/engine/api/.../TenantAPIBootstrapper.kt` — suppressed deprecation at the typealias declaration site
- `core/tenant/codegen/.../AssembleTenantModuleConfigFile.kt`, `ResolverParamsJsonCodec.kt` — migrated from deprecated `ObjectMapper().configure(MapperFeature, Boolean)` to `JsonMapper.builder().enable(MapperFeature).build()`
- `core/shared/utils/.../AsyncExtensions.kt` — added `@file:OptIn(DelicateCoroutinesApi::class)` for `isClosedForReceive` usage
- `core/shared/errors/.../UnsetFieldException.kt` — added `@file:OptIn(InternalApi::class)` because `UnsetFieldException` extends `@InternalApi`-annotated `TenantUsageException`

## How was it tested?  What documentation was provided?

- `./gradlew :core:engine:runtime:compileKotlin :core:engine:wiring:compileKotlin :core:tenant:codegen:compileKotlin :core:tenant:wiring:compileKotlin :core:tenant:runtime:compileKotlin :core:service:runtime:compileKotlin :core:service:wiring:compileKotlin :core:shared:utils:compileKotlin :core:shared:errors:compileKotlin` — 0 warnings
- `./gradlew :core:tenant:codegen:test` — BUILD SUCCESSFUL (validates Jackson migration)

Suppressions are file-level annotations on files that intentionally implement deprecated SPIs. The Jackson fix is a straightforward migration to the non-deprecated builder API.