### PR TITLE
feat(demoapps): add argument, mutation, and introspection test coverage to starters

### DIFF
--- a/demoapps/AGENTS.md
+++ b/demoapps/AGENTS.md
@@ -112,14 +112,36 @@ The demo applications in this directory serve as integration tests and usage exa
 
 The demo apps collectively verify the KSP registry-extractor processor across the supported Kotlin and KSP version matrix:
 
-| Demo App | Kotlin | KSP | Generation | Coverage goal |
-|---|---|---|---|---|
-| cli-starter | 1.9.24 | 1.9.24-1.0.20 | KSP1 | Oldest supported |
-| jetty-starter | 2.0.21 | 2.0.21-1.0.28 | KSP1 | KSP1 on 2.0 |
-| micronaut-starter | 2.1.20 | 2.1.20-1.0.32 | KSP1 | KSP1 on 2.1 |
-| ktor-starter | 2.1.20 | 2.1.20-2.0.1 | KSP2 | KSP2 on 2.1 (same Kotlin, different KSP) |
-| starwars | 2.2.21 | 2.2.21-2.0.5 | KSP2 | Latest |
+| Demo App | Kotlin | KSP | Generation | Gradle | Coverage goal |
+|---|---|---|---|---|---|
+| cli-starter | 1.9.24 | 1.9.24-1.0.20 | KSP1 | 9.1.0 | **Closest to treehouse** (internal pinned to 1.9.22) |
+| jetty-starter | 2.0.21 | 2.0.21-1.0.28 | KSP1 | 9.1.0 | KSP1 on 2.0 — OSS consumers only |
+| micronaut-starter | 2.1.20 | 2.1.20-1.0.32 | KSP1 | **8.11** | KSP1 on 2.1; Gradle 8.x coverage — OSS consumers only |
+| ktor-starter | 2.1.20 | 2.1.20-2.0.1 | KSP2 | 9.1.0 | KSP2 on 2.1 — OSS consumers only |
+| starwars | 2.2.21 | 2.2.21-2.0.5 | KSP2 | 9.1.0 | Latest — OSS consumers only |
 
-Full transition to KSP2-only will occur after we deprecate Kotlin 1.9 support. Note that Kotlin 2.3+ uses a standalone KSP model (version-independent of the compiler), which will require a separate migration when we extend support past 2.2.
+> **Treehouse note**: Airbnb's internal monorepo is pinned to Kotlin **1.9.22**. Only `cli-starter` reflects close-to-internal conditions; all other demoapps validate external consumer scenarios. Kotlin 2.3+ support (standalone KSP) is an OSS-only goal and is blocked by treehouse's Kotlin ceiling. See `ksp-versioning.md` for details.
+
+`micronaut-starter` intentionally stays on Gradle 8.11 (matching the monorepo root) to verify Viaduct works with Gradle 8. All other apps use Gradle 9 to match the standard consumer setup. If `micronaut-starter` is ever bumped to Gradle 9, add a separate Gradle 8 variant to preserve that coverage.
+
+Full transition to KSP2-only will occur after we deprecate Kotlin 1.9 support. Note that Kotlin 2.3+ uses a standalone KSP model (version-independent of the compiler), which will require a separate migration when we extend support past 2.2 — and only after treehouse upgrades past Kotlin 1.9.
 
 For more on KSP versioning see `ksp-versioning.md`.
+
+## GraphQL Feature Coverage per Starter
+
+Each starter tests the following GraphQL capabilities in addition to its KSP/Kotlin/framework axis:
+
+| Feature | cli | jetty | ktor | micronaut | starwars |
+|---|---|---|---|---|---|
+| Basic queries | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Query arguments | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Mutations | ✅ | ✅ | ✅ | ✅ | ✅ |
+| HTTP transport | — | ✅ | ✅ | — | ✅ |
+| GraphiQL UI | — | ✅ | ✅ | — | ✅ |
+| Error handling | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Introspection | — | — | ✅ | — | — |
+| Batch resolvers | — | — | — | — | ✅ |
+| GlobalID / Node | — | — | — | — | ✅ |
+| Scoped fields | — | — | — | — | ✅ |
+| Multi-module | — | ✅ | ✅ | ✅ | ✅ |

