### PR TITLE
docs: indent subsections in doc navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,7 +37,7 @@ theme:
     - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky
-    - navigation.sections
+    - navigation.expand
     - navigation.top
     - navigation.footer
     - toc.follow


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI
      https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

<img width="692" height="844" alt="image" src="https://github.com/user-attachments/assets/6c5a1b85-9c41-4a37-bd64-88668bd91c43" />


## How was it tested?  What documentation was provided?

`mkdocs serve`