### PR TITLE
build(release): add RC publication flow

### DIFF
--- a/.github/copydemoapps/README.md
+++ b/.github/copydemoapps/README.md
@@ -10,7 +10,7 @@ applications to their standalone GitHub repositories in the
 - `demoapps/micronaut-starter` → `viaduct-dev/micronaut-starter`
 - `demoapps/starwars` → `viaduct-dev/starwars`
 
-Publishing is step 10 of the release process described in `RELEASE-RUNBOOK.md`.
+Publishing is part of the release process described in [.github/impldocs/release-runbook.md](../impldocs/release-runbook.md).
 
 ## Theory of Operation
 
@@ -44,7 +44,7 @@ ssh -T git@github.com
 
 Expected: `Hi <username>! You've successfully authenticated...`
 
-If this fails, see the setup instructions in `RELEASE-RUNBOOK.md`.
+If this fails, see the setup instructions in [.github/impldocs/release-runbook.md](../impldocs/release-runbook.md).
 
 **For CI/GitHub Actions:** set the `VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN`
 environment variable. The `copy` script will use HTTPS with that token.

--- a/.github/impldocs/actions-arch.md
+++ b/.github/impldocs/actions-arch.md
@@ -77,19 +77,14 @@ An orchestrator helper is a reusable workflow that orchestrators delegate to for
 |---|---|---|
 | `post-alerts.yml` | Post pre-formatted alert text to Slack and Discord | called by orchestrators on failure, manual (test mode) |
 
-### Release Workflow
+### Release Workflows
 
-`release.yml` is separate from the CI infrastructure described above. It is a manually-triggered workflow used by release managers to publish Viaduct artifacts. See [RELEASE-RUNBOOK.md](../../RELEASE-RUNBOOK.md) for the full release process.
+`release.yml` is separate from the CI infrastructure described above. It is a manually-triggered workflow used by release managers to publish either a release candidate or a final Viaduct release. See [.github/impldocs/release-runbook.md](release-runbook.md) for the full release process.
 
-The workflow is triggered via `workflow_dispatch` with inputs for the release version, previous version (for changelog), and optional flags to skip checks or publishing. It:
+- RC mode publishes `X.Y.Z-rc.N` artifacts to Maven Central and the Gradle Plugin Portal, pushes demo apps to `rc/vX.Y.Z-rc.N`, and verifies the published RC.
+- Final mode publishes the final `X.Y.Z` release, pushes demo apps to `main`, verifies them, creates the `vX.Y.Z` tag, and publishes the GitHub release.
 
