### PR TITLE
ci: add Windows Gradle check jobs with Windows-specific compatibility fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,6 +163,27 @@ jobs:
           path: '**/build/test-results/test/*.xml'
 
 
+  core-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: ${{ fromJSON(inputs.java_versions || '["17", "21"]') }}
+    name: Core Check (Windows, Java ${{ matrix.java }})
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Check core
+        run: ./gradlew -p core check --scan
+        shell: bash
+
   coverage-reports:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -170,10 +170,16 @@ jobs:
         java: ${{ fromJSON(inputs.java_versions || '["17", "21"]') }}
     name: Core Check (Windows, Java ${{ matrix.java }})
     env:
-      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false"
+      # fromEnv lets Gradle's daemon JVM discovery find Java 21 via JAVA_HOME_21_X64 when JAVA_HOME != Java 21.
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_21_X64"
       BUILDSCAN_PUBLISH: "true"
       BUILDSCAN_AUTOACCEPTTERMS: "true"
     steps:
+      # Ensure Windows runners use core.autocrlf=false for parity with Linux/macOS.
+      - name: Disable autocrlf
+        shell: bash
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-build

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -22,3 +22,24 @@ jobs:
       ref: main
       run_ci_check: true
     secrets: inherit
+
+  windows-check:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: ["17", "21"]
+    name: Full Check (Windows, Java ${{ matrix.java }})
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Check
+        run: ./gradlew check --scan
+        shell: bash

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -30,10 +30,16 @@ jobs:
         java: ["17", "21"]
     name: Full Check (Windows, Java ${{ matrix.java }})
     env:
-      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false"
+      # fromEnv lets Gradle's daemon JVM discovery find Java 21 via JAVA_HOME_21_X64 when JAVA_HOME != Java 21.
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_21_X64"
       BUILDSCAN_PUBLISH: "true"
       BUILDSCAN_AUTOACCEPTTERMS: "true"
     steps:
+      # Ensure Windows runners use core.autocrlf=false for parity with Linux/macOS.
+      - name: Disable autocrlf
+        shell: bash
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-build

--- a/core/shared/arbitrary/build.gradle.kts
+++ b/core/shared/arbitrary/build.gradle.kts
@@ -36,4 +36,5 @@ dependencies {
     implementation(testFixtures(libs.viaduct.service.api))
 
     testImplementation(libs.kotest.assertions.shared)
+    testImplementation(libs.assertj.core)
 }

--- a/core/shared/arbitrary/src/test/kotlin/viaduct/arbitrary/common/CheckedArbTest.kt
+++ b/core/shared/arbitrary/src/test/kotlin/viaduct/arbitrary/common/CheckedArbTest.kt
@@ -8,31 +8,29 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.asSample
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 
 class CheckedArbTest : KotestPropertyBase() {
     @Test
     fun `checkAll -- succeeds`() {
-        assertDoesNotThrow {
+        assertThatCode {
             Arb.constant(1).withCheck({}).checkAll()
-        }
+        }.doesNotThrowAnyException()
     }
 
     @Test
     fun `checkAll -- fails`() {
         val err = RuntimeException()
-        val err2 = assertThrows<AssertionError> {
+        assertThatThrownBy {
             Arb.constant(1)
                 .withCheck { throw err }
                 .checkAll()
         }
-        assertSame(err, err2.cause)
+            .isInstanceOf(AssertionError::class.java)
+            .hasCause(err)
     }
 
     @Test
@@ -40,7 +38,7 @@ class CheckedArbTest : KotestPropertyBase() {
         val mv = Arb.constant(1)
             .withCheck {}
             .minViolation(Comparator.naturalOrder(), randomSource)
-        assertNull(mv)
+        assertThat(mv).isNull()
     }
 
     @Test
@@ -51,7 +49,7 @@ class CheckedArbTest : KotestPropertyBase() {
                 if (i == 0) throw err
             }
             .minViolation(Comparator.naturalOrder(), randomSource)
-        assertEquals(Violation(0, err, seed), mv)
+        assertThat(mv).isEqualTo(Violation(0, err, seed))
     }
 
     @Test
@@ -77,7 +75,7 @@ class CheckedArbTest : KotestPropertyBase() {
                 rs = randomSource,
                 iter = values.size
             )
-        assertEquals(Violation(1, err, seed), mv)
+        assertThat(mv).isEqualTo(Violation(1, err, seed))
     }
 
     @Test
