### PR TITLE
build: capitalize and dedupe release note entries

### DIFF
--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -11,6 +11,7 @@ while maintaining Viaduct's authorship semantics:
 """
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from collections import defaultdict
@@ -149,6 +150,63 @@ def strip_conventional_prefix(message: str) -> str:
     """Strip 'type(scope)!: ' prefix from a conventional commit subject."""
     match = re.match(r'^[a-z]+(\([^)]+\))?!?:\s*', message)
     return message[match.end():] if match else message
+
+
+def capitalize_first(text: str) -> str:
+    """Uppercase the first character of text, preserving the rest as-is."""
+    if not text:
+        return text
+    return text[0].upper() + text[1:]
+
+
+# Trailing reference markers added by the OSS workflow:
+#   - (sha)  — short git SHA, substituted from the (AIRBNB) marker on internal commits
+#   - (#NNN) — PR number, appended by GitHub on squash-merges
+# After OSS sync, the same change can appear with both forms in the git log.
+_SHA_REF_RE = re.compile(r'\(([0-9a-f]{4,40})\)\s*$', re.IGNORECASE)
+_PR_REF_RE = re.compile(r'\(#\d+\)\s*$')
+_TRAILING_REF_RE = re.compile(r'\s*\((?:#\d+|[0-9a-f]{4,40})\)\s*$', re.IGNORECASE)
+
+
+def _normalize_for_dedup(description: str) -> str:
+    """Strip a trailing (sha) or (#NNN) reference token for duplicate matching."""
+    return _TRAILING_REF_RE.sub('', description).strip()
+
+
+def _has_sha_ref(description: str) -> bool:
+    return bool(_SHA_REF_RE.search(description))
+
+
+def _has_pr_ref(description: str) -> bool:
+    return bool(_PR_REF_RE.search(description))
+
+
+def dedupe_entries(entries: list[ChangelogEntry]) -> list[ChangelogEntry]:
+    """
+    Drop PR-merge entries that duplicate a SHA-tagged entry.
+
+    OSS sync can leave the git log with both an original internal commit
+    (`(AIRBNB)` → `(sha)`) and the PR-merge commit synced back from GitHub
+    (`(#NNN)`) for the same change. When both forms exist with the same
+    normalized description and authors, keep the SHA-tagged entry.
+    """
+    groups: dict[tuple[str, tuple[str, ...]], list[ChangelogEntry]] = defaultdict(list)
+    for entry in entries:
+        key = (_normalize_for_dedup(entry.description), tuple(sorted(entry.authors)))
+        groups[key].append(entry)
+
+    drop_ids: set[int] = set()
+    for group in groups.values():
+        if len(group) < 2:
+            continue
+        has_sha = any(_has_sha_ref(e.description) for e in group)
+        if not has_sha:
+            continue
+        for e in group:
+            if _has_pr_ref(e.description) and not _has_sha_ref(e.description):
+                drop_ids.add(id(e))
+
+    return [e for e in entries if id(e) not in drop_ids]
 
 
 def replace_airbnb_marker(message: str, sha: str) -> str:
@@ -366,7 +424,7 @@ def render_section(change_type: str, entries: list[ChangelogEntry]) -> str:
 
     lines = [f"## {title}", ""]
     for entry in entries:
-        lines.append(f"- {entry.formatted_entry}")
+        lines.append(f"- {capitalize_first(entry.formatted_entry)}")
     lines.append("")
 
     return '\n'.join(lines)
@@ -384,7 +442,7 @@ def render_breaking_changes(entries: list[ChangelogEntry]) -> str:
     """
     lines = ["## Breaking Changes", ""]
     for entry in entries:
-        desc = entry.description
+        desc = capitalize_first(entry.description)
         lines.append(f"- {desc} by {entry.formatted_authors}")
     lines.append("")
 
@@ -404,6 +462,8 @@ def generate_changelog(tag1: str, tag2: str) -> str:
     """
     parser = ConventionalCommitParser()
 
+    release_ver = os.environ['RELEASE_VER']
+
     # Get and parse all commits
     entries: list[ChangelogEntry] = []
     for commit in get_commits_between_tags(tag1, tag2):
@@ -412,7 +472,10 @@ def generate_changelog(tag1: str, tag2: str) -> str:
             entries.append(entry)
 
     if not entries:
-        return f"# Version {tag2}\n\nNo changes.\n"
+        return f"# Version {release_ver}\n\nNo changes.\n"
+
+    # Drop PR-merge duplicates of SHA-tagged entries (see dedupe_entries)
+    entries = dedupe_entries(entries)
 
     # Separate breaking changes
     breaking_entries = [e for e in entries if e.is_breaking]
@@ -428,7 +491,7 @@ def generate_changelog(tag1: str, tag2: str) -> str:
     )
 
     # Build changelog