-- Checks out the `release/vX.Y.Z` branch (or `main` for snapshots)
-- Optionally runs `./gradlew check`
-- Publishes artifacts to Maven Central and the Gradle Plugin Portal
-- Creates a `vX.Y.Z` git tag
-- Generates a changelog and creates a draft GitHub release
-
-This workflow does not follow the atomic/orchestrator conventions — it predates them and is slated for replacement by a future `publish-branch.yml` atomic (see [Appendix: Future Work](#appendix-future-work)).
+`release.yml` delegates the actual artifact publication work to `publish-branch.yml`.
 
 ## run_id Output Convention
 
@@ -329,7 +324,7 @@ Notifications are suppressed on manual dispatch — the person who triggered the
 | `periodic-green-check.yml` | Run scheduled checks without waiting for cron | `branch`, `mode` (ci-check / staleness-check / all) |
 | `post-alerts.yml` | Verify Slack and Discord connectivity | `mode: test-posts` |
 | `conventional-commit.yml` | Test the PR title validator itself | — |
-| `release.yml` | Publish artifacts and create a GitHub release (see [RELEASE-RUNBOOK.md](../../RELEASE-RUNBOOK.md)) | `release_version`, `previous_release_version`, `publish_snapshot`, `skip_check`, `skip_publish` |
+| `release.yml` | Publish either a public release candidate or the final release (see [.github/impldocs/release-runbook.md](release-runbook.md)) | `release_version`, `rc_ver`, `final`, `release_notes` |
 
 ## Appendix: Future Work
 

--- a/.github/impldocs/release-runbook.md
+++ b/.github/impldocs/release-runbook.md
@@ -5,20 +5,22 @@
 The release process follows these steps:
 
 1. **Bump version** on main to the next SNAPSHOT (e.g., `0.8.0-SNAPSHOT`)
-2. **Create release branch** from the commit before the bump (e.g., `release/v0.7.0` with VERSION `0.7.0`)
+2. **Create release branch** from the commit before the bump (e.g., `release/v0.7.0` with initial VERSION `0.7.0`)
 3. **Validate** — run CI across all Java/OS combinations
-4. **Generate changelog** and review with the team
-5. **Confirm release** at the team meeting
-6. **Publish** — one command that publishes artifacts, pushes demo apps, verifies them, creates the tag, and publishes the GitHub release
-7. **Verify** — pull latest version of Star Wars demo app and verify it passes its tests
+4. **(Optional) Publish release candidate** — publish `X.Y.Z-rc.N` artifacts, push RC demo apps, and verify them
+5. **Generate changelog** and review with the team
+6. **Confirm release** at the team meeting
+7. **Publish final release** — one command that publishes `X.Y.Z`, pushes demo apps to `main`, verifies them, creates the tag, and publishes the GitHub release
+8. **Verify** — pull latest version of Star Wars demo app and verify it passes its tests
 
 ## Quick Command Reference
 
-Set these shell variables before starting. `RELEASE_VER` is the version you are releasing this week. `NEXT_VER` is the version that will replace it on main.
+Set these shell variables before starting. `RELEASE_VER` is the base version you are preparing this week. `RC_VER` is optional and only used when you cut a release candidate; it is just the suffix portion (for example `rc.1`). `NEXT_VER` is the version that will replace `RELEASE_VER` on main.
 
 ```bash
 export PREV_VER="0.28.0" \
 export RELEASE_VER="0.29.0" \
+export RC_VER="rc.1" \
 export NEXT_VER="0.30.0" \
 export GH_USER="your-github.com-username"
 ```
@@ -28,9 +30,10 @@ export GH_USER="your-github.com-username"
 | [2. Version bump](#2-bump-version-on-main) | `./gradlew setVersion -PsetVersion=${NEXT_VER}-SNAPSHOT`, PR |
 | [3. Release branch](#3-create-release-branch) | `git checkout -b release/v${RELEASE_VER}`, `./gradlew setVersion -PsetVersion=${RELEASE_VER}`, push |
 | [4. Validate build](#4-validate-build) | `gh workflow run ci-trigger.yml --ref release/v${RELEASE_VER}` |
-| [5. Changelog](#5-generate-changelog) | `generate_changelog.py origin/release/v${PREV_VER} HEAD` |
-| [7. Publish release](#7-publish-release) | `gh workflow run release.yml -f release_version=${RELEASE_VER} -F release_notes=@changelog.md` |
-| [8. Verify](#8-verify) | `cd ~/repos/starwars && git pull && ./gradlew test` |
+| [5. Publish RC](#5-publish-release-candidate-optional) | `./gradlew setVersion -PsetVersion=${RELEASE_VER}-${RC_VER}`, commit, push, `gh workflow run release.yml -f release_version=${RELEASE_VER} -f rc_ver=${RC_VER}` |
+| [6. Changelog](#6-generate-changelog) | `generate_changelog.py origin/release/v${PREV_VER} HEAD` |
+| [8. Publish final release](#8-publish-final-release) | `gh workflow run release.yml -f release_version=${RELEASE_VER} -f final=true -F release_notes=@changelog.md` |
+| [9. Verify](#9-verify) | `cd ~/repos/starwars && git pull && ./gradlew test` |
 
 ## Prerequisites
 
@@ -114,7 +117,16 @@ git remote -v
 The root `VERSION` file is the source of truth:
 
 - **On main:** Always `X.Y.Z-SNAPSHOT` (e.g., `0.8.0-SNAPSHOT`)
-- **On release branches:** Exactly `X.Y.Z` (e.g., `0.7.0`)
+- **On release branches before final publication:** Either `X.Y.Z` or `X.Y.Z-rc.N`
+- **For a final release:** Exactly `X.Y.Z`
+
+Release candidate numbering is sequential and never reused:
+
+- **First RC:** `X.Y.Z-rc.1`
+- **Second RC:** `X.Y.Z-rc.2`
+- **Final release:** `X.Y.Z`
+
+Do not publish the same RC version twice. If an RC needs fixes, increment `N`.
 
 Demo apps have `gradle.properties` files with a `viaductVersion` property that **must match** the root VERSION. Use Gradle tasks to keep them in sync:
 
@@ -151,7 +163,7 @@ git checkout -b candidate/v${NEXT_VER}
 
 ```bash
 git diff .
-# Should show VERSION + 5 demoapps/*/gradle.properties changed
+# Should show VERSION + 6 demoapps/*/gradle.properties changed
 ```
 
 **Commit, push to your fork, and create PR:**
@@ -225,7 +237,62 @@ This runs three sub-workflows:
 
 Wait for all jobs to pass (15-30 minutes).
 
-### 5) Generate changelog
+### 5) Publish release candidate (optional)
+
+Use this when you want a public release candidate before the final release.
+
+**Set the RC version on the release branch:**
+
+```bash
+cd ~/repos/viaduct
+git checkout release/v${RELEASE_VER}
+./gradlew setVersion -PsetVersion=${RELEASE_VER}-${RC_VER}
+```
+
+**Commit and push the RC version change:**
+
+```bash
+git add VERSION demoapps/*/gradle.properties
+git commit -m "chore: Set version to ${RELEASE_VER}-${RC_VER}"
+git push origin release/v${RELEASE_VER}
+```
+
+**Publish the RC:**
+
+```bash
+gh workflow run release.yml \
+  --repo airbnb/viaduct \
+  -f release_version=${RELEASE_VER} \
+  -f rc_ver=${RC_VER}
+```
+
+Monitor:
+
+```bash
+gh run list --workflow=release.yml --repo airbnb/viaduct --limit 3
+```
+
+The workflow runs these steps in sequence:
+1. **Preflight** — validates the `release_version` / `rc_ver` / `final` inputs and verifies the `release/v${RELEASE_VER}` branch exists
+2. **Publish** — validates versions, runs checks, and publishes `${RELEASE_VER}-${RC_VER}` to Plugin Portal + Maven Central
+3. **Push demo apps** — updates standalone `viaduct-dev/*` repos on `rc/v${RELEASE_VER}-${RC_VER}`
+4. **Verify demo apps** — confirms standalone repos build against the published RC artifacts
+
+It does **not** create a Git tag, publish a GitHub release, or push demo apps to `main`.
+
+If you need another RC after fixes, cherry-pick the fixes onto `release/v${RELEASE_VER}`, bump to the next RC number, push, and rerun the RC workflow:
+
+```bash
+cd ~/repos/viaduct
+git checkout release/v${RELEASE_VER}
+git cherry-pick <commit-sha>
+./gradlew setVersion -PsetVersion=${RELEASE_VER}-rc.2
+git add VERSION demoapps/*/gradle.properties
+git commit -m "chore: Set version to ${RELEASE_VER}-rc.2"
+git push origin release/v${RELEASE_VER}
+```
+
+### 6) Generate changelog
 
 ```bash
 cd ~/repos/viaduct
@@ -241,7 +308,7 @@ Edit the output: remove bookkeeping commits (version bumps), clarify cryptic mes
 
 Share in the team Slack channel for review before the release meeting.
 
-### 6) Confirm release
+### 7) Confirm release
 
 At the team meeting, present the changelog and get approval.
 
@@ -254,9 +321,20 @@ git cherry-pick <commit-sha>
 git push origin release/v${RELEASE_VER}
 ```
 
-If you cherry-picked, re-run Step 4 to validate.
+If you cherry-picked, re-run Step 4 to validate. If you already published an RC and still want a fresh RC after those changes, re-run Step 5 with the next RC number.
 
-### 7) Publish release
+### 8) Publish final release
+
+If the release branch is currently at an RC version, reset it back to the exact final version first:
+
+```bash
+cd ~/repos/viaduct
+git checkout release/v${RELEASE_VER}
+./gradlew setVersion -PsetVersion=${RELEASE_VER}
+git add VERSION demoapps/*/gradle.properties
+git commit -m "chore: Set version to ${RELEASE_VER}"
+git push origin release/v${RELEASE_VER}
+```
 
 > **Warning:** This publishes to Maven Central and Gradle Plugin Portal. Once published, a version cannot be unpublished from Maven Central.
 
@@ -266,6 +344,7 @@ This single command publishes artifacts, pushes demo apps to standalone repos, v
 gh workflow run release.yml \
   --repo airbnb/viaduct \
   -f release_version=${RELEASE_VER} \
+  -f final=true \
   -F release_notes=@/tmp/release-v${RELEASE_VER}-changelog.md
 ```
 
@@ -284,7 +363,7 @@ The workflow runs these steps in sequence:
 4. **Verify demo apps** — confirms standalone repos build against published artifacts
 5. **Create release** — creates the `v${RELEASE_VER}` tag and publishes the GitHub release with your changelog
 
-### 8) Verify
+### 9) Verify
 
 After the workflow completes:
 
@@ -321,6 +400,8 @@ A passing build confirms the published artifacts are resolvable and the demo app
 | `bumpSnapshotVersion` | Inserts/replaces `-rc.XXXX` in a SNAPSHOT version, syncs demo apps |
 | `unbumpSnapshotVersion` | Removes the `-rc.XXXX` marker from a SNAPSHOT version, syncs demo apps |
 
+`bumpSnapshotVersion` / `unbumpSnapshotVersion` are only for ephemeral SNAPSHOT publication testing. Public release candidates use explicit versions like `X.Y.Z-rc.N`.
+
 ## Troubleshooting
 
 ### `validate_release_state.py` not found
@@ -350,9 +431,20 @@ The release branch must exist before triggering `release.yml`. Create it in Step
 
 The version has already been released. If this was a mistake, contact the team before proceeding.
 
+### `release.yml` preflight fails — invalid RC/final inputs
+
+Exactly one mode must be selected:
+
+- **RC publication:** pass `release_version=X.Y.Z` and `rc_ver=rc.N`
+- **Final release:** pass `release_version=X.Y.Z` and `final=true`
+
 ### Publication fails partway through
 
 If `release.yml` fails after some artifacts are published (e.g., Plugin Portal succeeded but Maven Central failed), you can re-run the workflow. The Plugin Portal steps check for existing versions and skip them automatically. Maven Central and tagging are idempotent on retry.
+
+### RC publication fails partway through
+
+If `release.yml` fails during an RC publication after publishing `${RELEASE_VER}-${RC_VER}`, do not reuse that RC version. Fix the issue, increment to the next RC version, and rerun the workflow.
 
 ### Demo app tests fail after push
 

--- a/.github/scripts/tests/test_validate_release_inputs.py
+++ b/.github/scripts/tests/test_validate_release_inputs.py
@@ -1,0 +1,74 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from validate_release_inputs import validate_release_inputs
+
+
+class TestValidateReleaseInputs(unittest.TestCase):
+
+    def test_rc_inputs_valid(self):
+        result = validate_release_inputs("1.2.3", "rc.1", False, "")
+        self.assertTrue(result["is_valid"])
+        self.assertEqual(result["publish_mode"], "rc")
+        self.assertEqual(result["published_version"], "1.2.3-rc.1")
+        self.assertEqual(result["source_ref"], "release/v1.2.3")
+        self.assertEqual(result["destination_branch"], "rc/v1.2.3-rc.1")
+        self.assertFalse(result["is_final"])
+
+    def test_final_inputs_valid(self):
+        result = validate_release_inputs("1.2.3", "", True, "notes")
+        self.assertTrue(result["is_valid"])
+        self.assertEqual(result["publish_mode"], "release")
+        self.assertEqual(result["published_version"], "1.2.3")
+        self.assertEqual(result["source_ref"], "release/v1.2.3")
+        self.assertEqual(result["destination_branch"], "main")
+        self.assertTrue(result["is_final"])
+
+    def test_release_version_must_be_semver_triplet(self):
+        result = validate_release_inputs("1.2", "rc.1", False, "")
+        self.assertFalse(result["is_valid"])
+        self.assertIn("X.Y.Z", result["validation_error"])
+
+    def test_cannot_pass_final_and_rc_ver(self):
+        result = validate_release_inputs("1.2.3", "rc.1", True, "notes")
+        self.assertFalse(result["is_valid"])
+        self.assertIn("either final=true or rc_ver", result["validation_error"])
+
+    def test_non_final_requires_rc_ver(self):
+        result = validate_release_inputs("1.2.3", "", False, "")
+        self.assertFalse(result["is_valid"])
+        self.assertIn("rc_ver is required", result["validation_error"])
+
+    def test_rc_ver_must_have_numeric_suffix(self):
+        result = validate_release_inputs("1.2.3", "rc", False, "")
+        self.assertFalse(result["is_valid"])
+        self.assertIn("rc.N", result["validation_error"])
+
+    def test_rc_ver_must_be_positive(self):
+        result = validate_release_inputs("1.2.3", "rc.0", False, "")
+        self.assertFalse(result["is_valid"])
+
+    def test_final_requires_release_notes(self):
+        result = validate_release_inputs("1.2.3", "", True, "")
+        self.assertFalse(result["is_valid"])
+        self.assertIn("release_notes are required", result["validation_error"])
+
+    def test_input_whitespace_is_trimmed(self):
+        result = validate_release_inputs(" 1.2.3 ", " rc.2 ", False, " ")
+        self.assertTrue(result["is_valid"])
+        self.assertEqual(result["published_version"], "1.2.3-rc.2")
+
+    def test_output_is_json_serializable(self):
+        result = validate_release_inputs("1.2.3", "rc.1", False, "")
+        parsed = json.loads(json.dumps(result))
+        self.assertEqual(parsed["published_version"], "1.2.3-rc.1")
+        self.assertIsInstance(parsed["is_valid"], bool)
+        self.assertIsInstance(parsed["is_final"], bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_validate_release_state.py
+++ b/.github/scripts/tests/test_validate_release_state.py
@@ -44,6 +44,12 @@ class TestValidateReleaseState(unittest.TestCase):
         self.assertFalse(result["is_valid"])
         self.assertIn("exactly", result["validation_error"])
 
+    def test_release_branch_rc_mode_exact_rc_version_valid(self):
+        """release/v0.27.0 branch + 0.27.0-rc.1 + rc mode → valid"""
+        result = validate_release_state("rc", "release/v0.27.0", "0.27.0-rc.1", _TAG)
+        self.assertTrue(result["is_valid"])
+        self.assertTrue(result["is_release_branch"])
+
     def test_release_branch_rc_snapshot_mode_valid(self):
         """release/v0.27.0 branch + 0.27.0-rc.1-SNAPSHOT + snapshot mode → valid"""
         result = validate_release_state("snapshot", "release/v0.27.0", "0.27.0-rc.1-SNAPSHOT", _TAG)
@@ -131,6 +137,11 @@ class TestValidateReleaseState(unittest.TestCase):
         self.assertFalse(result["is_valid"])
         self.assertIn("release/vX.Y.Z", result["validation_error"])
 
+    def test_feature_branch_rc_mode_invalid(self):
+        result = validate_release_state("rc", "feature/foo", "0.27.0-rc.1", _TAG)
+        self.assertFalse(result["is_valid"])
+        self.assertIn("release/vX.Y.Z", result["validation_error"])
+
     def test_develop_branch_release_mode_invalid(self):
         result = validate_release_state("release", "develop", "0.27.0", _TAG)
         self.assertFalse(result["is_valid"])
@@ -145,6 +156,27 @@ class TestValidateReleaseState(unittest.TestCase):
     def test_rc_version_snapshot_mode_valid(self):
         result = validate_release_state("snapshot", "release/v0.27.0", "0.27.0-rc.2-SNAPSHOT", _TAG)
         self.assertTrue(result["is_valid"])
+
+    def test_rc_version_rc_mode_valid(self):
+        result = validate_release_state("rc", "release/v0.27.0", "0.27.0-rc.2", _TAG)
+        self.assertTrue(result["is_valid"])
+
+    def test_rc_version_rc_mode_missing_numeric_suffix_invalid(self):
+        result = validate_release_state("rc", "release/v0.27.0", "0.27.0-rc", _TAG)
+        self.assertFalse(result["is_valid"])
+        self.assertIn("rc.N", result["validation_error"])
+
+    def test_rc_version_rc_mode_zero_suffix_invalid(self):
+        result = validate_release_state("rc", "release/v0.27.0", "0.27.0-rc.0", _TAG)
+        self.assertFalse(result["is_valid"])
+
+    def test_release_version_rc_mode_invalid(self):
+        result = validate_release_state("rc", "release/v0.27.0", "0.27.0", _TAG)
+        self.assertFalse(result["is_valid"])
+
+    def test_snapshot_version_rc_mode_invalid(self):
+        result = validate_release_state("rc", "release/v0.27.0", "0.27.0-SNAPSHOT", _TAG)
+        self.assertFalse(result["is_valid"])
 
     def test_rc_version_without_snapshot_suffix_release_mode_invalid(self):
         """0.27.0-rc.1 is not a valid release version"""

--- a/.github/scripts/validate_release_inputs.py
+++ b/.github/scripts/validate_release_inputs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Validate and derive release workflow inputs for RC and final publications.
+
+Usage:
+    python3 validate_release_inputs.py --release-version 1.2.3 --rc-ver rc.1 --final false
+    python3 validate_release_inputs.py --release-version 1.2.3 --final true --release-notes "..."
+
+Exit codes:
+    0 - script completed; inspect is_valid in output
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+_RELEASE_VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+_RC_VER_PATTERN = re.compile(r"^rc\.[1-9]\d*$")
+
+
+def validate_release_inputs(
+    release_version: str,
+    rc_ver: str,
+    final: bool,
+    release_notes: str,
+) -> dict:
+    """
+    Pure validation and derivation for release workflow inputs.
+
+    Returns:
+        dict with keys:
+            publish_mode (str): "rc" or "release"
+            published_version (str): X.Y.Z-rc.N or X.Y.Z
+            source_ref (str): release/vX.Y.Z
+            destination_branch (str): rc/vX.Y.Z-rc.N or main
+            is_final (bool): whether this is a final release flow
+            is_valid (bool): whether validation succeeded
+            validation_error (str): human-readable error string, or ""
+    """
+    release_version = release_version.strip()
+    rc_ver = rc_ver.strip()
+    release_notes = release_notes.strip()
+
+    result = {
+        "publish_mode": "",
+        "published_version": "",
+        "source_ref": "",
+        "destination_branch": "",
+        "is_final": False,
+        "is_valid": True,
+        "validation_error": "",
+    }
+
+    if not _RELEASE_VERSION_PATTERN.fullmatch(release_version):
+        result["is_valid"] = False
+        result["validation_error"] = (
+            f"release_version must be 'X.Y.Z', got '{release_version}'"
+        )
+        return result
+
+    if final and rc_ver:
+        result["is_valid"] = False
+        result["validation_error"] = "Pass either final=true or rc_ver, not both."
+        return result
+
+    if not final and not rc_ver:
+        result["is_valid"] = False
+        result["validation_error"] = (
+            "For non-final publication, rc_ver is required (example: rc.1)."
+        )
+        return result
+
+    if rc_ver and not _RC_VER_PATTERN.fullmatch(rc_ver):
+        result["is_valid"] = False
+        result["validation_error"] = (
+            f"rc_ver must look like 'rc.N' with N >= 1, got '{rc_ver}'"
+        )
+        return result
+
+    if final and not release_notes:
+        result["is_valid"] = False
+        result["validation_error"] = "release_notes are required when final=true."
+        return result
+
+    source_ref = f"release/v{release_version}"
+    if rc_ver:
+        result.update({
+            "publish_mode": "rc",
+            "published_version": f"{release_version}-{rc_ver}",
+            "source_ref": source_ref,
+            "destination_branch": f"rc/v{release_version}-{rc_ver}",
+            "is_final": False,
+        })
+    else:
+        result.update({
+            "publish_mode": "release",
+            "published_version": release_version,
+            "source_ref": source_ref,
+            "destination_branch": "main",
+            "is_final": True,
+        })
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate and derive release workflow inputs."
+    )
+    parser.add_argument(
+        "--release-version",
+        required=True,
+        help="Base release version in X.Y.Z format",
+    )
+    parser.add_argument(
+        "--rc-ver",
+        default="",
+        help="RC suffix only, like rc.1",
+    )
+    parser.add_argument(
+        "--final",
+        required=True,
+        choices=["true", "false"],
+        help="Whether this is a final release flow",
+    )
+    parser.add_argument(
+        "--release-notes",
+        default="",
+        help="Release notes body for final releases",
+    )
+    args = parser.parse_args()
+
+    result = validate_release_inputs(
+        release_version=args.release_version,
+        rc_ver=args.rc_ver,
+        final=args.final == "true",
+        release_notes=args.release_notes,
+    )
+
+    print(json.dumps(result, indent=2))
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            for key, value in result.items():
+                out = json.dumps(value) if isinstance(value, bool) else value
+                f.write(f"{key}={out}\n")
+
+    if result["is_valid"]:
+        print(
+            f"✅ Valid: {result['publish_mode']} publication for "
+            f"'{result['published_version']}' from '{result['source_ref']}'",
+            file=sys.stderr,
+        )
+    else:
+        print(f"❌ Invalid: {result['validation_error']}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/validate_release_state.py
+++ b/.github/scripts/validate_release_state.py
@@ -8,6 +8,7 @@ JSON consumable by GitHub Actions workflows via fromJSON().
 
 Usage:
     python3 validate_release_state.py --mode snapshot
+    python3 validate_release_state.py --mode rc --branch release/v0.27.0
     python3 validate_release_state.py --mode release --branch release/v0.27.0
     python3 validate_release_state.py --mode snapshot --branch main --version-file VERSION
 
@@ -27,6 +28,11 @@ from pathlib import Path
 from typing import Optional
 
 _RELEASE_BRANCH_PATTERN = re.compile(r"^release/v(\d+\.\d+\.\d+)$")
+
+
+def _is_rc_version_for_base(version: str, base: str) -> bool:
+    """True if version is exactly base-rc.N where N is a positive integer."""
+    return re.fullmatch(rf"{re.escape(base)}-rc\.[1-9]\d*", version) is not None
 
 
 def _find_version_file(start_dir: Path) -> Path:
@@ -75,7 +81,7 @@ def validate_release_state(mode: str, branch: str, version_content: str, snapsho
     Pure validation function — no I/O, no subprocess, no side effects.
 
     Args:
-        mode: "snapshot" or "release"
+        mode: "snapshot", "rc", or "release"
         branch: git branch name (e.g. "main", "release/v0.27.0", "feature/foo")
         version_content: raw content of the VERSION file (trailing whitespace is stripped)
         snapshot_tag: pre-generated snapshot tag (e.g. from _make_snapshot_tag())
@@ -113,6 +119,15 @@ def validate_release_state(mode: str, branch: str, version_content: str, snapsho
                     f"Release mode requires VERSION to be exactly '{base_release_version}', "
                     f"but got '{effective_version}'"
                 )
+        elif mode == "rc":
+            # RC mode: VERSION must be exactly X.Y.Z-rc.N
+            if not _is_rc_version_for_base(effective_version, base_release_version):
+                is_valid = False
+                validation_error = (
+                    f"RC mode requires VERSION to be exactly "
+                    f"'{base_release_version}-rc.N' (for example '{base_release_version}-rc.1'), "
+                    f"but got '{effective_version}'"
+                )
         elif mode == "snapshot":
             # Snapshot mode on release branch: VERSION must end with -SNAPSHOT
             if not effective_version.endswith("-SNAPSHOT"):
@@ -127,6 +142,12 @@ def validate_release_state(mode: str, branch: str, version_content: str, snapsho
             is_valid = False
             validation_error = (
                 f"Release mode requires a 'release/vX.Y.Z' branch, "
+                f"but current branch is '{branch}'"
+            )
+        elif mode == "rc":
+            is_valid = False
+            validation_error = (
+                f"RC mode requires a 'release/vX.Y.Z' branch, "
                 f"but current branch is '{branch}'"
             )
         elif mode == "snapshot":
@@ -155,8 +176,8 @@ def main() -> int:
     parser.add_argument(
         "--mode",
         required=True,
-        choices=["snapshot", "release"],
-        help="Publication mode: 'snapshot' or 'release'",
+        choices=["snapshot", "rc", "release"],
+        help="Publication mode: 'snapshot', 'rc', or 'release'",
     )
     parser.add_argument(
         "--branch",

--- a/.github/workflows/check-published-demoapps.yml
+++ b/.github/workflows/check-published-demoapps.yml
@@ -7,11 +7,20 @@ on:
         description: "Branch in viaduct-dev/* repos to test (NOT an airbnb/viaduct ref)"
         required: true
         type: string
+      use_snapshot_repo:
+        description: "If true, include the Maven Central snapshots repository during resolution"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       ref:
         required: true
         type: string
+      use_snapshot_repo:
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -48,6 +57,6 @@ jobs:
       - name: Test ${{ matrix.demoapp }}
         working-directory: app
         env:
-          USE_VIADUCT_SNAPSHOT_REPO: ${{ inputs.ref != 'main' && 'true' || 'false' }}
+          USE_VIADUCT_SNAPSHOT_REPO: ${{ inputs.use_snapshot_repo && 'true' || 'false' }}
         run: ./gradlew test --no-daemon
         shell: bash

--- a/.github/workflows/check-published-demoapps.yml
+++ b/.github/workflows/check-published-demoapps.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       use_snapshot_repo:
-        description: "If true, include the Maven Central snapshots repository during resolution"
+        description: "Include the Maven Central snapshots repository during resolution (required for non-release branches that publish SNAPSHOT artifacts)"
         required: false
         default: false
         type: boolean

--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -106,6 +106,7 @@ jobs:
     uses: ./.github/workflows/check-published-demoapps.yml
     with:
       ref: ${{ needs.push-demoapps.outputs.destination_branch }}
+      use_snapshot_repo: true
 
   # ---------------------------------------------------------------------------
   # Alert on failure — post to Slack and Discord

--- a/.github/workflows/e2e-snapshot-test.yml
+++ b/.github/workflows/e2e-snapshot-test.yml
@@ -82,3 +82,4 @@ jobs:
     uses: ./.github/workflows/check-published-demoapps.yml
     with:
       ref: ${{ needs.push-demoapps.outputs.destination_branch }}
+      use_snapshot_repo: true

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -83,14 +83,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          path: tooling
+
+      - uses: actions/checkout@v6
+        with:
           ref: ${{ inputs.ref }}
+          path: source
 
       - name: Validate branch and version state
         id: validate
+        working-directory: tooling
         run: |
           python3 .github/scripts/validate_release_state.py \
             --mode "${{ inputs.mode }}" \
-            --branch "${{ inputs.ref }}"
+            --branch "${{ inputs.ref }}" \
+            --version-file ../source/VERSION
         shell: bash
 
   confirm-versions:

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Publication mode: snapshot or release"
+        description: "Publication mode: snapshot, rc, or release"
         required: true
         type: choice
         options:
           - snapshot
+          - rc
           - release
       ref:
         description: "Git ref to checkout and publish"
@@ -134,7 +135,7 @@ jobs:
       && (needs.confirm-versions.result == 'success' || needs.confirm-versions.result == 'skipped')
       && (needs.check.result == 'success' || needs.check.result == 'skipped')
     runs-on: ubuntu-latest
-    environment: ${{ inputs.mode == 'release' && 'release' || '' }}
+    environment: ${{ (inputs.mode == 'release' || inputs.mode == 'rc') && 'release' || '' }}
     outputs:
       source_sha: ${{ steps.sha.outputs.source_sha }}
     steps:
@@ -163,12 +164,11 @@ jobs:
           set -euo pipefail
           MODE="${{ inputs.mode }}"
 
-          if [ "$MODE" = "release" ]; then
-            echo "Publishing RELEASE artifacts..."
+          if [ "$MODE" = "release" ] || [ "$MODE" = "rc" ]; then
+            echo "Publishing ${MODE^^} artifacts..."
             export RELEASE=true
-            # Publish to Gradle Plugin Portal (release only)
+            # Publish to Gradle Plugin Portal and Maven Central for non-SNAPSHOT versions.
             ./gradlew gradle-plugins:publishPlugins --no-daemon --stacktrace
-            # Publish to Maven Central
             ./gradlew publishToMavenCentral --no-daemon --stacktrace
           else
             echo "Publishing SNAPSHOT artifacts..."

--- a/.github/workflows/push-demoapps.yml
+++ b/.github/workflows/push-demoapps.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: false
         type: boolean
+      destination_branch:
+        description: "Optional explicit destination branch in viaduct-dev repos"
+        required: false
+        type: string
   workflow_call:
     inputs:
       ref:
@@ -21,6 +25,9 @@ on:
         required: false
         default: false
         type: boolean
+      destination_branch:
+        required: false
+        type: string
     outputs:
       destination_branch:
         description: "Branch pushed to in viaduct-dev repos"
@@ -48,10 +55,13 @@ jobs:
         env:
           REF: ${{ inputs.ref }}
           RELEASE_MODE: ${{ inputs.release_mode }}
+          DESTINATION_BRANCH_OVERRIDE: ${{ inputs.destination_branch }}
         run: |
           set -euo pipefail
 
-          if [ "$REF" = "main" ]; then
+          if [ -n "$DESTINATION_BRANCH_OVERRIDE" ]; then
+            DEST_BRANCH="$DESTINATION_BRANCH_OVERRIDE"
+          elif [ "$REF" = "main" ]; then
             DEST_BRANCH="snapshot"
           elif [[ "$REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$RELEASE_MODE" = "true" ]; then
             DEST_BRANCH="main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         if: steps.validate.outputs.is_valid == 'true' && steps.validate.outputs.is_final == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: v${{ inputs.release_version }}
+          TAG: v${{ steps.validate.outputs.published_version }}
         run: |
           set -euo pipefail
           if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG}" --silent 2>/dev/null; then
@@ -198,10 +198,10 @@ jobs:
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/v${{ inputs.release_version }}',
+              ref: 'refs/tags/v${{ needs.preflight.outputs.published_version }}',
               sha: '${{ needs.publish.outputs.source_sha }}'
             })
-            console.log('✅ Created tag v${{ inputs.release_version }}')
+            console.log('✅ Created tag v${{ needs.preflight.outputs.published_version }}')
 
       - name: Publish GitHub release
         env:
@@ -209,10 +209,10 @@ jobs:
           RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           set -euo pipefail
-          gh release create "v${{ inputs.release_version }}" \
+          gh release create "v${{ needs.preflight.outputs.published_version }}" \
             --repo "${{ github.repository }}" \
-            --title "Release ${{ inputs.release_version }}" \
+            --title "Release ${{ needs.preflight.outputs.published_version }}" \
             --notes "$RELEASE_NOTES" \
             --latest
-          echo "✅ Published release v${{ inputs.release_version }}"
+          echo "✅ Published release v${{ needs.preflight.outputs.published_version }}"
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,56 +1,108 @@
 name: Release
-# Orchestrates a full Viaduct release: validate → publish → push demoapps → verify → tag → release.
-# This is THE release workflow. It delegates publication to publish-branch.yml and demoapp
-# distribution to push-demoapps.yml / check-published-demoapps.yml.
+# Orchestrates either a release candidate or a final Viaduct release.
+# RC flow: validate -> publish -> push RC demoapps -> verify.
+# Final flow: validate -> publish -> push demoapps -> verify -> tag -> GitHub release.
 
 on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release version (e.g., 1.0.0)'
+        description: 'Base release version (e.g., 1.0.0)'
         required: true
+        type: string
+      rc_ver:
+        description: "Optional RC suffix only (e.g., 'rc.1'). Leave empty for final releases."
+        required: false
+        type: string
+      final:
+        description: "Must be true for a final release. Leave false when publishing an RC."
+        required: false
+        default: false
+        type: boolean
       release_notes:
-        description: 'Release notes body (use gh -F release_notes=file.md to upload from file)'
-        required: true
+        description: 'Release notes body for final releases (use gh -F release_notes=@file.md to upload from file)'
+        required: false
         type: string
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.release_version }}-${{ inputs.rc_ver || 'final' }}
   cancel-in-progress: false  # never cancel a release mid-flight
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Pre-flight: verify release branch exists and tag does not
+  # Pre-flight: validate mode inputs, verify branch exists, and derive outputs
   # ---------------------------------------------------------------------------
   preflight:
     runs-on: ubuntu-latest
+    outputs:
+      publish_mode: ${{ steps.validate.outputs.publish_mode }}
+      published_version: ${{ steps.validate.outputs.published_version }}
+      source_ref: ${{ steps.validate.outputs.source_ref }}
+      destination_branch: ${{ steps.validate.outputs.destination_branch }}
+      is_final: ${{ steps.validate.outputs.is_final }}
     steps:
-      - name: Verify release branch exists
+      - uses: actions/checkout@v6
+
+      - name: Validate inputs and derive release metadata
+        id: validate
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          RC_VER: ${{ inputs.rc_ver }}
+          FINAL: ${{ inputs.final }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           set -euo pipefail
-          BRANCH="release/v${{ inputs.release_version }}"
+          args=(--release-version "$RELEASE_VERSION")
+          args+=(--final "$FINAL")
+          if [ -n "$RC_VER" ]; then
+            args+=(--rc-ver "$RC_VER")
+          fi
+          if [ -n "$RELEASE_NOTES" ]; then
+            args+=(--release-notes "$RELEASE_NOTES")
+          fi
+          python3 .github/scripts/validate_release_inputs.py "${args[@]}"
+        shell: bash
+
+      - name: Fail if release inputs are invalid
+        if: steps.validate.outputs.is_valid != 'true'
+        env:
+          VALIDATION_ERROR: ${{ steps.validate.outputs.validation_error }}
+        run: |
+          set -euo pipefail
+          echo "::error::${VALIDATION_ERROR}"
+          exit 1
+        shell: bash
+
+      - name: Verify release branch exists
+        if: steps.validate.outputs.is_valid == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.validate.outputs.source_ref }}
+        run: |
+          set -euo pipefail
           if ! gh api "repos/${{ github.repository }}/branches/${BRANCH}" --silent 2>/dev/null; then
             echo "::error::Release branch '${BRANCH}' does not exist. Create it first."
             exit 1
           fi
           echo "✅ Release branch '${BRANCH}' exists."
+        shell: bash
 
       - name: Verify release tag does not exist
+        if: steps.validate.outputs.is_valid == 'true' && steps.validate.outputs.is_final == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: v${{ inputs.release_version }}
         run: |
           set -euo pipefail
-          TAG="v${{ inputs.release_version }}"
           if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG}" --silent 2>/dev/null; then
             echo "::error::Tag '${TAG}' already exists. This version has already been released."
             exit 1
           fi
           echo "✅ Tag '${TAG}' does not exist. Safe to proceed."
+        shell: bash
 
   # ---------------------------------------------------------------------------
   # Publish artifacts via publish-branch.yml (checks + Plugin Portal + Maven Central)
@@ -59,8 +111,8 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/publish-branch.yml
     with:
-      mode: release
-      ref: release/v${{ inputs.release_version }}
+      mode: ${{ needs.preflight.outputs.publish_mode }}
+      ref: ${{ needs.preflight.outputs.source_ref }}
       run_checks: true
       confirm_versions: true
     secrets: inherit
@@ -69,11 +121,12 @@ jobs:
   # Push demoapps to viaduct-dev/* standalone repos
   # ---------------------------------------------------------------------------
   push-demoapps:
-    needs: [publish]
+    needs: [preflight, publish]
     uses: ./.github/workflows/push-demoapps.yml
     with:
-      ref: release/v${{ inputs.release_version }}
-      release_mode: true
+      ref: ${{ needs.preflight.outputs.source_ref }}
+      release_mode: ${{ needs.preflight.outputs.is_final == 'true' }}
+      destination_branch: ${{ needs.preflight.outputs.destination_branch }}
     secrets: inherit
 
   # ---------------------------------------------------------------------------
@@ -82,12 +135,12 @@ jobs:
   # newly-published version even though publish succeeded.
   # ---------------------------------------------------------------------------
   wait-for-new-artifacts:
-    needs: [push-demoapps]
+    needs: [preflight, push-demoapps]
     runs-on: ubuntu-latest
     steps:
-      - name: Probe Maven Central and Plugin Portal for ${{ inputs.release_version }}
+      - name: Probe Maven Central and Plugin Portal for ${{ needs.preflight.outputs.published_version }}
         env:
-          VERSION: ${{ inputs.release_version }}
+          VERSION: ${{ needs.preflight.outputs.published_version }}
         run: |
           set -euo pipefail
           URLS=(
@@ -126,13 +179,15 @@ jobs:
     needs: [push-demoapps, wait-for-new-artifacts]
     uses: ./.github/workflows/check-published-demoapps.yml
     with:
-      ref: main
+      ref: ${{ needs.push-demoapps.outputs.destination_branch }}
+      use_snapshot_repo: false
 
   # ---------------------------------------------------------------------------
   # Create tag and publish GitHub release
   # ---------------------------------------------------------------------------
   create-release:
-    needs: [publish, verify-demoapps]
+    needs: [preflight, publish, verify-demoapps]
+    if: needs.preflight.outputs.is_final == 'true'
     runs-on: ubuntu-latest
     environment: release
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Releases are listed [here](https://github.com/airbnb/viaduct/releases).
 
 ## Who is responsible for a release?
 
-Releases are performed by maintainers according to the [RELEASE-RUNBOOK.md](RELEASE-RUNBOOK.md).  The release process requires permissions only held by maintainers.  If you are an external contributor and would like to help with a release, please reach out to the core team via a GitHub discussion.
+Releases are performed by maintainers according to the [release runbook](.github/impldocs/release-runbook.md). The release process requires permissions only held by maintainers. If you are an external contributor and would like to help with a release, please reach out to the core team via a GitHub discussion.
 
 ## Versioning
 

--- a/impldocs/e2e-snapshot-test.md
+++ b/impldocs/e2e-snapshot-test.md
@@ -14,7 +14,7 @@ The process has the following steps:
 ## Prerequisites
 
 - Permission to create branches in `https://github.com/airbnb/viaduct` (the `origin` remote)
-- Local clone of the Viaduct repo with two remotes: `origin` pointing to `airbnb/viaduct` and `fork` pointing to your personal fork (see RELEASE-RUNBOOK.md for setup)
+- Local clone of the Viaduct repo with two remotes: `origin` pointing to `airbnb/viaduct` and `fork` pointing to your personal fork (see [.github/impldocs/release-runbook.md](../.github/impldocs/release-runbook.md) for setup)
 - `gh` CLI installed and authenticated
 
 ## Detailed Steps


### PR DESCRIPTION
## Summary

This PR adds a public RC publication path for Viaduct releases while keeping final releases on the existing `release.yml` entrypoint.

The Python validation helpers now distinguish `snapshot`, `rc`, and final `release` publication modes. The GitHub Actions release flow now supports either `release_version=X.Y.Z` with `rc_ver=rc.N` for RC publication or `release_version=X.Y.Z` with `final=true` for the final release. RC publications publish to Maven Central and the Gradle Plugin Portal, push demoapps to `rc/vX.Y.Z-rc.N`, and verify those published artifacts without creating a tag or GitHub release.

This PR also moves the maintainer release runbook to `.github/impldocs/release-runbook.md` and updates the linked implementation docs to reflect the RC flow and the new `release.yml` inputs.

## Documentation

Developer docs updated.

## How was it validated?

* New tests added for `validate_release_inputs.py`.
* `python3 .github/scripts/tests/test_validate_release_inputs.py` -- 10 pass
* `python3 .github/scripts/tests/test_validate_release_state.py` -- 44 pass
* `actionlint .github/workflows/check-published-demoapps.yml .github/workflows/demoapps-nightly-check.yml .github/workflows/e2e-snapshot-test.yml .github/workflows/publish-branch.yml .github/workflows/push-demoapps.yml .github/workflows/release.yml` -- pass
* `git diff --check` -- pass

Co-Authored-By: Codex <noreply@openai.com>
