### PR TITLE
feat(scope): introduce SchemaScoping data class and DSL accumulation surface

### DIFF
--- a/core/service/api/api/api.api
+++ b/core/service/api/api/api.api
@@ -75,6 +75,25 @@ public final class viaduct/service/api/Viaduct$DefaultImpls {
 	public static synthetic fun executeAsync$default (Lviaduct/service/api/Viaduct;Lviaduct/service/api/ExecutionInput;Lviaduct/service/api/SchemaId;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class viaduct/service/api/scoping/SchemaScoping : java/io/Serializable {
+	public static final field CURRENT_VERSION Ljava/lang/String;
+	public static final field Companion Lviaduct/service/api/scoping/SchemaScoping$Companion;
+	public fun <init> (Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;)Lviaduct/service/api/scoping/SchemaScoping;
+	public static synthetic fun copy$default (Lviaduct/service/api/scoping/SchemaScoping;Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lviaduct/service/api/scoping/SchemaScoping;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getScopeUniverse ()Ljava/util/Set;
+	public final fun getScopedSchemas ()Ljava/util/Map;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isScoped ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class viaduct/service/api/spi/CodeInjector {
 	public static final field Companion Lviaduct/service/api/spi/CodeInjector$Companion;
 	public abstract fun getProvider (Ljava/lang/Class;)Ljavax/inject/Provider;

--- a/core/service/api/api/api.api
+++ b/core/service/api/api/api.api
@@ -75,25 +75,6 @@ public final class viaduct/service/api/Viaduct$DefaultImpls {
 	public static synthetic fun executeAsync$default (Lviaduct/service/api/Viaduct;Lviaduct/service/api/ExecutionInput;Lviaduct/service/api/SchemaId;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class viaduct/service/api/scoping/SchemaScoping : java/io/Serializable {
-	public static final field CURRENT_VERSION Ljava/lang/String;
-	public static final field Companion Lviaduct/service/api/scoping/SchemaScoping$Companion;
-	public fun <init> (Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Set;
-	public final fun component2 ()Ljava/util/Map;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;)Lviaduct/service/api/scoping/SchemaScoping;
-	public static synthetic fun copy$default (Lviaduct/service/api/scoping/SchemaScoping;Ljava/util/Set;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lviaduct/service/api/scoping/SchemaScoping;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getScopeUniverse ()Ljava/util/Set;
-	public final fun getScopedSchemas ()Ljava/util/Map;
-	public final fun getVersion ()Ljava/lang/String;
-	public fun hashCode ()I
-	public final fun isScoped ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class viaduct/service/api/spi/CodeInjector {
 	public static final field Companion Lviaduct/service/api/spi/CodeInjector$Companion;
 	public abstract fun getProvider (Ljava/lang/Class;)Ljavax/inject/Provider;

--- a/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
+++ b/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
@@ -1,7 +1,7 @@
 package viaduct.service.api.scoping
 
 import java.io.Serializable
-import viaduct.apiannotations.StableApi
+import viaduct.apiannotations.ExperimentalApi
 
 /**
  * Build-to-runtime contract describing the schema-scoping declarations of a Viaduct application.
@@ -18,7 +18,7 @@ import viaduct.apiannotations.StableApi
  *  set is an alias for the full schema.
  * @property version manifest schema version, used to evolve the on-disk JSON format.
  */
-@StableApi
+@ExperimentalApi
 data class SchemaScoping(
     val scopeUniverse: Set<String>,
     val scopedSchemas: Map<String, Set<String>>,

--- a/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
+++ b/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
@@ -1,0 +1,39 @@
+package viaduct.service.api.scoping
+
+import java.io.Serializable
+import viaduct.apiannotations.StableApi
+
+/**
+ * Build-to-runtime contract describing the schema-scoping declarations of a Viaduct application.
+ *
+ * Emitted by the `viaduct-application` Gradle plugin from the application's `declaredSchemaScopes` /
+ * `declaredScopedSchema` DSL, and consumed at runtime when a Viaduct instance resolves which scoped
+ * schemas to register. The canonical cross-process exchange format is the JSON manifest written
+ * into the application JAR; the [Serializable] implementation supports in-process Gradle plumbing
+ * (e.g. configuration-cache state) and is not the wire format for runtime consumption.
+ *
+ * @property scopeUniverse the complete set of scope IDs declared as valid for this application;
+ *  empty when the application does not opt into scoping.
+ * @property scopedSchemas mapping from declared scoped-schema ID to its scope set; an empty scope
+ *  set is an alias for the full schema.
+ * @property version manifest schema version, used to evolve the on-disk JSON format.
+ */
+@StableApi
+data class SchemaScoping(
+    val scopeUniverse: Set<String>,
+    val scopedSchemas: Map<String, Set<String>>,
+    val version: String = CURRENT_VERSION,
+) : Serializable {
+    /**
+     * Whether this application opts into scope-based filtering. The presence of a declared
+     * universe — not the contents of [scopedSchemas] — is the source of truth.
+     */
+    val isScoped: Boolean get() = scopeUniverse.isNotEmpty()
+
+    companion object {
+        const val CURRENT_VERSION: String = "1"
+
+        /** Convenience constant for the "no scoping declared" state. */
+        val EMPTY: SchemaScoping = SchemaScoping(emptySet(), emptyMap())
+    }
+}

--- a/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
+++ b/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
@@ -7,7 +7,7 @@ import viaduct.apiannotations.ExperimentalApi
  * Build-to-runtime contract describing the schema-scoping declarations of a Viaduct application.
  *
  * Emitted by the `viaduct-application` Gradle plugin from the application's `declaredSchemaScopes` /
- * `declaredScopedSchema` DSL, and consumed at runtime when a Viaduct instance resolves which scoped
+ * `declaredScopedSchemas` DSL, and consumed at runtime when a Viaduct instance resolves which scoped
  * schemas to register. The canonical cross-process exchange format is the JSON manifest written
  * into the application JAR; the [Serializable] implementation supports in-process Gradle plumbing
  * (e.g. configuration-cache state) and is not the wire format for runtime consumption.

--- a/core/service/api/src/test/kotlin/viaduct/service/api/scoping/SchemaScopingTest.kt
+++ b/core/service/api/src/test/kotlin/viaduct/service/api/scoping/SchemaScopingTest.kt
@@ -8,7 +8,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
+import viaduct.apiannotations.ExperimentalApi
 
+@OptIn(ExperimentalApi::class)
 class SchemaScopingTest {
     @Test
     fun `EMPTY has no universe, no scoped schemas, and current version`() {

--- a/core/service/api/src/test/kotlin/viaduct/service/api/scoping/SchemaScopingTest.kt
+++ b/core/service/api/src/test/kotlin/viaduct/service/api/scoping/SchemaScopingTest.kt
@@ -1,0 +1,98 @@
+package viaduct.service.api.scoping
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class SchemaScopingTest {
+    @Test
+    fun `EMPTY has no universe, no scoped schemas, and current version`() {
+        assertEquals(emptySet(), SchemaScoping.EMPTY.scopeUniverse)
+        assertEquals(emptyMap(), SchemaScoping.EMPTY.scopedSchemas)
+        assertEquals(SchemaScoping.CURRENT_VERSION, SchemaScoping.EMPTY.version)
+    }
+
+    @Test
+    fun `isScoped is false when the scope universe is empty`() {
+        assertFalse(SchemaScoping.EMPTY.isScoped)
+        // A populated scopedSchemas map without a declared universe still reads as unscoped:
+        // the universe is the source of truth for whether @scope is in play.
+        assertFalse(
+            SchemaScoping(
+                scopeUniverse = emptySet(),
+                scopedSchemas = mapOf("API" to emptySet()),
+            ).isScoped,
+        )
+    }
+
+    @Test
+    fun `isScoped is true when the scope universe is non-empty`() {
+        assertTrue(
+            SchemaScoping(
+                scopeUniverse = setOf("public"),
+                scopedSchemas = emptyMap(),
+            ).isScoped,
+        )
+        assertTrue(
+            SchemaScoping(
+                scopeUniverse = setOf("public", "internal"),
+                scopedSchemas = mapOf("PUBLIC_API" to setOf("public")),
+            ).isScoped,
+        )
+    }
+
+    @Test
+    fun `data class equality compares fields by value`() {
+        val a = SchemaScoping(
+            scopeUniverse = setOf("public", "internal"),
+            scopedSchemas = mapOf("PUBLIC_API" to setOf("public")),
+        )
+        val b = SchemaScoping(
+            scopeUniverse = setOf("public", "internal"),
+            scopedSchemas = mapOf("PUBLIC_API" to setOf("public")),
+        )
+        val different = SchemaScoping(
+            scopeUniverse = setOf("public"),
+            scopedSchemas = mapOf("PUBLIC_API" to setOf("public")),
+        )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertTrue(a != different)
+    }
+
+    @Test
+    fun `version defaults to CURRENT_VERSION`() {
+        val scoping = SchemaScoping(
+            scopeUniverse = setOf("public"),
+            scopedSchemas = emptyMap(),
+        )
+        assertEquals(SchemaScoping.CURRENT_VERSION, scoping.version)
+    }
+
+    @Test
+    fun `Serializable round-trip preserves all fields`() {
+        val original = SchemaScoping(
+            scopeUniverse = setOf("public", "internal"),
+            scopedSchemas = mapOf(
+                "PUBLIC_API" to setOf("public"),
+                "FULL_ALIAS" to emptySet(),
+            ),
+        )
+
+        val bytes = ByteArrayOutputStream().use { bytes ->
+            ObjectOutputStream(bytes).use { it.writeObject(original) }
+            bytes.toByteArray()
+        }
+
+        val restored = ObjectInputStream(ByteArrayInputStream(bytes)).use { it.readObject() }
+            as SchemaScoping
+
+        assertEquals(original, restored)
+        assertEquals(original.isScoped, restored.isScoped)
+    }
+}

--- a/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
+++ b/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
@@ -8,6 +8,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import viaduct.apiannotations.ExperimentalApi
 import viaduct.service.api.scoping.SchemaScoping
 
 /**
@@ -18,6 +19,7 @@ import viaduct.service.api.scoping.SchemaScoping
  * ID-format, reserved-name, and subset validation are enforced elsewhere and are not covered
  * here.
  */
+@OptIn(ExperimentalApi::class)
 class ViaductApplicationExtensionTest {
     private lateinit var extension: ViaductApplicationExtension
 

--- a/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
+++ b/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
@@ -14,10 +14,10 @@ import viaduct.service.api.scoping.SchemaScoping
 /**
  * Tests for the schema-scoping DSL surface on ViaductApplicationExtension.
  *
- * The DSL accumulates declarations across calls and rejects duplicate IDs at setter time so
- * convention plugins composed with application code cannot silently shadow each other.
- * ID-format, reserved-name, and subset validation are enforced elsewhere and are not covered
- * here.
+ * The DSL is single-call immutable: each declaration setter may be invoked at most once and
+ * rejects empty inputs, so convention plugins composed with application code must compose at
+ * the call site rather than mutate across calls. ID-format, reserved-name, and subset
+ * validation are enforced elsewhere and are not covered here.
  */
 @OptIn(ExperimentalApi::class)
 class ViaductApplicationExtensionTest {
@@ -44,20 +44,39 @@ class ViaductApplicationExtensionTest {
     }
 
     @Test
-    fun `multiple declaredSchemaScopes calls accumulate into a single universe`() {
+    fun `second declaredSchemaScopes call is rejected`() {
         extension.declaredSchemaScopes(setOf("public"))
-        extension.declaredSchemaScopes(setOf("internal", "admin"))
-        assertEquals(
-            setOf("public", "internal", "admin"),
-            extension.schemaScoping.get().scopeUniverse,
+        val ex = assertThrows<GradleException> {
+            extension.declaredSchemaScopes(setOf("internal"))
+        }
+        // The message must name the single-call constraint so the caller understands the
+        // composition contract (compose at the call site, do not mutate via repeated calls).
+        assertTrue(
+            ex.message!!.contains("only be called once"),
+            "Expected message to explain the single-call constraint, got: ${ex.message}",
         )
     }
 
     @Test
-    fun `declaredScopedSchema records each scoped-schema entry`() {
+    fun `declaredSchemaScopes rejects an empty set`() {
+        val ex = assertThrows<GradleException> {
+            extension.declaredSchemaScopes(emptySet())
+        }
+        // "never set" is the way to express "no scoping". Explicitly setting an empty universe
+        // is forbidden so that the call itself carries semantic weight: present => scoping.
+        assertTrue(
+            ex.message!!.contains("at least one"),
+            "Expected message to direct caller to omit the call instead, got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `declaredScopedSchemas records each scoped-schema entry`() {
         extension.declaredSchemaScopes(setOf("public", "internal"))
-        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
-        extension.declaredScopedSchema("INTERNAL_API", setOf("public", "internal"))
+        extension.declaredScopedSchemas(
+            "PUBLIC_API" to setOf("public"),
+            "INTERNAL_API" to setOf("public", "internal"),
+        )
 
         val schemas = extension.schemaScoping.get().scopedSchemas
         assertEquals(
@@ -70,9 +89,9 @@ class ViaductApplicationExtensionTest {
     }
 
     @Test
-    fun `declaredScopedSchema accepts an empty scope set as a full-schema alias`() {
+    fun `declaredScopedSchemas accepts an empty scope set as a full-schema alias`() {
         extension.declaredSchemaScopes(setOf("public"))
-        extension.declaredScopedSchema("FULL_ALIAS", emptySet())
+        extension.declaredScopedSchemas("FULL_ALIAS" to emptySet())
 
         val schemas = extension.schemaScoping.get().scopedSchemas
         assertTrue(schemas.containsKey("FULL_ALIAS"))
@@ -80,8 +99,50 @@ class ViaductApplicationExtensionTest {
     }
 
     @Test
+    fun `second declaredScopedSchemas call is rejected`() {
+        extension.declaredSchemaScopes(setOf("public", "internal"))
+        extension.declaredScopedSchemas("PUBLIC_API" to setOf("public"))
+        val ex = assertThrows<GradleException> {
+            extension.declaredScopedSchemas("INTERNAL_API" to setOf("internal"))
+        }
+        assertTrue(
+            ex.message!!.contains("only be called once"),
+            "Expected message to explain the single-call constraint, got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `declaredScopedSchemas rejects an empty entries list`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        val ex = assertThrows<GradleException> {
+            extension.declaredScopedSchemas()
+        }
+        // Symmetric with `declaredSchemaScopes` empty rejection: omitting the call is the way
+        // to express "no scoped schemas declared".
+        assertTrue(
+            ex.message!!.contains("at least one"),
+            "Expected message to direct caller to omit the call instead, got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `duplicate scoped-schema IDs within a single declaredScopedSchemas call fail`() {
+        extension.declaredSchemaScopes(setOf("public", "internal"))
+        val ex = assertThrows<GradleException> {
+            extension.declaredScopedSchemas(
+                "PUBLIC_API" to setOf("public"),
+                "PUBLIC_API" to setOf("internal"),
+            )
+        }
+        assertTrue(
+            ex.message!!.contains("PUBLIC_API"),
+            "Expected message to name the duplicated schema id 'PUBLIC_API', got: ${ex.message}",
+        )
+    }
+
+    @Test
     fun `isScoped is false when no scopes have been declared`() {
-        extension.declaredScopedSchema("FULL_ALIAS", emptySet())
+        extension.declaredScopedSchemas("FULL_ALIAS" to emptySet())
         // The universe (not the scoped-schemas map) is the source of truth for `isScoped`,
         // so declaring a scoped schema in isolation still reads as unscoped here. Whether this
         // combination is rejected is the concern of validation layered on top of the DSL.
@@ -96,18 +157,17 @@ class ViaductApplicationExtensionTest {
 
     @Test
     fun `schemaScoping reflects state at the moment of get`() {
-        extension.declaredSchemaScopes(setOf("public"))
+        extension.declaredSchemaScopes(setOf("public", "internal"))
         val first = extension.schemaScoping.get()
 
-        extension.declaredSchemaScopes(setOf("internal"))
-        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
+        extension.declaredScopedSchemas("PUBLIC_API" to setOf("public"))
         val second = extension.schemaScoping.get()
 
-        // First snapshot retains the state it captured.
-        assertEquals(setOf("public"), first.scopeUniverse)
+        // First snapshot retains the state it captured: scoped-schemas map still empty.
+        assertEquals(setOf("public", "internal"), first.scopeUniverse)
         assertEquals(emptyMap(), first.scopedSchemas)
 
-        // Second snapshot reflects the additional declarations.
+        // Second snapshot reflects the additional declaration.
         assertEquals(setOf("public", "internal"), second.scopeUniverse)
         assertEquals(mapOf("PUBLIC_API" to setOf("public")), second.scopedSchemas)
     }
@@ -122,39 +182,13 @@ class ViaductApplicationExtensionTest {
     }
 
     @Test
-    fun `duplicate scope IDs across multiple declaredSchemaScopes calls fail`() {
-        extension.declaredSchemaScopes(setOf("public"))
-        val ex = assertThrows<GradleException> {
-            extension.declaredSchemaScopes(setOf("public", "internal"))
-        }
-        // The failure message must name the duplicated scope ID so the user can find it
-        // in their build script. Failing without naming the offender forces a guessing game
-        // when convention plugins and application code both contribute scopes.
-        assertTrue(
-            ex.message!!.contains("public"),
-            "Expected message to name the duplicated scope id 'public', got: ${ex.message}",
-        )
-    }
-
-    @Test
-    fun `duplicate schema IDs across multiple declaredScopedSchema calls fail`() {
-        extension.declaredSchemaScopes(setOf("public", "internal"))
-        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
-        val ex = assertThrows<GradleException> {
-            extension.declaredScopedSchema("PUBLIC_API", setOf("internal"))
-        }
-        assertTrue(
-            ex.message!!.contains("PUBLIC_API"),
-            "Expected message to name the duplicated schema id 'PUBLIC_API', got: ${ex.message}",
-        )
-    }
-
-    @Test
     fun `assembled scoping matches a directly-constructed SchemaScoping`() {
         extension.declaredSchemaScopes(setOf("public", "internal", "admin"))
-        extension.declaredScopedSchema("FULL_ALIAS", emptySet())
-        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
-        extension.declaredScopedSchema("INTERNAL_API", setOf("public", "internal"))
+        extension.declaredScopedSchemas(
+            "FULL_ALIAS" to emptySet(),
+            "PUBLIC_API" to setOf("public"),
+            "INTERNAL_API" to setOf("public", "internal"),
+        )
 
         val expected = SchemaScoping(
             scopeUniverse = setOf("public", "internal", "admin"),

--- a/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
+++ b/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
@@ -1,0 +1,167 @@
+package viaduct.gradle
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import viaduct.service.api.scoping.SchemaScoping
+
+/**
+ * Tests for the schema-scoping DSL surface on ViaductApplicationExtension.
+ *
+ * The DSL accumulates declarations across calls and rejects duplicate IDs at setter time so
+ * convention plugins composed with application code cannot silently shadow each other.
+ * ID-format, reserved-name, and subset validation are enforced elsewhere and are not covered
+ * here.
+ */
+class ViaductApplicationExtensionTest {
+    private lateinit var extension: ViaductApplicationExtension
+
+    @BeforeEach
+    fun setUp() {
+        val project = ProjectBuilder.builder().build()
+        extension = ViaductApplicationExtension(project.objects)
+    }
+
+    @Test
+    fun `schemaScoping is empty by default`() {
+        val scoping = extension.schemaScoping.get()
+        assertEquals(emptySet(), scoping.scopeUniverse)
+        assertEquals(emptyMap(), scoping.scopedSchemas)
+        assertFalse(scoping.isScoped)
+    }
+
+    @Test
+    fun `declaredSchemaScopes populates the universe`() {
+        extension.declaredSchemaScopes(setOf("public", "internal"))
+        assertEquals(setOf("public", "internal"), extension.schemaScoping.get().scopeUniverse)
+    }
+
+    @Test
+    fun `multiple declaredSchemaScopes calls accumulate into a single universe`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        extension.declaredSchemaScopes(setOf("internal", "admin"))
+        assertEquals(
+            setOf("public", "internal", "admin"),
+            extension.schemaScoping.get().scopeUniverse,
+        )
+    }
+
+    @Test
+    fun `declaredScopedSchema records each scoped-schema entry`() {
+        extension.declaredSchemaScopes(setOf("public", "internal"))
+        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
+        extension.declaredScopedSchema("INTERNAL_API", setOf("public", "internal"))
+
+        val schemas = extension.schemaScoping.get().scopedSchemas
+        assertEquals(
+            mapOf(
+                "PUBLIC_API" to setOf("public"),
+                "INTERNAL_API" to setOf("public", "internal"),
+            ),
+            schemas,
+        )
+    }
+
+    @Test
+    fun `declaredScopedSchema accepts an empty scope set as a full-schema alias`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        extension.declaredScopedSchema("FULL_ALIAS", emptySet())
+
+        val schemas = extension.schemaScoping.get().scopedSchemas
+        assertTrue(schemas.containsKey("FULL_ALIAS"))
+        assertEquals(emptySet(), schemas["FULL_ALIAS"])
+    }
+
+    @Test
+    fun `isScoped is false when no scopes have been declared`() {
+        extension.declaredScopedSchema("FULL_ALIAS", emptySet())
+        // The universe (not the scoped-schemas map) is the source of truth for `isScoped`,
+        // so declaring a scoped schema in isolation still reads as unscoped here. Whether this
+        // combination is rejected is the concern of validation layered on top of the DSL.
+        assertFalse(extension.schemaScoping.get().isScoped)
+    }
+
+    @Test
+    fun `isScoped is true once a non-empty universe is declared`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        assertTrue(extension.schemaScoping.get().isScoped)
+    }
+
+    @Test
+    fun `schemaScoping reflects state at the moment of get`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        val first = extension.schemaScoping.get()
+
+        extension.declaredSchemaScopes(setOf("internal"))
+        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
+        val second = extension.schemaScoping.get()
+
+        // First snapshot retains the state it captured.
+        assertEquals(setOf("public"), first.scopeUniverse)
+        assertEquals(emptyMap(), first.scopedSchemas)
+
+        // Second snapshot reflects the additional declarations.
+        assertEquals(setOf("public", "internal"), second.scopeUniverse)
+        assertEquals(mapOf("PUBLIC_API" to setOf("public")), second.scopedSchemas)
+    }
+
+    @Test
+    fun `pre-existing scalar properties remain functional`() {
+        // Guard against accidental regression of the existing extension surface.
+        assertEquals("viaduct.api.grts", extension.grtPackageName.get())
+
+        extension.modulePackagePrefix.set("com.example")
+        assertEquals("com.example", extension.modulePackagePrefix.get())
+    }
+
+    @Test
+    fun `duplicate scope IDs across multiple declaredSchemaScopes calls fail`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        val ex = assertThrows<GradleException> {
+            extension.declaredSchemaScopes(setOf("public", "internal"))
+        }
+        // The failure message must name the duplicated scope ID so the user can find it
+        // in their build script. Failing without naming the offender forces a guessing game
+        // when convention plugins and application code both contribute scopes.
+        assertTrue(
+            ex.message!!.contains("public"),
+            "Expected message to name the duplicated scope id 'public', got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `duplicate schema IDs across multiple declaredScopedSchema calls fail`() {
+        extension.declaredSchemaScopes(setOf("public", "internal"))
+        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
+        val ex = assertThrows<GradleException> {
+            extension.declaredScopedSchema("PUBLIC_API", setOf("internal"))
+        }
+        assertTrue(
+            ex.message!!.contains("PUBLIC_API"),
+            "Expected message to name the duplicated schema id 'PUBLIC_API', got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `assembled scoping matches a directly-constructed SchemaScoping`() {
+        extension.declaredSchemaScopes(setOf("public", "internal", "admin"))
+        extension.declaredScopedSchema("FULL_ALIAS", emptySet())
+        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
+        extension.declaredScopedSchema("INTERNAL_API", setOf("public", "internal"))
+
+        val expected = SchemaScoping(
+            scopeUniverse = setOf("public", "internal", "admin"),
+            scopedSchemas = mapOf(
+                "FULL_ALIAS" to emptySet(),
+                "PUBLIC_API" to setOf("public"),
+                "INTERNAL_API" to setOf("public", "internal"),
+            ),
+        )
+        assertEquals(expected, extension.schemaScoping.get())
+    }
+}

--- a/gradle-plugins/common/build.gradle.kts
+++ b/gradle-plugins/common/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 dependencies {
     api(gradleApi())
 
+    // ViaductApplicationExtension exposes Provider<SchemaScoping> from service-api as the
+    // canonical scope-state surface, so the type must be on the api classpath.
+    api(libs.viaduct.service.api)
+
     implementation(libs.idea.gradle.plugin)
 }
 

--- a/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ScopedSchemaDefinition.kt
+++ b/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ScopedSchemaDefinition.kt
@@ -1,0 +1,13 @@
+package viaduct.gradle
+
+import java.io.Serializable
+
+/**
+ * Internal wrapper carrying a scoped schema's scope set inside a Gradle `MapProperty`.
+ *
+ * Gradle's `MapProperty<K, V>` cannot take a parameterized value type like `Set<String>` directly,
+ * so we wrap it. Kept `internal` so the workaround does not leak into the public Gradle plugin API.
+ */
+internal data class ScopedSchemaDefinition(
+    val scopeSet: Set<String>,
+) : Serializable

--- a/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
+++ b/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
@@ -22,9 +22,12 @@ open class ViaductApplicationExtension(objects: ObjectFactory) {
     private val scopedSchemasProperty: MapProperty<String, ScopedSchemaDefinition> =
         objects.mapProperty(String::class.java, ScopedSchemaDefinition::class.java)
 
+    private var scopeUniverseDeclared = false
+    private var scopedSchemasDeclared = false
+
     /**
      * Canonical view of the application's schema-scoping declarations, derived from the
-     * `declaredSchemaScopes` and `declaredScopedSchema` DSL methods. Re-evaluated on each `get()`,
+     * `declaredSchemaScopes` and `declaredScopedSchemas` DSL methods. Re-evaluated on each `get()`,
      * so successive snapshots reflect the state at the moment of resolution.
      */
     val schemaScoping: Provider<SchemaScoping> =
@@ -36,37 +39,60 @@ open class ViaductApplicationExtension(objects: ObjectFactory) {
         }
 
     /**
-     * Adds [scopes] to the declared scope universe. May be called multiple times; calls accumulate
-     * via set union. A scope ID that already appears in the universe from an earlier call is
-     * rejected with a [GradleException] naming the duplicate, so that convention plugins and
-     * application code can't silently shadow each other.
+     * Declares the scope universe for this application. May be called at most once with a
+     * non-empty set; the call is the single decision-point for what scopes exist. Omit the call
+     * entirely to express "no scoping". Convention plugins that contribute baseline scopes
+     * compose at the call site rather than via repeated mutation. An empty set or a second call
+     * is rejected with a [GradleException].
      */
     fun declaredSchemaScopes(scopes: Set<String>) {
-        val existing = scopeUniverseProperty.getOrElse(emptySet())
-        val duplicates = scopes intersect existing
-        if (duplicates.isNotEmpty()) {
+        if (scopeUniverseDeclared) {
             throw GradleException(
-                "Duplicate scope ID(s) declared via declaredSchemaScopes: " +
-                    "${duplicates.sorted()}. Each scope ID may only be declared once.",
+                "declaredSchemaScopes may only be called once. " +
+                    "Compose convention-plugin contributions into a single Set before the call.",
             )
         }
-        scopeUniverseProperty.addAll(scopes)
+        if (scopes.isEmpty()) {
+            throw GradleException(
+                "declaredSchemaScopes requires at least one scope ID. " +
+                    "Omit the call entirely if this application does not declare scopes.",
+            )
+        }
+        scopeUniverseDeclared = true
+        scopeUniverseProperty.set(scopes)
     }
 
     /**
-     * Declares that schema [id] is restricted to [scopes]. An empty [scopes] set is permitted and
-     * acts as an alias for the full schema. A schema ID that was already declared by an earlier
-     * call is rejected with a [GradleException] naming the duplicate, so that convention plugins
-     * and application code can't silently overwrite each other.
+     * Declares the application's scoped schemas as a fixed map from schema ID to its scope set.
+     * May be called at most once with at least one entry; the call is the single decision-point
+     * for which scoped schemas exist. An empty value set per entry (e.g. `"FULL_ALIAS" to
+     * emptySet()`) is allowed and acts as an alias for the full schema. A second call, an empty
+     * varargs list, or duplicate schema IDs within the single call are rejected with a
+     * [GradleException].
      */
-    fun declaredScopedSchema(id: String, scopes: Set<String>) {
-        val existing = scopedSchemasProperty.getOrElse(emptyMap())
-        if (id in existing) {
+    fun declaredScopedSchemas(vararg entries: Pair<String, Set<String>>) {
+        if (scopedSchemasDeclared) {
             throw GradleException(
-                "Duplicate scoped-schema ID declared via declaredScopedSchema: " +
-                    "'$id'. Each scoped-schema ID may only be declared once.",
+                "declaredScopedSchemas may only be called once. " +
+                    "Compose convention-plugin contributions into a single varargs invocation.",
             )
         }
-        scopedSchemasProperty.put(id, ScopedSchemaDefinition(scopes))
+        if (entries.isEmpty()) {
+            throw GradleException(
+                "declaredScopedSchemas requires at least one scoped-schema entry. " +
+                    "Omit the call entirely if this application does not declare scoped schemas.",
+            )
+        }
+        val duplicates = entries.groupBy { it.first }.filter { it.value.size > 1 }.keys.sorted()
+        if (duplicates.isNotEmpty()) {
+            throw GradleException(
+                "Duplicate scoped-schema ID(s) declared via declaredScopedSchemas: " +
+                    "$duplicates. Each scoped-schema ID may only appear once.",
+            )
+        }
+        scopedSchemasDeclared = true
+        scopedSchemasProperty.set(
+            entries.associate { (id, scopes) -> id to ScopedSchemaDefinition(scopes) },
+        )
     }
 }

--- a/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
+++ b/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
@@ -5,8 +5,10 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
+import viaduct.apiannotations.ExperimentalApi
 import viaduct.service.api.scoping.SchemaScoping
 
+@OptIn(ExperimentalApi::class)
 open class ViaductApplicationExtension(objects: ObjectFactory) {
     /** Kotlin package name for generated GRT classes. */
     val grtPackageName = objects.property(String::class.java).convention("viaduct.api.grts")

--- a/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
+++ b/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
@@ -1,9 +1,70 @@
 package viaduct.gradle
 
-open class ViaductApplicationExtension(objects: org.gradle.api.model.ObjectFactory) {
+import org.gradle.api.GradleException
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import viaduct.service.api.scoping.SchemaScoping
+
+open class ViaductApplicationExtension(objects: ObjectFactory) {
     /** Kotlin package name for generated GRT classes. */
     val grtPackageName = objects.property(String::class.java).convention("viaduct.api.grts")
 
     /** Kotlin package name prefix for all modules. */
     val modulePackagePrefix = objects.property(String::class.java)
+
+    private val scopeUniverseProperty: SetProperty<String> =
+        objects.setProperty(String::class.java)
+
+    private val scopedSchemasProperty: MapProperty<String, ScopedSchemaDefinition> =
+        objects.mapProperty(String::class.java, ScopedSchemaDefinition::class.java)
+
+    /**
+     * Canonical view of the application's schema-scoping declarations, derived from the
+     * `declaredSchemaScopes` and `declaredScopedSchema` DSL methods. Re-evaluated on each `get()`,
+     * so successive snapshots reflect the state at the moment of resolution.
+     */
+    val schemaScoping: Provider<SchemaScoping> =
+        scopeUniverseProperty.zip(scopedSchemasProperty) { universe, schemas ->
+            SchemaScoping(
+                scopeUniverse = universe,
+                scopedSchemas = schemas.mapValues { it.value.scopeSet },
+            )
+        }
+
+    /**
+     * Adds [scopes] to the declared scope universe. May be called multiple times; calls accumulate
+     * via set union. A scope ID that already appears in the universe from an earlier call is
+     * rejected with a [GradleException] naming the duplicate, so that convention plugins and
+     * application code can't silently shadow each other.
+     */
+    fun declaredSchemaScopes(scopes: Set<String>) {
+        val existing = scopeUniverseProperty.getOrElse(emptySet())
+        val duplicates = scopes intersect existing
+        if (duplicates.isNotEmpty()) {
+            throw GradleException(
+                "Duplicate scope ID(s) declared via declaredSchemaScopes: " +
+                    "${duplicates.sorted()}. Each scope ID may only be declared once.",
+            )
+        }
+        scopeUniverseProperty.addAll(scopes)
+    }
+
+    /**
+     * Declares that schema [id] is restricted to [scopes]. An empty [scopes] set is permitted and
+     * acts as an alias for the full schema. A schema ID that was already declared by an earlier
+     * call is rejected with a [GradleException] naming the duplicate, so that convention plugins
+     * and application code can't silently overwrite each other.
+     */
+    fun declaredScopedSchema(id: String, scopes: Set<String>) {
+        val existing = scopedSchemasProperty.getOrElse(emptyMap())
+        if (id in existing) {
+            throw GradleException(
+                "Duplicate scoped-schema ID declared via declaredScopedSchema: " +
+                    "'$id'. Each scoped-schema ID may only be declared once.",
+            )
+        }
+        scopedSchemasProperty.put(id, ScopedSchemaDefinition(scopes))
+    }
 }


### PR DESCRIPTION
Implements #366 — first slice of the #361 schema-scoping breakdown.

Foundational slice: introduces the canonical `SchemaScoping` data class and the DSL accumulation pattern on `ViaductApplicationExtension`. **No SDL validation, no resource emission, no runtime behavior change.** Follow-up slices layer those on. Duplicate-ID rejection on the DSL setters is in scope per [decisions.md D13](https://github.com/airbnb/viaduct/issues/361#issuecomment-4617603809) (the cross-slice decisions doc is attached to #361 as a comment).

### Why this is its own PR

`SchemaScoping` is the build-to-runtime API contract that #366's siblings (extension validation, SDL validation, manifest writer, runtime reader, builder wiring) all depend on. Landing the data class and the DSL shape first — with no behavioral payload beyond accumulate-with-dedup-rejection — keeps the architectural decision focused and lets reviewers reason about the API shape.

### What ships

- `SchemaScoping` data class in `core/service/api/.../scoping/`, sibling to `SchemaId.kt`. Fields, `isScoped` predicate, `EMPTY` constant, `CURRENT_VERSION`. `Serializable` for in-process Gradle plumbing; JSON wire format lands in a later slice.
- `ViaductApplicationExtension` gains `declaredSchemaScopes(Set<String>)` and `declaredScopedSchemas(vararg "id" to scopes)` DSL methods, backed by private storage. Both are **single-call immutable** — second invocation throws `GradleException`. Empty inputs and within-`declaredScopedSchemas` duplicate IDs are rejected with `GradleException`. Public surface is `Provider<SchemaScoping>` — re-evaluates on every `get()` to reflect current state.
- Internal `ScopedSchemaDefinition` wrapper around `Set<String>` (Gradle `MapProperty` value-type erasure workaround). Kept `internal`; projected back to `Set<String>` before reaching the public `SchemaScoping`.
- Tests cover the single-call DSL contract: 14 tests in `ViaductApplicationExtensionTest` plus 6 in `SchemaScopingTest`. All tests are behavioral — no source-file string inspection, no brittle line-count assertions.

### Out of scope (deferred to follow-up slices)

- ID-format / reserved-ID / subset / "absent → both absent" validation
- `@scope` directive injection toggle, SDL validation against the declared universe
- JSON manifest writer + runtime reader
- Builder wiring, demo-app migration, deprecation of raw-scope-set factories

### Reviewers should focus on

- **Module location.** `SchemaScoping` lives in `core/service/api/.../scoping/`, sibling to `SchemaId.kt`. Rationale: this is the build-to-runtime API contract; `service/api` already holds the equivalent concrete public types, and `service/runtime` consumes it transitively.
- **`abstract class @Inject` vs `open class(objects)`.** Kept the existing `open class` constructor to avoid touching the plugin's `extensions.create(..., objects)` call site. Easy to flip later if there's a preference; it's a local change.
- **`ScopedSchemaDefinition` kept `internal`.** It only exists to satisfy `MapProperty<K, V>`'s value-type erasure, and is projected away before reaching the public Provider type. Worth confirming this is the desired contract before any convention plugins start composing.
- **Duplicate-rejection error messages.** Both setters throw `GradleException` synchronously and the message includes the duplicate ID(s) so users can grep their build script. PR 2 will introduce the formalized error catalogue (codes + templated messages + remediation); these messages are placeholder-style for now and will be re-keyed then.

### Open questions, deviations, ambiguities of the spec

Three points worth a reviewer call. (A prior question on multi-call duplicate handling was resolved offline — see "Resolved" below.)

**1. `@get:Input` on the `schemaScoping` Provider omitted vs sample code.** The slice-doc sample shows:
```kotlin
@get:org.gradle.api.tasks.Input
val schemaScoping: Provider<SchemaScoping> = ...
```
This PR omits the annotation. Three reasons:
- Gradle only inspects `@Input` annotations on `Task` properties; on an extension, it is a no-op at runtime.
- None of the pre-existing extension properties on `ViaductApplicationExtension` (`grtPackageName`, `modulePackagePrefix`, `servePort`, `serveHost`) carry `@Input` either, so adding it only on the new property would be locally inconsistent.
- The slice doc's own "Out of scope" section says: *"Plumbing `schemaScoping` as `@Input` on `AssembleCentralSchemaTask` — PR 3."* The `@Input` lives on the task in slice 3, not on the extension.

Reading: the annotation in the sample is likely a small drafting inconsistency. Happy to add `@get:Input` back if a reviewer prefers cargo-cult-now-rename-later; otherwise it lands on the task in slice 3.

**2. Constructor shape: `open class(objects)` vs `abstract class @Inject`.** Also called out under "Reviewers should focus on" above. Sample is `abstract @Inject`; this PR keeps the existing `open class(objects)` constructor to minimize blast radius at the plugin call site (`extensions.create("viaductApplication", ViaductApplicationExtension::class.java, objects)` in `ViaductApplicationPlugin.kt:36`). Easy flip later.

**3. TestKit coverage of the DSL through a real `build.gradle.kts` — should slice 1 include it?** The slice spec's test plan only asks for `ProjectBuilder` tests, and this PR delivers exactly that — 14 tests instantiating `ViaductApplicationExtension(project.objects)` directly. The plugin application path (`extensions.create(...)` inside `ViaductApplicationPlugin.apply`) is **not** exercised by these tests. Specifically, three things remain unverified end-to-end:

- That `extensions.create("viaductApplication", ViaductApplicationExtension::class.java, objects)` still wires the new private `SetProperty` / `MapProperty` correctly (the constructor signature is unchanged, so this should be safe, but it's untested).
- That the duplicate-rejection `GradleException` actually propagates through Gradle's configuration phase as a clear build failure (vs. being re-wrapped in a way that hides the dup-id in the user-facing message).
- That a real `viaductApplication { declaredSchemaScopes(...); declaredScopedSchema(...) }` block in a consumer's `build.gradle.kts` behaves as expected.

There is already a TestKit pattern in the same module — `ViaductApplicationPluginFunctionalTest.kt` uses `GradleRunner` with a synthesized `settings.gradle.kts` + `build.gradle.kts` for exactly this kind of check, and [`gradle-plugins/CLAUDE.md`](../../blob/main/gradle-plugins/CLAUDE.md) explicitly lists "clear diagnostics for invalid or incomplete plugin configuration" and "confirming that correctly configured projects do not fail during configuration" as appropriate TestKit cases.

Three small cases would close the gap:
- happy-path DSL invocation succeeds at configuration time;
- duplicate scope ID via the real DSL fails the build with the dup-id in the output;
- duplicate scoped-schema ID via the real DSL fails the build with the dup-id in the output.

Two readings:
- **Add to slice 1**, because TestKit coverage of the DSL ergonomics is cheap (one file, ~3 cases), and it confirms the duplicate-rejection contract surfaces correctly in real builds — the most user-visible behavior in this slice.
- **Defer**, because the spec's test plan is explicit and the demoapp migration in slice 11 is the canonical end-to-end verification — adding TestKit now duplicates what slice 11 will catch anyway.

Leaning slightly toward "add to slice 1" since duplicate-rejection is the only error path users will hit from this slice, and a TestKit check makes the error message contract self-evident at review time. Open to either. Will add if reviewer agrees.

**Resolved — single-call immutable DSL (D13 rescinded).** Multi-call accumulation has been **rescinded** in response to follow-up review feedback. D13's "accumulate-with-dedup-rejection" is superseded by a single-call immutable contract: `declaredSchemaScopes(Set<String>)` and `declaredScopedSchemas(vararg "id" to scopes)` are each callable at most once, reject empty inputs, and reject duplicate scoped-schema IDs within the single varargs invocation. The singular `declaredScopedSchema(id, scopes)` is renamed to plural `declaredScopedSchemas` with varargs of `Pair`. Empty `Set<String>` as a per-entry value (the full-schema alias) remains allowed. Full spec change recorded at https://github.com/airbnb/viaduct/issues/366#issuecomment-4617579597; the cross-slice decisions doc attached to #361 still contains D13's original text for historical context.

## Test plan

- [x] `viaduct.service.api.scoping.SchemaScopingTest`: 6/6 passing (EMPTY, isScoped both branches, data-class equality, default version, Serializable round-trip)
- [x] `viaduct.gradle.ViaductApplicationExtensionTest`: 14/14 passing — covers the single-call DSL contract: default-empty, single-call universe + scoped-schemas, second-call rejection on both setters, empty-input rejection on both setters, within-call duplicate-ID rejection, empty-set value (full-schema alias), isScoped both branches, snapshot semantics — plus pre-existing-property regression and end-to-end DSL → SchemaScoping equivalence
- [x] Pre-existing `viaduct.gradle.ViaductApplicationPluginTest` ran in the same suite — no regressions
- [x] Local `./gradlew :core:service:api:test :gradle-plugins:common:test :gradle-plugins:application:test` → BUILD SUCCESSFUL
- [x] `./gradlew :core:service:api:apiCheck` → BUILD SUCCESSFUL (no BCV public-surface drift)
- [x] End-to-end `./gradlew :starwars:test` → BUILD SUCCESSFUL (plugin loads cleanly under the reshaped DSL)
- [ ] TestKit functional test exercising the DSL through a real `build.gradle.kts` — see Open Question #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
