### PR TITLE
fix(ci): add failure alerting to demoapps-nightly-check workflow

### DIFF
--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -108,6 +108,66 @@ jobs:
       ref: ${{ needs.push-demoapps.outputs.destination_branch }}
 
   # ---------------------------------------------------------------------------
+  # Alert on failure — post to Slack and Discord
+  # ---------------------------------------------------------------------------
+  format-alerts:
+    needs: [publish-snapshot, push-demoapps, wait-for-publication, check-demoapps]
+    runs-on: ubuntu-latest
+    if: >-
+      always()
+      && (needs.publish-snapshot.result == 'failure'
+          || needs.push-demoapps.result == 'failure'
+          || needs.wait-for-publication.result == 'failure'
+          || needs.check-demoapps.result == 'failure')
+    outputs:
+      text: ${{ steps.fmt.outputs.text }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build failed-jobs list
+        id: jobs
+        env:
+          PUBLISH_RESULT: ${{ needs.publish-snapshot.result }}
+          PUSH_RESULT: ${{ needs.push-demoapps.result }}
+          WAIT_RESULT: ${{ needs.wait-for-publication.result }}
+          CHECK_RESULT: ${{ needs.check-demoapps.result }}
+        run: |
+          jobs_json='[]'
+          if [ "$PUBLISH_RESULT" = "failure" ]; then
+            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Publish Snapshot" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
+          fi
+          if [ "$PUSH_RESULT" = "failure" ]; then
+            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Push Demoapps" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
+          fi
+          if [ "$WAIT_RESULT" = "failure" ]; then
+            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Wait for Publication" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
+          fi
+          if [ "$CHECK_RESULT" = "failure" ]; then
+            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Check Demoapps" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
+          fi
+          echo "jobs_json=${jobs_json}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Format alert
+        id: fmt
+        uses: ./.github/actions/collect-failure-info
+        with:
+          jobs_json: ${{ steps.jobs.outputs.jobs_json }}
+          branch: ${{ inputs.ref }}
+          server_url: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          sha: ${{ github.sha }}
+          actor: ${{ github.actor }}
+
+  send-alerts:
+    needs: [format-alerts]
+    if: always() && needs.format-alerts.result == 'success'
+    uses: ./.github/workflows/post-alerts.yml
+    with:
+      text: ${{ needs.format-alerts.outputs.text }}
+    secrets: inherit
+
+  # ---------------------------------------------------------------------------
   # Delete temporary branches in viaduct-dev/* repos (ephemeral refs only)
   # ---------------------------------------------------------------------------
   cleanup:


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The nightly E2E workflow (`demoapps-nightly-check.yml`) was the only orchestrator workflow without failure notifications. When a stage failed (e.g. unresolved snapshot dependency in `check-demoapps`), no alert reached Slack or Discord — the failure went unnoticed until manual inspection.
All other orchestrator workflows (`ci-trigger.yml`, `periodic-green-check.yml`) already post alerts, and `ci-watchdog.yml` only catches `startup_failure` conclusions, not regular failures.

**Key Changes**

- `.github/workflows/demoapps-nightly-check.yml` — Add `format-alerts` and `send-alerts` jobs gated on failure of any stage (publish-snapshot, push-demoapps, wait-for-publication, check-demoapps). Follows the same pattern as `ci-trigger.yml`: collect failed job names, format via `collect-failure-info` action, then delegate to `post-alerts.yml` for Slack/Discord delivery.

## How was it tested?  What documentation was provided?

- `actionlint .github/workflows/demoapps-nightly-check.yml` — passes with no errors