@@ -85,7 +83,7 @@ class CheckedArbTest : KotestPropertyBase() {
         val result = Arb.int(0..100)
             .withCheck {}
             .seedMarch(maxIter = iterations, printEvery = -1)
-        assertNull(result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -99,7 +97,7 @@ class CheckedArbTest : KotestPropertyBase() {
                 }
             }
             .seedMarch(maxIter = iterations, printEvery = -1)
-        assertEquals(Violation(1, err, 3), result)
+        assertThat(result).isEqualTo(Violation(1, err, 3))
     }
 
     @Test
@@ -118,19 +116,19 @@ class CheckedArbTest : KotestPropertyBase() {
         val result = arb
             .withCheck {}
             .seedMarch(startingSeed = 3, maxIter = 3, printEvery = -1)
-        assertNull(result?.value)
-        assertSame(err, result?.err)
-        assertEquals(5, result?.seed)
+        assertThat(result?.value).isNull()
+        assertThat(result?.err).isSameAs(err)
+        assertThat(result?.seed).isEqualTo(5)
     }
 
     @Test
     fun `seedMarch -- returns assertion failures`() {
         val result = Arb.constant(1)
-            .withCheck { assertTrue(it < 0) }
+            .withCheck { assertThat(it).isLessThan(0) }
             .seedMarch(maxIter = 1, printEvery = -1)
-        assertEquals(1, result?.value)
-        assertEquals(0, result?.seed)
-        assertTrue(result?.err is AssertionError)
+        assertThat(result?.value).isEqualTo(1)
+        assertThat(result?.seed).isEqualTo(0)
+        assertThat(result?.err).isInstanceOf(AssertionError::class.java)
     }
 
     @Test
@@ -139,7 +137,7 @@ class CheckedArbTest : KotestPropertyBase() {
         Arb.int(0..100)
             .withCheck {}
             .seedMarch(maxIter = iterations, printEvery = -1, out = PrintStream(out))
-        assertTrue(out.toString().isEmpty())
+        assertThat(out.toString()).isEmpty()
     }
 
     @Test
@@ -148,15 +146,14 @@ class CheckedArbTest : KotestPropertyBase() {
         Arb.int(0..50)
             .withCheck {}
             .seedMarch(startingSeed = 3, maxIter = 40, printEvery = 10, out = PrintStream(out))
-        assertEquals(
+        assertThat(out.toString()).isEqualToNormalizingNewlines(
             """
                     |Seed 3...
                     |Seed 13...
                     |Seed 23...
                     |Seed 33...
                     |
-            """.trimMargin(),
-            out.toString()
+            """.trimMargin()
         )
     }
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

ci: add Windows Gradle check jobs with Windows-specific compatibility fixes

  - Adds a core check matrix job to build-and-test on windows-latest (Java 17, 21).
  - Adds a full check matrix job to nightly-build on windows-latest (Java 17, 21).
  - Disables core.autocrlf before checkout so Windows runners preserve LF line endings, matching Linux/macOS.  
  - Migrates ArbExtTest to AssertJ's isEqualToNormalizingNewlines so PrintStream-based output assertions tolerate platform line endings.

## Description

Enables Windows CI for the Gradle build. Adds a `core-windows` matrix job to `build-and-test.yml` (mirrors the existing Linux/macOS core check) and a `windows-check` matrix job to `nightly-build.yml` for the full `./gradlew check`. 

Migrates `ArbExtTest` to AssertJ's `isEqualToNormalizingNewlines` to handle `PrintStream` line-ending differences.

## How was it tested?  What documentation was provided?

  Triggered the updated nightly workflow on `win-test-matrix`; all matrix entries (Java 17, 21) pass `./gradlew check` on Windows. `core-windows` job in build-and-test exercises `./gradlew -p core check` with
  the same matrix. No docs needed.