### PR TITLE
fix(build): wire remoteresolvers into snapshot publication task graph

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,10 @@ orchestration {
 
 // remoteresolvers is a single-module included build (no subprojects), so it doesn't
 // expose the orchestration aggregate tasks the root orchestration depends on. Wire
-// its root-level publishToMavenLocal directly so standalone demoapp tests can find
-// the artifact in Maven Local.
+// its root-level publish tasks directly so standalone demoapp tests can find the artifact.
 tasks.named("publishToMavenLocal") {
     dependsOn(gradle.includedBuild("remoteresolvers").task(":publishToMavenLocal"))
+}
+tasks.named("publishToSnapshots") {
+    dependsOn(gradle.includedBuild("remoteresolvers").task(":publishMavenPublicationToSnapshotsRepository"))
 }

--- a/x/remoteresolvers/build.gradle.kts
+++ b/x/remoteresolvers/build.gradle.kts
@@ -22,6 +22,16 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            name = "snapshots"
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            credentials {
+                username = providers.gradleProperty("mavenCentralUsername").orNull
+                password = providers.gradleProperty("mavenCentralPassword").orNull
+            }
+        }
+    }
 }
 
 // Configure detekt to use local config


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The nightly E2E workflow publishes snapshots via `./gradlew publishToSnapshots`, but the `remoteresolvers` included build was excluded from that task graph. The `starwars` demoapp depends on `com.airbnb.viaduct:remoteresolvers:1.0.0-SNAPSHOT`, so the downstream `check-demoapps` job fails with an unresolved dependency against Sonatype.

The `publishToMavenLocal` path already included remoteresolvers (and CI-precheck passed) masking the gap in the remote-publication path.

**Key Changes**

- `x/remoteresolvers/build.gradle.kts` — Add the Sonatype snapshots Maven repository definition so the `publishMavenPublicationToSnapshotsRepository` task exists (this module uses plain `maven-publish`, not the shared convention plugin that adds it automatically)
- `build.gradle.kts` — Wire the new task into the root `publishToSnapshots` aggregation, mirroring the existing `publishToMavenLocal` pattern

## How was it tested?  What documentation was provided?

- `actionlint .github/workflows/*.yml`
- `./gradlew -p x/remoteresolvers tasks --group=publishing` — confirmed `publishMavenPublicationToSnapshotsRepository` task is registered
- `./gradlew publishToSnapshots --dry-run` — confirmed `:remoteresolvers:publishMavenPublicationToSnapshotsRepository` appears in the task execution plan alongside the other included builds
- `./gradlew publishToMavenLocal -PpublishMinimal` — confirmed no regression on the existing local-publish path