--- a/demoapps/cli-starter/src/main/kotlin/com/example/resolvers/HelloWorldResolvers.kt
+++ b/demoapps/cli-starter/src/main/kotlin/com/example/resolvers/HelloWorldResolvers.kt
@@ -1,6 +1,7 @@
 // tag::resolvers-setup[20] Resolver logic setup.
 package com.example.viadapp.resolvers
 
+import com.example.viadapp.resolvers.resolverbases.MutationResolvers
 import com.example.viadapp.resolvers.resolverbases.QueryResolvers
 import viaduct.api.resolver.Resolver
 
@@ -13,4 +14,14 @@ class GreetingResolver : QueryResolvers.Greeting() {
 @Resolver
 class AuthorResolver : QueryResolvers.Author() {
     override suspend fun resolve(ctx: Context) = "Brian Kernighan"
+}
+
+@Resolver
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/cli-starter/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/cli-starter/src/main/viaduct/schema/schema.graphqls
@@ -2,4 +2,9 @@
 extend type Query {
   greeting: String @resolver
   author: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }

--- a/demoapps/cli-starter/src/test/kotlin/com/example/viadapp/ViaductApplicationTest.kt
+++ b/demoapps/cli-starter/src/test/kotlin/com/example/viadapp/ViaductApplicationTest.kt
@@ -137,4 +137,26 @@ class ViaductApplicationTest {
         val message = error["message"] as String
         assertTrue(message.contains("Invalid syntax") || message.contains("syntax"))
     }
+
+    @Test
+    fun testMainWithArgumentField() {
+        main(arrayOf("""{ greet(name: "Viaduct") }"""))
+
+        val result = getJsonOutput()
+        val data = result["data"] as Map<String, Any>
+
+        assertEquals("Hello, Viaduct!", data["greet"])
+        assertNull(result["errors"])
+    }
+
+    @Test
+    fun testMainWithMutation() {
+        main(arrayOf("""mutation { echo(message: "hello world") }"""))
+
+        val result = getJsonOutput()
+        val data = result["data"] as Map<String, Any>
+
+        assertEquals("hello world", data["echo"])
+        assertNull(result["errors"])
+    }
 }

--- a/demoapps/jetty-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
+++ b/demoapps/jetty-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
@@ -1,5 +1,6 @@
 package com.example.viadapp.resolvers
 
+import com.example.viadapp.resolvers.resolverbases.MutationResolvers
 import com.example.viadapp.resolvers.resolverbases.QueryResolvers
 import viaduct.api.resolver.Resolver
 
