### PR TITLE
feat(changelog): Deduplicate cherry-picked commits in changelog generation

### DIFF
--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -180,6 +180,26 @@ def _has_pr_ref(description: str) -> bool:
     return bool(_PR_REF_RE.search(description))
 
 
+def _get_base_commit_keys(tag1: str, tag2: str) -> set[tuple[str, tuple[str, ...]]]:
+    """
+    Collect (normalized_description, authors) keys for commits unique to tag1
+    (reachable from tag1 but not tag2). These represent cherry-picks and
+    release-specific commits on the previous release branch.
+    """
+    keys: set[tuple[str, tuple[str, ...]]] = set()
+    for commit in get_commits_between_tags(tag2, tag1):
+        if not should_include_commit(commit.message):
+            continue
+        cleaned = clean_commit_message(commit.message)
+        cleaned = replace_airbnb_marker(cleaned, commit.sha)
+        description = strip_conventional_prefix(cleaned)
+        normalized = _normalize_for_dedup(description)
+        authors = tuple(sorted(extract_authors(commit)))
+        if normalized:
+            keys.add((normalized, authors))
+    return keys
+
+
 def dedupe_entries(entries: list[ChangelogEntry]) -> list[ChangelogEntry]:
     """
     Drop PR-merge entries that duplicate a SHA-tagged entry.
@@ -467,6 +487,13 @@ def generate_changelog(tag1: str, tag2: str) -> str:
         entry = parse_commit(commit, parser)
         if entry:
             entries.append(entry)
+
+    # Drop commits already delivered via cherry-pick on the previous release branch
+    base_keys = _get_base_commit_keys(tag1, tag2)
+    entries = [
+        e for e in entries
+        if (_normalize_for_dedup(e.description), tuple(sorted(e.authors))) not in base_keys
+    ]
 
     # Drop PR-merge duplicates of SHA-tagged entries (see dedupe_entries)
     entries = dedupe_entries(entries)

--- a/.github/scripts/tests/test_generate_changelog.py
+++ b/.github/scripts/tests/test_generate_changelog.py
@@ -24,6 +24,7 @@ from generate_changelog import (
     generate_changelog,
     capitalize_first,
     dedupe_entries,
+    _get_base_commit_keys,
     CommitInfo,
     ChangelogEntry,
     BOT_USERNAMES,
@@ -549,6 +550,91 @@ class TestCapitalizeFirst(unittest.TestCase):
         self.assertEqual(capitalize_first("(scope) fix"), "(scope) fix")
 
 
+class TestCherryPickDedup(unittest.TestCase):
+    """Tests for cherry-pick deduplication via _get_base_commit_keys."""
+
+    def _commit(self, sha, message, author_email="john.doe@example.com"):
+        return CommitInfo(
+            sha=sha, message=message, body="",
+            author_email=author_email, co_authors_raw="",
+        )
+
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_get_base_commit_keys_collects_normalized_keys(self, mock_get_commits):
+        mock_get_commits.return_value = iter([
+            self._commit("aaa111", "feat: add widget (AIRBNB)"),
+            self._commit("bbb222", "fix: parser crash (AIRBNB)"),
+        ])
+        keys = _get_base_commit_keys("origin/release/v1.0.0", "HEAD")
+        # Called with reversed args: get_commits_between_tags("HEAD", "origin/release/v1.0.0")
+        mock_get_commits.assert_called_once_with("HEAD", "origin/release/v1.0.0")
+        # Descriptions are normalized: conventional prefix stripped, trailing (sha) stripped
+        self.assertIn(("add widget", ("@john.doe",)), keys)
+        self.assertIn(("parser crash", ("@john.doe",)), keys)
+
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_get_base_commit_keys_skips_ignored_commits(self, mock_get_commits):
+        mock_get_commits.return_value = iter([
+            self._commit("aaa111", "ignore: test only"),
+            self._commit("bbb222", "feat: real change (AIRBNB)"),
+        ])
+        keys = _get_base_commit_keys("tag1", "tag2")
+        self.assertEqual(len(keys), 1)
+        self.assertIn(("real change", ("@john.doe",)), keys)
+
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_cherry_pick_filtered_from_changelog(self, mock_get_commits):
+        """A commit cherry-picked onto the prev release is excluded from the next changelog."""
+        base_cherry_pick = self._commit("aaa1111", "feat: add widget (AIRBNB)")
+        original_on_main = self._commit("bbb2222", "feat: add widget (AIRBNB)")
+        new_commit = self._commit("ccc3333", "feat: new thing (AIRBNB)")
+
+        def side_effect(tag1, tag2):
+            if tag1 == "HEAD" and tag2 == "origin/release/v1.0.0":
+                # Reverse range: commits unique to previous release branch
+                return iter([base_cherry_pick])
+            else:
+                # Forward range: commits in the new release
+                return iter([original_on_main, new_commit])
+
+        mock_get_commits.side_effect = side_effect
+        changelog = generate_changelog("origin/release/v1.0.0", "HEAD")
+        self.assertIn("New thing", changelog)
+        self.assertNotIn("Add widget", changelog)
+
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_cherry_pick_not_filtered_when_authors_differ(self, mock_get_commits):
+        """Same message but different author is NOT filtered (author protection)."""
+        base_cherry_pick = self._commit("aaa1111", "feat: add widget (AIRBNB)", author_email="alice@example.com")
+        original_on_main = self._commit("bbb2222", "feat: add widget (AIRBNB)", author_email="bob@example.com")
+
+        def side_effect(tag1, tag2):
+            if tag1 == "HEAD" and tag2 == "origin/release/v1.0.0":
+                return iter([base_cherry_pick])
+            else:
+                return iter([original_on_main])
+
+        mock_get_commits.side_effect = side_effect
+        changelog = generate_changelog("origin/release/v1.0.0", "HEAD")
+        self.assertIn("Add widget", changelog)
+
+    @patch("generate_changelog.get_commits_between_tags")
+    def test_cherry_pick_with_pr_ref_still_filtered(self, mock_get_commits):
+        """Cherry-pick on release has (AIRBNB), original on main has (#123) — still deduped."""
+        base_cherry_pick = self._commit("aaa1111", "feat: add widget (AIRBNB)")
+        original_on_main = self._commit("bbb2222", "feat: add widget (#123)")
+
+        def side_effect(tag1, tag2):
+            if tag1 == "HEAD" and tag2 == "origin/release/v1.0.0":
+                return iter([base_cherry_pick])
+            else:
+                return iter([original_on_main])
+
+        mock_get_commits.side_effect = side_effect
+        changelog = generate_changelog("origin/release/v1.0.0", "HEAD")
+        self.assertNotIn("Add widget", changelog)
+
+
 class TestGenerateChangelog(unittest.TestCase):
     def _commit(self, sha, message, author_email="john.doe@example.com", body="", co_authors_raw=""):
         return CommitInfo(
@@ -561,9 +647,12 @@ class TestGenerateChangelog(unittest.TestCase):
 
     @patch("generate_changelog.get_commits_between_tags")
     def test_omits_version_header(self, mock_get_commits):
-        mock_get_commits.return_value = iter([
-            self._commit("abc1234", "feat: add a thing"),
-        ])
+        def side_effect(tag1, tag2):
+            if tag1 == "HEAD" and tag2 == "v0.31.0":
+                return iter([])  # no cherry-picks on previous release
+            return iter([self._commit("abc1234", "feat: add a thing")])
+
+        mock_get_commits.side_effect = side_effect
         changelog = generate_changelog("v0.31.0", "HEAD")
         self.assertNotIn("# Version", changelog)
 


### PR DESCRIPTION
## Summary

When a release branch uses cherry-picks (rather than merge commits) to pull in fixes, the changelog script previously included those commits twice: once as the cherry-pick on the release branch, and once as the original on main. This happens because cherry-picks create new SHA objects, so git's reachability-based range (`prev_release..HEAD`) doesn't filter them out.

This PR adds a cherry-pick deduplication pass that computes the reverse range (`HEAD..prev_release`) to find commits unique to the previous release branch, normalizes their descriptions and authors, and filters matching entries from the changelog. The author tuple is included in the dedup key to avoid false positives when two different authors happen to write commits with identical subjects.

## How was it validated?

* 5 new tests added in `TestCherryPickDedup` covering: key collection, ignored-commit skipping, successful cherry-pick filtering, author-protection (different authors not filtered), and cross-format matching (`(AIRBNB)`/`(sha)` vs `(#NNN)`)
* Existing `TestGenerateChangelog` tests updated to account for the new `get_commits_between_tags` call
* Full test suite: 81 tests pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>