### PR TITLE
build: drop version header from changelog

### DIFF
--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -11,7 +11,6 @@ while maintaining Viaduct's authorship semantics:
 """
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 from collections import defaultdict
@@ -461,8 +460,6 @@ def generate_changelog(tag1: str, tag2: str) -> str:
         Formatted markdown changelog
     """
     parser = ConventionalCommitParser()
-
-    release_ver = os.environ['RELEASE_VER']
 
     # Get and parse all commits
     entries: list[ChangelogEntry] = []

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -471,11 +471,10 @@ def generate_changelog(tag1: str, tag2: str) -> str:
         if entry:
             entries.append(entry)
 
-    if not entries:
-        return f"# Version {release_ver}\n\nNo changes.\n"
-
     # Drop PR-merge duplicates of SHA-tagged entries (see dedupe_entries)
     entries = dedupe_entries(entries)
+    if not entries:
+        return "No changes.\n"
 
     # Separate breaking changes
     breaking_entries = [e for e in entries if e.is_breaking]
@@ -491,7 +490,11 @@ def generate_changelog(tag1: str, tag2: str) -> str:
     )
 
     # Build changelog
+<<<<<<< HEAD
     sections = [f"# Version {release_ver}", ""]
+=======
+    sections: list[str] = []
+>>>>>>> 0d38ad45 (build: drop version header from changelog)
 
     # Add breaking changes first if any
     if breaking_entries:

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -487,11 +487,7 @@ def generate_changelog(tag1: str, tag2: str) -> str:
     )
 
     # Build changelog
-<<<<<<< HEAD
-    sections = [f"# Version {release_ver}", ""]
-=======
     sections: list[str] = []
->>>>>>> 0d38ad45 (build: drop version header from changelog)
 
     # Add breaking changes first if any
     if breaking_entries:

--- a/.github/scripts/tests/test_generate_changelog.py
+++ b/.github/scripts/tests/test_generate_changelog.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -560,31 +559,19 @@ class TestGenerateChangelog(unittest.TestCase):
             co_authors_raw=co_authors_raw,
         )
 
-    @patch.dict(os.environ, {"RELEASE_VER": "0.32.0"})
     @patch("generate_changelog.get_commits_between_tags")
-    def test_uses_release_ver_for_header(self, mock_get_commits):
+    def test_omits_version_header(self, mock_get_commits):
         mock_get_commits.return_value = iter([
             self._commit("abc1234", "feat: add a thing"),
         ])
         changelog = generate_changelog("v0.31.0", "HEAD")
-        self.assertIn("# Version 0.32.0", changelog)
-        self.assertNotIn("# Version HEAD", changelog)
+        self.assertNotIn("# Version", changelog)
 
-    @patch.dict(os.environ, {"RELEASE_VER": "1.2.3"})
     @patch("generate_changelog.get_commits_between_tags")
-    def test_uses_release_ver_for_empty_changelog(self, mock_get_commits):
+    def test_empty_changelog(self, mock_get_commits):
         mock_get_commits.return_value = iter([])
         changelog = generate_changelog("v1.2.2", "HEAD")
-        self.assertEqual(changelog, "# Version 1.2.3\n\nNo changes.\n")
-
-    @patch.dict(os.environ, {}, clear=True)
-    @patch("generate_changelog.get_commits_between_tags")
-    def test_missing_release_ver_raises(self, mock_get_commits):
-        mock_get_commits.return_value = iter([
-            self._commit("abc1234", "feat: add a thing"),
-        ])
-        with self.assertRaises(KeyError):
-            generate_changelog("v0.31.0", "HEAD")
+        self.assertEqual(changelog, "No changes.\n")
 
 
 class TestRenderBreakingChanges(unittest.TestCase):


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Remove the version header from the changelog generator as it is redundant.

## How was it tested?  What documentation was provided?

Tested manually.