-    sections = [f"# Version {tag2}", ""]
+    sections = [f"# Version {release_ver}", ""]
 
     # Add breaking changes first if any
     if breaking_entries:

--- a/.github/scripts/tests/test_generate_changelog.py
+++ b/.github/scripts/tests/test_generate_changelog.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -22,6 +23,8 @@ from generate_changelog import (
     render_section,
     render_breaking_changes,
     generate_changelog,
+    capitalize_first,
+    dedupe_entries,
     CommitInfo,
     ChangelogEntry,
     BOT_USERNAMES,
@@ -454,6 +457,135 @@ class TestRenderSection(unittest.TestCase):
         self.assertIn("- Fix bug 1 by @john", result)
         self.assertIn("- Fix bug 2 by @jane", result)
 
+    def test_render_section_capitalizes_lowercase_descriptions(self):
+        entries = [
+            ChangelogEntry("a", "m1", ["@john"], "fix", None, "fix bug in parser", False, None, LevelBump.PATCH),
+            ChangelogEntry("b", "m2", ["@jane"], "fix", None, "add validation", False, None, LevelBump.PATCH),
+        ]
+        result = render_section("fix", entries)
+        self.assertIn("- Fix bug in parser by @john", result)
+        self.assertIn("- Add validation by @jane", result)
+
+
+class TestDedupeEntries(unittest.TestCase):
+    def _entry(self, sha, description, authors=("@geo",), change_type="feat"):
+        return ChangelogEntry(
+            sha=sha,
+            message=description,
+            authors=list(authors),
+            change_type=change_type,
+            scope=None,
+            description=description,
+            is_breaking=False,
+            breaking_description=None,
+            bump=LevelBump.MINOR,
+        )
+
+    def test_drops_pr_duplicate_when_sha_twin_exists(self):
+        sha_entry = self._entry("3b4c18b7", "strict missing-resolver validation at startup (3b4c18b7)")
+        pr_entry = self._entry("0000000", "strict missing-resolver validation at startup (#333)")
+        result = dedupe_entries([sha_entry, pr_entry])
+        self.assertEqual(result, [sha_entry])
+
+    def test_drops_pr_duplicate_regardless_of_order(self):
+        sha_entry = self._entry("3b4c18b7", "strict missing-resolver validation at startup (3b4c18b7)")
+        pr_entry = self._entry("0000000", "strict missing-resolver validation at startup (#333)")
+        result = dedupe_entries([pr_entry, sha_entry])
+        self.assertEqual(result, [sha_entry])
+
+    def test_keeps_pr_entry_when_no_sha_twin(self):
+        # No internal commit pair — keep the PR entry as-is
+        pr_entry = self._entry("0000000", "external contribution (#400)", authors=("@external",))
+        result = dedupe_entries([pr_entry])
+        self.assertEqual(result, [pr_entry])
+
+    def test_does_not_dedupe_when_authors_differ(self):
+        # Same description but different authors — treat as distinct changes
+        sha_entry = self._entry("3b4c18b7", "rename SomeClass (3b4c18b7)", authors=("@alice",))
+        pr_entry = self._entry("0000000", "rename SomeClass (#333)", authors=("@bob",))
+        result = dedupe_entries([sha_entry, pr_entry])
+        self.assertEqual(result, [sha_entry, pr_entry])
+
+    def test_does_not_dedupe_when_descriptions_differ(self):
+        a = self._entry("aaaaaaaa", "fix parser bug (aaaaaaaa)")
+        b = self._entry("bbbbbbbb", "fix lexer bug (bbbbbbbb)")
+        result = dedupe_entries([a, b])
+        self.assertEqual(result, [a, b])
+
+    def test_keeps_two_sha_entries_with_same_description(self):
+        # Two distinct internal commits with identical descriptions —
+        # neither has a (#NNN) marker, so neither is the dedupe target.
+        a = self._entry("aaaaaaaa", "bump deps (aaaaaaaa)")
+        b = self._entry("bbbbbbbb", "bump deps (bbbbbbbb)")
+        result = dedupe_entries([a, b])
+        self.assertEqual(result, [a, b])
+
+    def test_preserves_relative_order_of_kept_entries(self):
+        e1 = self._entry("11111111", "first change (11111111)")
+        sha_entry = self._entry("3b4c18b7", "shared change (3b4c18b7)")
+        pr_entry = self._entry("0000000", "shared change (#333)")
+        e2 = self._entry("22222222", "later change (22222222)")
+        result = dedupe_entries([e1, pr_entry, sha_entry, e2])
+        self.assertEqual(result, [e1, sha_entry, e2])
+
+
+class TestCapitalizeFirst(unittest.TestCase):
+    def test_capitalizes_lowercase_first_char(self):
+        self.assertEqual(capitalize_first("fix bug"), "Fix bug")
+
+    def test_preserves_already_capitalized(self):
+        self.assertEqual(capitalize_first("Fix bug"), "Fix bug")
+
+    def test_preserves_rest_of_string(self):
+        # Don't lowercase subsequent capitals (acronyms, type names, etc.)
+        self.assertEqual(capitalize_first("rename GraphQL types"), "Rename GraphQL types")
+
+    def test_empty_string(self):
+        self.assertEqual(capitalize_first(""), "")
+
+    def test_single_char(self):
+        self.assertEqual(capitalize_first("a"), "A")
+
+    def test_non_letter_first_char_unchanged(self):
+        self.assertEqual(capitalize_first("(scope) fix"), "(scope) fix")
+
+
+class TestGenerateChangelog(unittest.TestCase):
+    def _commit(self, sha, message, author_email="john.doe@example.com", body="", co_authors_raw=""):
+        return CommitInfo(
+            sha=sha,
+            message=message,
+            body=body,
+            author_email=author_email,
+            co_authors_raw=co_authors_raw,
+        )
+
+    @patch.dict(os.environ, {"RELEASE_VER": "0.32.0"})
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_uses_release_ver_for_header(self, mock_get_commits):
+        mock_get_commits.return_value = iter([
+            self._commit("abc1234", "feat: add a thing"),
+        ])
+        changelog = generate_changelog("v0.31.0", "HEAD")
+        self.assertIn("# Version 0.32.0", changelog)
+        self.assertNotIn("# Version HEAD", changelog)
+
+    @patch.dict(os.environ, {"RELEASE_VER": "1.2.3"})
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_uses_release_ver_for_empty_changelog(self, mock_get_commits):
+        mock_get_commits.return_value = iter([])
+        changelog = generate_changelog("v1.2.2", "HEAD")
+        self.assertEqual(changelog, "# Version 1.2.3\n\nNo changes.\n")
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_missing_release_ver_raises(self, mock_get_commits):
+        mock_get_commits.return_value = iter([
+            self._commit("abc1234", "feat: add a thing"),
+        ])
+        with self.assertRaises(KeyError):
+            generate_changelog("v0.31.0", "HEAD")
+
 
 class TestRenderBreakingChanges(unittest.TestCase):
     def test_render_breaking_changes(self):
@@ -462,7 +594,7 @@ class TestRenderBreakingChanges(unittest.TestCase):
         ]
         result = render_breaking_changes(entries)
         self.assertIn("## Breaking Changes", result)
-        self.assertIn("subject description", result)
+        self.assertIn("Subject description", result)
         self.assertNotIn("body trailer description", result)
         self.assertIn("@john", result)
 
@@ -472,7 +604,7 @@ class TestRenderBreakingChanges(unittest.TestCase):
             ChangelogEntry("abc1234", "m1", ["@alice"], "refactor", None, "rename SomeClass (abc1234)", True, "SomeClass renamed to OtherClass.", LevelBump.MAJOR),
         ]
         result = render_breaking_changes(entries)
-        self.assertIn("rename SomeClass (abc1234)", result)
+        self.assertIn("Rename SomeClass (abc1234)", result)
         self.assertNotIn("SomeClass renamed to OtherClass.", result)
 
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Capitalize and dedupe release note entries to reduce manual cleanup during release process.


## How was it tested?  What documentation was provided?

See unit tests.