### PR TITLE
build: wait for new artifacts to appear in maven central/plugin portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
             "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/gradle/common/${VERSION}/common-${VERSION}.pom"
             "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/shared/graphql/${VERSION}/graphql-${VERSION}.pom"
             "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/shared/viaductschema/${VERSION}/viaductschema-${VERSION}.pom"
-            "https://plugins.gradle.org/m2/com/airbnb/viaduct/gradle/common/${VERSION}/common-${VERSION}.pom"
+            "https://plugins.gradle.org/m2/com/airbnb/viaduct/application-gradle-plugin/com.airbnb.viaduct.application-gradle-plugin.gradle.plugin/${VERSION}/com.airbnb.viaduct.application-gradle-plugin.gradle.plugin-${VERSION}.pom"
           )
           MAX_ATTEMPTS=60
           SLEEP_SECONDS=30
@@ -103,7 +103,7 @@ jobs:
             attempt=0
             while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
               attempt=$((attempt + 1))
-              code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "000")
+              code=$(curl -sL -o /dev/null -w "%{http_code}" "$url" || echo "000")
               if [[ "$code" == "200" ]]; then
                 echo "  ✅ available (attempt ${attempt})"
                 break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,53 @@ jobs:
     secrets: inherit
 
   # ---------------------------------------------------------------------------
+  # Wait for new artifacts to propagate to Maven Central / Plugin Portal CDNs.
+  # Without this, verify-demoapps races the CDN and fails to resolve the
+  # newly-published version even though publish succeeded.
+  # ---------------------------------------------------------------------------
+  wait-for-new-artifacts:
+    needs: [push-demoapps]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe Maven Central and Plugin Portal for ${{ inputs.release_version }}
+        env:
+          VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          URLS=(
+            "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/gradle/common/${VERSION}/common-${VERSION}.pom"
+            "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/shared/graphql/${VERSION}/graphql-${VERSION}.pom"
+            "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/shared/viaductschema/${VERSION}/viaductschema-${VERSION}.pom"
+            "https://plugins.gradle.org/m2/com/airbnb/viaduct/gradle/common/${VERSION}/common-${VERSION}.pom"
+          )
+          MAX_ATTEMPTS=60
+          SLEEP_SECONDS=30
+          for url in "${URLS[@]}"; do
+            echo "Probing $url"
+            attempt=0
+            while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
+              attempt=$((attempt + 1))
+              code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "000")
+              if [[ "$code" == "200" ]]; then
+                echo "  ✅ available (attempt ${attempt})"
+                break
+              fi
+              if [[ $attempt -eq $MAX_ATTEMPTS ]]; then
+                echo "::error::Artifact $url not visible after $((MAX_ATTEMPTS * SLEEP_SECONDS / 60))m of polling (last status: $code)"
+                exit 1
+              fi
+              echo "  ⏳ HTTP $code (attempt ${attempt}/${MAX_ATTEMPTS}) — sleeping ${SLEEP_SECONDS}s"
+              sleep "$SLEEP_SECONDS"
+            done
+          done
+          echo "✅ All probed artifacts are visible"
+        shell: bash
+
+  # ---------------------------------------------------------------------------
   # Verify standalone repos build against published release artifacts
   # ---------------------------------------------------------------------------
   verify-demoapps:
-    needs: [push-demoapps]
+    needs: [push-demoapps, wait-for-new-artifacts]
     uses: ./.github/workflows/check-published-demoapps.yml
     with:
       ref: main


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Poll for new artifacts in Sonatype and the Gradle Plugin Portal before verifying the demo apps.

## How was it tested?  What documentation was provided?

We tested by extracting the workflow's probe loop into a local bash one-liner and running it directly:

**Happy path** — `VERSION=0.32.0`, looped over the four URLs with `curl -sL -o /dev/null -w "%{http_code}"`. Caught two real bugs:
1. The Plugin Portal URL for `gradle/common` returned `303` (redirects to Maven Central) — the original probe would have looped forever waiting for `200`. Fixed by adding `-L` so curl follows redirects.
2. The probed URL was a redundant duplicate of Maven Central. Replaced it with the **plugin marker** (`com.airbnb.viaduct.application-gradle-plugin.gradle.plugin`) — that's the Plugin-Portal-only artifact Gradle actually resolves when applying a plugin.

After fixing, all four URLs returned `200`.

**Negative path** — `VERSION=99.99.99` returned `404` on both representative URLs, confirming the loop would sleep/retry and ultimately fail-with-error-annotation rather than spin or false-pass.