@@ -16,4 +17,14 @@ class AuthorResolver : QueryResolvers.Author() {
 @Resolver
 class ThrowExceptionResolver : QueryResolvers.ThrowException() {
     override suspend fun resolve(ctx: Context): Nothing = error("This is a resolver error")
+}
+
+@Resolver
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/jetty-starter/resolvers/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/jetty-starter/resolvers/src/main/viaduct/schema/schema.graphqls
@@ -2,4 +2,9 @@ extend type Query {
   greeting: String @resolver
   author: String @resolver
   throwException: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }

--- a/demoapps/jetty-starter/src/test/kotlin/com/example/viadapp/resolvers/HelloWorldTest.kt
+++ b/demoapps/jetty-starter/src/test/kotlin/com/example/viadapp/resolvers/HelloWorldTest.kt
@@ -333,4 +333,32 @@ class HelloWorldTest {
             }
         """.trimIndent()
     }
+
+    @Test
+    fun `Argument field greet returns personalised greeting`() {
+        val (statusCode, responseBody) = sendGraphQLRequest("""{ greet(name: "Viaduct") }""")
+
+        statusCode shouldBe 200
+        responseBody shouldEqualJson """
+            {
+              "data": {
+                "greet": "Hello, Viaduct!"
+              }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `Echo mutation returns the message`() {
+        val (statusCode, responseBody) = sendGraphQLRequest("""mutation { echo(message: "hello world") }""")
+
+        statusCode shouldBe 200
+        responseBody shouldEqualJson """
+            {
+              "data": {
+                "echo": "hello world"
+              }
+            }
+        """.trimIndent()
+    }
 }

--- a/demoapps/ksp-versioning.md
+++ b/demoapps/ksp-versioning.md
@@ -51,6 +51,16 @@ The Viaduct module plugin does NOT apply KSP itself. The consumer ("service engi
 
 This avoids the version-coupling problem entirely — we never need to know the consumer's Kotlin version at publish time.
 
+## Treehouse (Airbnb-internal) Constraint
+
+Viaduct is developed simultaneously in this OSS repo and in Airbnb's internal monorepo ("treehouse"). As of 2026-06-02, treehouse is pinned to **Kotlin 1.9.22**. This has two practical consequences:
+
+1. **The internal Viaduct deployment only ever uses the KSP1/Kotlin 1.9 row** of the compatibility matrix. All Kotlin 2.x rows in the demoapp matrix are validated solely for external (OSS) consumers.
+
+2. **Kotlin 2.3+ support is blocked by treehouse** for the foreseeable future. Even when KSP 2.3+ (standalone versioning) becomes the norm for external users, it cannot be adopted in treehouse until treehouse upgrades past Kotlin 1.9. Treat any Kotlin 2.3+ planning as a long-range OSS-only goal.
+
+When evaluating whether a new Viaduct feature or dependency can be backported to the internal version, always check whether it requires Kotlin APIs above 1.9.22. If it does, it is OSS-only and must be clearly marked as such.
+
 ## What We've Tested
 
 The demo apps verify the full matrix:

--- a/demoapps/ktor-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
+++ b/demoapps/ktor-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
@@ -1,5 +1,6 @@
 package com.example.viadapp.resolvers
 
+import com.example.viadapp.resolvers.resolverbases.MutationResolvers
 import com.example.viadapp.resolvers.resolverbases.QueryResolvers
 import viaduct.api.resolver.Resolver
 
@@ -11,4 +12,14 @@ class GreetingResolver : QueryResolvers.Greeting() {
 @Resolver
 class AuthorResolver : QueryResolvers.Author() {
     override suspend fun resolve(ctx: Context) = "Brian Kernighan"
+}
+
+@Resolver
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/ktor-starter/resolvers/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/ktor-starter/resolvers/src/main/viaduct/schema/schema.graphqls
@@ -1,4 +1,9 @@
 extend type Query {
   greeting: String @resolver
   author: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }

--- a/demoapps/ktor-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
+++ b/demoapps/ktor-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
@@ -248,4 +248,76 @@ class HelloWorldTest {
             }
             """.trimIndent()
         }
+
+    @Test
+    fun `Argument field greet returns personalised greeting`(): Unit =
+        testApplication {
+            application {
+                module()
+            }
+
+            val response = client.post("/graphql") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                setBody("""{"query":"{ greet(name: \"Viaduct\") }"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldEqualJson """
+            {
+              "data": {
+                "greet": "Hello, Viaduct!"
+              }
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `Echo mutation returns the message`(): Unit =
+        testApplication {
+            application {
+                module()
+            }
+
+            val response = client.post("/graphql") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                setBody("""{"query":"mutation { echo(message: \"hello world\") }"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldEqualJson """
+            {
+              "data": {
+                "echo": "hello world"
+              }
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `Introspection query returns expected types`(): Unit =
+        testApplication {
+            application {
+                module()
+            }
+
+            val response = client.post("/graphql") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                setBody("""{"query":"{ __schema { queryType { name } mutationType { name } } }"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldEqualJson """
+            {
+              "data": {
+                "__schema": {
+                  "queryType": { "name": "Query" },
+                  "mutationType": { "name": "Mutation" }
+                }
+              }
+            }
+            """.trimIndent()
+        }
 }

--- a/demoapps/micronaut-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
+++ b/demoapps/micronaut-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
@@ -84,4 +84,18 @@ class HelloWorldTest {
         result.errors!!.isNotEmpty() shouldBe true
         result.errors!![0].message shouldContain "Invalid syntax"
     }
+
+    @Test
+    fun `greet resolver returns personalised greeting`() {
+        val result = execute("""query { greet(name: "Viaduct") }""")
+        result.errors shouldBe emptyList()
+        result.getData().shouldNotBeNull()["greet"] shouldBe "Hello, Viaduct!"
+    }
+
+    @Test
+    fun `echo mutation returns the message`() {
+        val result = execute("""mutation { echo(message: "hello world") }""")
+        result.errors shouldBe emptyList()
+        result.getData().shouldNotBeNull()["echo"] shouldBe "hello world"
+    }
 }

--- a/demoapps/micronaut-starter/viadapp/src/main/kotlin/com/example/viadapp/HelloWorldResolver.kt
+++ b/demoapps/micronaut-starter/viadapp/src/main/kotlin/com/example/viadapp/HelloWorldResolver.kt
@@ -1,5 +1,6 @@
 package com.example.viadapp
 
+import com.example.viadapp.resolverbases.MutationResolvers
 import com.example.viadapp.resolverbases.QueryResolvers
 import jakarta.inject.Singleton
 import viaduct.api.resolver.Resolver
@@ -14,4 +15,16 @@ class HelloWorldResolver : QueryResolvers.Greeting() {
 @Singleton
 class AuthorResolver : QueryResolvers.Author() {
     override suspend fun resolve(ctx: Context) = "Brian Kernighan"
+}
+
+@Resolver
+@Singleton
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+@Singleton
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/micronaut-starter/viadapp/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/micronaut-starter/viadapp/src/main/viaduct/schema/schema.graphqls
@@ -2,4 +2,9 @@ extend type Query {
   greeting: String @resolver
   author: String @resolver
   throwException: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }

--- a/publications/runtime/build.gradle.kts
+++ b/publications/runtime/build.gradle.kts
@@ -50,6 +50,7 @@ tasks.named<ShadowJar>("shadowJar") {
     exclude("reactor/**")
     exclude("io/projectreactor/**")
     exclude("_COROUTINE/**")
+    exclude("org/junit/**")
 
     // Relocate common dependencies to avoid conflicts
     relocate("com.google.common", "viaduct.shaded.guava")

--- a/publications/runtime/build.gradle.kts
+++ b/publications/runtime/build.gradle.kts
@@ -50,7 +50,6 @@ tasks.named<ShadowJar>("shadowJar") {
     exclude("reactor/**")
     exclude("io/projectreactor/**")
     exclude("_COROUTINE/**")
-    exclude("org/junit/**")
 
     // Relocate common dependencies to avoid conflicts
     relocate("com.google.common", "viaduct.shaded.guava")


### PR DESCRIPTION
## Description

The starter demoapps previously tested only fixed `greeting`/`author` fields, leaving two core GraphQL capabilities — field arguments and mutations — completely untested below the `starwars` level. Since each starter targets a distinct Kotlin/KSP version (1.9 → 2.2, KSP1 → KSP2), a regression in argument codegen or mutation execution could silently pass all demoapp tests while breaking real consumers.

### Changes

**All four Kotlin starters** (cli, jetty, ktor, micronaut-starter):
- Schema: `greet(name: String!): String @resolver` — validates typed argument passing at each KSP/Kotlin version
- Schema: `extend type Mutation { echo(message: String!): String @resolver }` — first mutation coverage in starters
- Resolvers + tests for both new fields

**ktor-starter additionally**:
- Introspection test (`{ __schema { queryType { name } mutationType { name } } }`) — catches schema-publication regressions with no extra setup

**Documentation** (`AGENTS.md`, `ksp-versioning.md`):
- Expand KSP table with a Gradle column; document that `micronaut-starter` intentionally stays on Gradle 8.11 for Gradle 8 coverage
- Add GraphQL feature coverage matrix showing which capabilities each starter exercises
- Document the treehouse (Airbnb-internal) Kotlin 1.9.22 ceiling: only `cli-starter` approximates internal conditions; all Kotlin 2.x rows are OSS-consumer-only; Kotlin 2.3+ is a long-range OSS-only goal blocked by treehouse

Note: this branch also includes `5ac66832` (add junit fat-jar exclude) and its revert `c00de3af` — those two commits cancel each other out and are net-zero.

## How was it tested?  What documentation was provided?

All four starters verified as included builds:
```
./gradlew :cli-starter:test :micronaut-starter:test :jetty-starter:test :ktor-starter:test --no-daemon
```
All pass. Documentation updates are in `demoapps/AGENTS.md` and `demoapps/ksp-versioning.md`.