### PR TITLE
docs: second pass on reviewer feedback

### DIFF
--- a/docs/docs/docs/developers/viaduct_api/index.md
+++ b/docs/docs/docs/developers/viaduct_api/index.md
@@ -166,7 +166,7 @@ Typical usage:
 import viaduct.service.api.SchemaId
 
 suspend fun handleRequest(viaduct: Viaduct, input: ExecutionInput): Map<String, Any?> {
-  val result = viaduct.executeAsync(input, SchemaId.Full).await() 
+  val result = viaduct.executeAsync(input, SchemaId.Full).await()
   return result.toSpecification()
 }
 
@@ -205,10 +205,12 @@ val response = result.toSpecification()
 #### Data vs Errors
 
 GraphQL supports **partial results**:
+
 - A nullable field can error and become `null` while siblings still resolve.
 - Errors in non-nullable fields may bubble up and null out parents.
 
 You should:
+
 - Always serialize both `"data"` (possibly `null`) and `"errors"` when errors exist.
 - Treat `errors.isNotEmpty()` as “something went wrong” even if data exists.
 
@@ -227,6 +229,7 @@ if (scopes == null) {
 }
 ```
 
-**Semantics**
+#### Semantics
+
 - Returns `null` when no scopes are configured for the schema.
 - Returns the set of scope IDs applied to the schema when it is scoped.

--- a/docs/docs/getting_started/extending/index.md
+++ b/docs/docs/getting_started/extending/index.md
@@ -4,11 +4,11 @@ description: Learn how to add new functionality to your Viaduct application
 ---
 
 
-Let's explore our sample application more deeply by extending its functionality. Viaduct is a "schema first" GraphQL environment, meaning you write your schema first, and then generate classes to write your code against.
+Let's extend our sample application to tie its two existing fields together. Viaduct is a "schema first" GraphQL server, meaning you write your schema first, and then generate classes to write your code against.
 
 ## Extending the Schema
 
-Let's add a new field called `attributedGreeting`, which will attribute the greeting to its author. Open `schema.graphqls` and extend it as follows:
+The starter ships with two unrelated `Query` fields, `greeting` and `author`. We'll add a third field, `attributedGreeting`, that combines them — giving us a chance to see how a resolver reads sibling fields and how Viaduct generates code for object types. Open `schema.graphqls` and extend it as follows:
 
 ```graphql
 extend type Query {
@@ -22,10 +22,9 @@ type AttributedGreeting {
 }
 ```
 
-There's no practical reason to have the `AttributedGreeting` type here: `attributedGreeting` could've just been a `String`. We're using a GraphQL object-type here in order to demonstrate some features of our API.
+We're modeling `attributedGreeting` as an object type rather than a plain `String` so the example exercises Viaduct's generated builder and `getX()` helpers (the GraphQL Representational Types, or GRTs, covered later on this page).
 
-
-This will regenerate the code needed to build your application. Viaduct generates Kotlin classes and interfaces that correspond to your GraphQL types, making it type-safe to work with your schema.
+> **Codegen tip:** the next section references generated classes like `QueryResolvers.AttributedGreeting` and `AttributedGreeting.Builder` that don't exist yet. Run `./gradlew build` (or your IDE's Gradle task) so the codegen step produces them; otherwise your IDE will show red squiggles.
 
 ## Writing the Resolver
 
@@ -79,7 +78,7 @@ val greeting = ctx.objectValue.getGreeting()
 val author = ctx.objectValue.getAuthor()
 ```
 
-The resolver can access the values of `greeting` and `author` through the `Context` object. These values are computed by their respective resolvers before this resolver runs.
+`ctx` is the per-resolver execution context — it gives you access to the parent object, arguments, and request-scoped utilities. Inside a `Query` field resolver, `ctx.objectValue` represents the `Query` root, so `getGreeting()` and `getAuthor()` return the values produced by the sibling `GreetingResolver` and `AuthorResolver`. Viaduct ensures those run before this resolver because the `@Resolver` annotation declared a dependency on them.
 
 ### Building the Result
 
@@ -135,4 +134,4 @@ You should see the appropriate response with the author attribution!
 
 **Documentation.** Explore our [full documentation site](../../index.md).
 
-**Building your own application.** Pick the structure that you like best—single project, two project (root plus one module), or multi-module. Make a copy of the respective demo app (CLI, Spring, or StarWars) and customize it for your needs.
+**Building your own application.** Pick the structure that fits your project — single project, two-project (root plus one module), or multi-module — and start from one of the [starter applications](../setup/clone/index.md) (CLI, Spring, or StarWars). Customize the schema, resolvers, and any wiring you need.

--- a/docs/docs/getting_started/index.md
+++ b/docs/docs/getting_started/index.md
@@ -5,6 +5,24 @@ description: Set up your first Viaduct application
 
 This section will guide you through setting up your first Viaduct tenant and understanding the core concepts of Viaduct. You'll start by configuring your development environment—either by cloning an existing tenant or creating one from scratch—then take a tour of the codebase structure. The Star Wars tutorial walks you through building a complete GraphQL API, covering schemas, resolvers, directives, mutations, and testing. By the end of this section, you'll have a working Viaduct tenant and the foundational knowledge to build and extend your own GraphQL servers.
 
+## How a request flows through Viaduct
+
+```mermaid
+flowchart LR
+    Client(["GraphQL client"]) -->|HTTP| Service["Embedding service<br/>(your web server)"]
+    Service -->|ExecutionInput| Viaduct["viaduct.service.api.Viaduct"]
+    Viaduct --> Engine["Engine<br/>(plan + execute)"]
+    Engine -->|invokes| Resolvers["Tenant resolvers<br/>node / field / batch"]
+    Resolvers -->|loads from| Backends[("Data sources<br/>DBs, services, caches")]
+    Backends --> Resolvers
+    Resolvers --> Engine
+    Engine --> Viaduct
+    Viaduct -->|ExecutionResult| Service
+    Service -->|HTTP response| Client
+```
+
+Your code touches three layers: the **embedding service** (a Spring/Ktor/CLI app that holds the `Viaduct` instance and routes HTTP), the **schema** that lists fields and `@resolver` directives, and the **resolvers** that produce the values. The engine plans the query, calls your resolvers in the right order, and assembles the response.
+
 ## Start here if you are…
 
 - **A tenant developer** writing GraphQL schema and resolvers — work through this Getting Started section, then keep the [Developers](../docs/developers/index.md) reference at hand.

--- a/docs/docs/getting_started/setup/clone/index.md
+++ b/docs/docs/getting_started/setup/clone/index.md
@@ -1,38 +1,34 @@
 ---
-title: Clone Approach
-description: Get by cloning a starter application
+title: Clone a Starter Application
+description: Get going by cloning the CLI starter, the simplest Viaduct starter application.
 ---
 
 
-This guide walks you through getting started with Viaduct by cloning one of our starter applications.
+This guide walks you through getting started with Viaduct by cloning the **CLI starter** — the smallest starter application. We use it because it's quick to clone, has no web framework to set up, and exercises the same core Viaduct APIs you'd use in a full server.
 
-## Getting Started
+## Run the CLI starter
 
-To get you started with Viaduct, we have created a number of small demonstration applications to illustrate what a Viaduct application is and how you write and build one. You can find these at [github.com/viaduct-dev](https://github.com/viaduct-dev). In particular, in order of complexity, we have a CLI starter, a Spring starter, and a more full-featured StarWars application.
-
-### Running the Application
-
-Start by making a local clone of the [CLI starter](https://github.com/viaduct-dev/cli-starter):
+Make a local clone of the [CLI starter](https://github.com/viaduct-dev/cli-starter):
 
 ```shell
 git clone https://github.com/viaduct-dev/cli-starter.git
 ```
 
-Next, `cd` into that clone and test that your environment is ready by typing:
+`cd` into the clone and verify your environment:
 
 ```shell
 ./gradlew test
 ```
 
-After building and testing the CLI demo, Gradle should report that the build was successful.
+Gradle should report that the build was successful.
 
-Although Viaduct is typically hosted in a web server, to keep things simple the CLI demo calls it directly from the application's main function. You can do this through Gradle:
+Although Viaduct is typically hosted in a web server, the CLI starter calls it directly from the application's `main` function so the example stays small. Run a query through Gradle:
 
 ```shell
 ./gradlew -q run --args="'{ greeting }'"
 ```
 
-Here is the full schema for this simple application:
+The starter ships with a tiny schema:
 
 ```graphql
 type Query {
@@ -41,7 +37,19 @@ type Query {
 }
 ```
 
-Through the command line you can issue any query against this schema.
+Any query that's valid against this schema can be passed via `--args`.
+
+## Other starter applications
+
+Besides the CLI starter, [github.com/viaduct-dev](https://github.com/viaduct-dev) hosts several framework-specific starters:
+
+- [`cli-starter`](https://github.com/viaduct-dev/cli-starter) — the smallest one; covered above.
+- [`ktor-starter`](https://github.com/viaduct-dev/ktor-starter) — a Ktor-based HTTP server.
+- [`jetty-starter`](https://github.com/viaduct-dev/jetty-starter) — a Jetty-based HTTP server.
+- [`micronaut-starter`](https://github.com/viaduct-dev/micronaut-starter) — a Micronaut-based HTTP server.
+- [`starwars`](https://github.com/viaduct-dev/starwars) — a fuller demonstration application built on Spring Boot, exercising most Viaduct features. The [Star Wars tutorial](../../starwars/index.md) walks through it.
+
+Pick the one that matches your target framework. Each repo's README has its own setup steps.
 
 ## What's Next
 

--- a/docs/docs/getting_started/setup/index.md
+++ b/docs/docs/getting_started/setup/index.md
@@ -14,13 +14,14 @@ description: Set up your first Viaduct application
 
 Viaduct is compatible with the following versions:
 
+- **Language**: Kotlin (tenant code is written in Kotlin; Java tenants are not yet supported).
 - **Java**: 17+
 - **Gradle**: 8.10+ (Gradle 9.1.0+ supported with Kotlin 2.0+)
 - **Kotlin**: Use a Kotlin version compatible with your Gradle version.
     - Gradle 8.x: Kotlin 1.9.x or 2.x
     - Gradle 9.x: Kotlin 2.0+
 
-> **Note**: When setting up a new project, choose Gradle and Kotlin versions that are compatible with each other. Refer to the [Gradle-Kotlin compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html#kotlin) for guidance.
+> **Note**: Choose Gradle and Kotlin versions that are compatible with each other — the [Gradle-Kotlin compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html#kotlin) is the authoritative reference.
 
 ## Choose Your Approach
 

--- a/docs/docs/getting_started/starwars/core/resolver_integrations.md
+++ b/docs/docs/getting_started/starwars/core/resolver_integrations.md
@@ -7,6 +7,19 @@ description: How node and field resolvers work together in Viaduct.
 Resolvers in Viaduct form a **layered model** that separates entity retrieval from per-field computation. Node, field,
 and batch field resolvers each play a distinct role but integrate seamlessly during execution.
 
+```mermaid
+flowchart TD
+    Query["GraphQL query<br/>(planned by the engine)"] --> Node["Node resolver layer<br/>fetch entities by Global ID"]
+    Query --> Field["Field resolver layer<br/>compute / format derived values"]
+    Query --> Batch["Batch resolver layer<br/>aggregate / load relationships in bulk"]
+    Node --> Response["Assembled GraphQL response"]
+    Field --> Response
+    Batch --> Response
+```
+
+Each layer has a single responsibility: nodes fetch, fields compute, batch resolvers aggregate. Tenants compose them
+freely — a single query typically passes through all three.
+
 ## Standard entity pattern
 
 Each entity type can typically implement:
@@ -16,14 +29,14 @@ Each entity type can typically implement:
 {{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/characters/resolvers/CharacterNodeResolver.kt", "node_resolver_example", lang="kotlin") }}
 
 
-2. **Batch field resolvers** for expensive computed fields that benefit from batching.
-
-{{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/characters/resolvers/CharacterFilmCountResolver.kt", "film_count_batch_resolver", lang="kotlin") }}
-
-
-3. **Single field resolvers** for lightweight computed or derived values.
+2. **Single field resolvers** for lightweight computed or derived values.
 
 {{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/characters/resolvers/CharacterDisplayNameResolver.kt", "resolver_example", lang="kotlin") }}
+
+
+3. **Batch field resolvers** for expensive computed fields that benefit from batching.
+
+{{ codetag("demoapps/starwars/modules/filmography/src/main/kotlin/com/example/starwars/modules/filmography/characters/resolvers/CharacterFilmCountResolver.kt", "film_count_batch_resolver", lang="kotlin") }}
 
 
 ## The entity resolution flow

--- a/docs/docs/getting_started/starwars/directives/index.md
+++ b/docs/docs/getting_started/starwars/directives/index.md
@@ -4,18 +4,15 @@ description: Learn about custom directives like @backingData, @scope, @idOf, @on
 ---
 
 
-Custom directives in Viaduct enhance your GraphQL schema with extra behavior and validation. This page introduces the
-directives used in the Star Wars demo and links to focused pages for details and examples.
+Custom directives in Viaduct enhance your GraphQL schema with extra behavior and validation. A **custom directive** is a schema annotation that Viaduct interprets at planning or execution time — they let you express resolver hints, identity types, and visibility rules without writing extra Kotlin. This page introduces the directives used in the Star Wars demo and links to focused pages for details and examples.
 
 ## What you will find here
 
-- **`@backingData`** — share pre-fetched data between sibling field resolvers to avoid duplicate calls.
-- **`@scope`** — expose types/fields only to specific scopes (multi-module boundaries).
-- **`@idOf`** — mark `ID` fields/args with their GraphQL type for type-safe Global ID handling.
-- **`@oneOf`** — enforce exactly one non-null field in an input object (union-like inputs).
-- **`@connection`** — mark object types as Relay Connection types for pagination.
-- **`@edge`** — mark object types as Relay Edge types within connections.
-
-> To access scoped fields, include the `X-Viaduct-Scopes` header in your request.
+- [`@backingData`](backing_data.md) — share pre-fetched data between sibling field resolvers to avoid duplicate calls.
+- [`@scope`](scope.md) — expose types/fields only to specific scopes (multi-module boundaries).
+- [`@idOf`](idof.md) — mark `ID` fields/args with their GraphQL type for type-safe Global ID handling.
+- [`@oneOf`](oneof.md) — enforce exactly one non-null field in an input object (union-like inputs).
+- [`@connection`](connection.md) — mark object types as Relay Connection types for pagination.
+- [`@edge`](edge.md) — mark object types as Relay Edge types within connections.
 
 

--- a/docs/docs/getting_started/starwars/index.md
+++ b/docs/docs/getting_started/starwars/index.md
@@ -1,5 +1,5 @@
 ---
-title: StarWars Demo Application
+title: Star Wars Demo Application
 description: Explore an advanced Viaduct application.
 ---
 
@@ -7,21 +7,25 @@ description: Explore an advanced Viaduct application.
 This application implements a comprehensive GraphQL API for the Star Wars universe, demonstrating how Viaduct handles
 complex data relationships, advanced resolver patterns, and sophisticated schema design.
 
+## Requirements
+
+- Java 17+ and `git` (see [Project Setup](../setup/index.md) for the full compatibility matrix).
+- A clone of [github.com/viaduct-dev/starwars](https://github.com/viaduct-dev/starwars). Read the repo's README for any framework-specific setup steps.
+
 ## What you'll find
 
-The StarWars demo showcases:
+The Star Wars demo showcases:
 
-- **Node Resolvers**: Direct object resolution patterns
-- **Field Resolvers**: Field-level data fetching strategies
-- **Batch Resolution**: Efficient bulk data loading techniques
-- **Mutations**: Modifying data through GraphQL mutations
-- **Variables Provider**: Dynamic variable injection and management
-- **Backing Data**: Using Kotlin objects as data sources in Viaduct
-- **Global ID System**: Viaduct's approach to unique entity identification across your schema grts
+- **[Global IDs](core/global_id.md)** — Viaduct's identity model and how `Node` types are referenced.
+- **[Node Resolvers](core/node_resolvers.md)** — direct object resolution by Global ID.
+- **[Field Resolvers](core/field_resolvers.md)** — field-level computation and lightweight lookups.
+- **[Batch Resolvers](core/batch_resolvers.md)** — efficient bulk data loading.
+- **[Resolver Integration Patterns](core/resolver_integrations.md)** — how the layers compose at execution time.
+- **[Mutations](mutations/index.md)** — modifying data through GraphQL mutations.
+- **[Variables](variables/index.md)** — dynamic variable provision.
+- **[Backing Data](directives/backing_data.md)** — sharing pre-fetched data between sibling resolvers via `@backingData`.
 
-## Getting the starwars application
-
-The StarWars application is available on GitHub at [github.com/viaduct-dev/starwars](https://github.com/viaduct-dev/starwars).
+## Getting the Star Wars application
 
 ```shell
 git clone https://github.com/viaduct-dev/starwars.git
@@ -37,12 +41,16 @@ Follow the instructions in the repository's README to build and run the applicat
 ./gradlew run
 ```
 
-After exploring the StarWars application, you'll have a solid understanding of how to build production-ready GraphQL
+After exploring the Star Wars application, you'll have a solid understanding of how to build production-ready GraphQL
 applications with Viaduct.
+
+## What's Next
+
+Continue to [Core Concepts](core/index.md) to walk through Viaduct's foundational building blocks as they appear in this demo.
 
 ## Related resources
 
-- [Viaduct Documentation](../)
+- [Viaduct Documentation](../../index.md)
 - [GitHub Repository](https://github.com/viaduct-dev)
 
 

--- a/docs/docs/getting_started/tour/index.md
+++ b/docs/docs/getting_started/tour/index.md
@@ -4,7 +4,7 @@ description: Understanding the structure of a Viaduct application
 ---
 
 
-Now that you have a running Viaduct application, let's explore its structure and understand how the pieces fit together.
+Now that you have a running Viaduct application, let's explore its structure and understand how the pieces fit together. The full source for the CLI starter lives at [github.com/viaduct-dev/cli-starter](https://github.com/viaduct-dev/cli-starter); we'll highlight the key files below.
 
 ## Project Structure
 
@@ -32,7 +32,7 @@ Here's what you'll see in the schema:
 {{ codetag("demoapps/cli-starter/src/main/viaduct/schema/schema.graphqls", "schema-config", lang="kotlin") }}
 
 
-Viaduct itself has built-in definitions for the root GraphQL types `Query` and `Mutation` (Viaduct doesn't yet support subscriptions). Since `Query` is built-in, application code should extend it as illustrated above.
+Viaduct itself has built-in definitions for the root GraphQL types `Query` and `Mutation`. Subscriptions are not yet supported; see the [roadmap](../../roadmap/index.md) for the current plan. Since `Query` is built-in, application code should extend it as illustrated above.
 
 You'll notice that both fields have `@resolver` applied to them, meaning that a developer-provided function is needed to compute their respective value. **All fields of `Query` must have `@resolver` applied to them.**
 
@@ -68,7 +68,7 @@ This sends the query to the Viaduct engine and waits for the result. Viaduct use
 
 ## Resolver Implementation
 
-**`HelloWorldResolvers.kt`** contains the "application logic" for our schema—the code that defines how to resolve the fields of the schema.
+**`HelloWorldResolvers.kt`** holds the resolver classes for this schema — each one provides the value-producing function for a field marked with `@resolver`.
 
 Each resolver is a class that extends a generated base class and overrides the `resolve` function:
 
@@ -93,7 +93,7 @@ You can see the two Viaduct plugins appearing here:
 
 - **`viaduct.module`**: This plugin indicates that the project contains application code (resolvers). One or more projects in your build can apply this plugin.
 
-Viaduct applications are structured as multi-project Gradle builds. As this example shows, a Viaduct application can be as simple as a single project build, in which case both plugins are applied to that one project.
+Viaduct applications are structured as multi-project Gradle builds. The CLI starter is the simplest case — a single project where both plugins are applied to the same module. Real-world applications usually split things up: one project applies `viaduct.application` and wires the runtime, and one or more sibling projects apply `viaduct.module` to contribute schema and resolvers (one Gradle module per **tenant**). The Star Wars demo's [Architecture section](../starwars/architecture/index.md) walks through that layout end-to-end.
 
 ## What's Next
 

--- a/docs/docs/stylesheets/brand.css
+++ b/docs/docs/stylesheets/brand.css
@@ -34,6 +34,11 @@
   background-color: #337985;
 }
 
+/* Tables — Material's default 0.64rem is hard to read in long prose */
+.md-typeset table:not([class]) {
+  font-size: 0.8rem;
+}
+
 /* Links */
 .md-typeset a {
   color: #337985;

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,7 +74,11 @@ markdown_extensions:
       toc_depth: 3
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -219,6 +219,30 @@
   margin-bottom: 0;
 }
 
+/* Community links row under the description banner */
+.mdx-description__community {
+  margin: 24px auto 0;
+  max-width: 800px;
+  text-align: center;
+  font-size: 0.95rem;
+  color: var(--md-typeset-color);
+  opacity: 0.85;
+}
+
+.mdx-description__community a {
+  color: var(--viaduct-secondary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.mdx-description__community a:hover {
+  text-decoration: underline;
+}
+
+[data-md-color-scheme="slate"] .mdx-description__community a {
+  color: var(--viaduct-primary);
+}
+
 /* Warning banner */
 .mdx-banner {
   max-width: 800px;
@@ -341,6 +365,39 @@
     <p>Viaduct provides you with one global schema and query system. Regardless of the engineering ownership or backing service, data access and mutations should follow a reliable and consistent pattern. The code which hydrates such queries should be maintained by the team which owns the data, to prevent the need to implement such logic by every team querying it.</p>
     <div class="mdx-banner">
       <p>The Viaduct engine is in production, at scale, at Airbnb where it has proven reliable. The developer API of Viaduct is under active development. In <a href="roadmap/">our roadmap</a> we indicate which parts of the API are more or less subject to future change. This is a good time to join the project and influence the direction that this API takes!</p>
+    </div>
+    <p class="mdx-description__community">
+      Get involved:
+      <a href="https://github.com/airbnb/viaduct/discussions">GitHub Discussions</a>
+      &middot;
+      <a href="https://discord.gg/v9gkcKMM">Contributor Discord</a>
+      &middot;
+      <a href="community/">Community page</a>
+    </p>
+  </div>
+</section>
+
+<section class="mdx-features mdx-features--why">
+  <div class="mdx-features__header">
+    <h2 class="mdx-features__title">Why Viaduct?</h2>
+    <p class="mdx-features__subtitle">What you get when many teams contribute to one GraphQL server</p>
+  </div>
+  <div class="mdx-features__grid">
+    <div class="mdx-feature">
+      <h3>One global schema</h3>
+      <p>Independent teams contribute schema and resolvers ("tenant modules") that compose into a single GraphQL surface clients can target — without forcing teams to share a codebase.</p>
+    </div>
+    <div class="mdx-feature">
+      <h3>Owners write the resolvers</h3>
+      <p>The team that owns the data writes the resolver that fetches it. Other teams query through the schema instead of reimplementing access logic, which keeps domain knowledge where it belongs.</p>
+    </div>
+    <div class="mdx-feature">
+      <h3>Performance by construction</h3>
+      <p>Batching, deduplication, and per-field dependency tracking are built into the engine, so the natural way to write a resolver is also the efficient way — N+1 patterns are hard to introduce.</p>
+    </div>
+    <div class="mdx-feature">
+      <h3>Type-safe identity</h3>
+      <p>Every cross-entity reference flows through a typed Global ID. References stay stable across storage changes, and resolvers consume them through generated, type-safe APIs instead of raw strings.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Follow-up to the prior reviewer-feedback pass, addressing the remaining items from feedback.md.

- Rewrite setup/clone page: retitle to "Clone a Starter Application", scope the walkthrough to the CLI starter, and add a curated list of the published viaduct-dev starter repos in place of the bare org link.
- Tour page: link to the cli-starter on GitHub, neutralize the "application logic" wording, point the subscriptions sentence at the roadmap, and expand the multi-project Gradle paragraph with a tenant framing and a forward link to Star Wars architecture.
- Star Wars index: add Requirements callout, link every "What you'll find" bullet to its destination, add a "What's Next" pointer, fix the "../" relative-link warning, and use "Star Wars" consistently.
- Directives index: turn each directive into a real link and add a one-line definition of "custom directive". Remove the trailing X-Viaduct-Scopes tip — it duplicates content on scope.md.
- Setup index: add a Language entry to Compatibility (Kotlin only; Java tenants not yet supported) and tighten the new-project note.
- Resolver Integrations: reorder "Standard entity pattern" so single field resolvers precede batch field resolvers, matching the rest of the docs.
- Enable Mermaid via pymdownx.superfences custom_fences, add a request-flow diagram on getting_started/index.md and a layered-model diagram on resolver_integrations.md.
- Home page: add a centered community links row (GitHub Discussions, Discord, Community page) under the description, plus a "Why Viaduct?" feature grid above the existing Core Values block.
- Bump default prose-table font from Material's 0.64rem to 0.8rem so long tables (e.g. resolver_integrations.md) read at body weight.
- Extending page rewrite: reframe the running example so attributedGreeting motivates the existing greeting+author fields, drop the "no practical reason" disclaimer and the copy-paste line, explain ctx, add a codegen callout for IDE squiggles, and link "Building your own application" back to the clone page.

## How was it tested?  What documentation was provided?

`mkdocs serve`