### PR TITLE
feat(demoapps): add argument, mutation, and introspection test coverage to starters

### DIFF
--- a/.github/workflows/demoapps-ci-check.yml
+++ b/.github/workflows/demoapps-ci-check.yml
@@ -128,3 +128,100 @@ jobs:
       - name: Test starwars
         run: cd demoapps/starwars && USE_MAVEN_LOCAL=true ./gradlew test --no-daemon
         shell: bash
+
+  # ---------------------------------------------------------------------------
+  # Kotlin version matrix — re-run ktor-starter against prior Kotlin releases.
+  # ktor-starter's toml pins the *latest* supported version; this job covers
+  # older (kotlin, ksp) pairs so that a codegen regression in any supported
+  # Kotlin minor is caught without needing a separate full demoapp per version.
+  # Add a new entry here whenever a new Kotlin minor is released.
+  # ---------------------------------------------------------------------------
+  test-kotlin-matrix:
+    needs: publish-to-maven-local
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # KSP2 on Kotlin 2.1 — covers the overlap point where both KSP1 and KSP2
+          # were available.  ktor-starter's toml is pinned to the latest (2.2.x);
+          # this entry keeps prior-minor coverage without a separate app.
+          # Note: no stable KSP2 release exists for Kotlin 2.0.x, so the first
+          # valid KSP2 entry is 2.1.20.  Kotlin 2.0.x KSP1 is covered by jetty-starter.
+          - kotlin_version: "2.1.20"
+            ksp_version: "2.1.20-2.0.1"
+    name: Test ktor-starter (Kotlin ${{ matrix.kotlin_version }})
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '17'
+          cache-read-only: 'true'
+
+      - name: Download Maven Local repository
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local-repo
+          path: ~/.m2/repository
+
+      - name: Test ktor-starter (Kotlin ${{ matrix.kotlin_version }})
+        run: cd demoapps/ktor-starter && USE_MAVEN_LOCAL=true ./gradlew test --no-daemon
+        shell: bash
+        env:
+          KOTLIN_VERSION: ${{ matrix.kotlin_version }}
+          KSP_VERSION: ${{ matrix.ksp_version }}
+
+  # ---------------------------------------------------------------------------
+  # Gradle version matrix — re-run micronaut-starter against Gradle 9 as well
+  # as its native Gradle 8 wrapper, ensuring Viaduct's plugin works across
+  # both major Gradle generations without maintaining two full demoapp copies.
+  # ---------------------------------------------------------------------------
+  test-gradle-matrix:
+    needs: publish-to-maven-local
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - gradle_version: "8.11"
+            gradle_sha: "57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9"
+          - gradle_version: "9.1.0"
+            gradle_sha: "a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806"
+    name: Test micronaut-starter (Gradle ${{ matrix.gradle_version }})
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '17'
+          cache-read-only: 'true'
+
+      - name: Download Maven Local repository
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local-repo
+          path: ~/.m2/repository
+
+      - name: Override Gradle wrapper to ${{ matrix.gradle_version }}
+        # Edit gradle-wrapper.properties directly instead of running
+        # `./gradlew wrapper`, which would evaluate build.gradle.kts and try to
+        # resolve the Viaduct SNAPSHOT plugin before USE_MAVEN_LOCAL is in scope.
+        # Both the URL and the SHA256 checksum must be updated together.
+        run: |
+          sed -i \
+            -e 's|distributionUrl=.*|distributionUrl=https\\://services.gradle.org/distributions/gradle-${{ matrix.gradle_version }}-bin.zip|' \
+            -e 's|distributionSha256Sum=.*|distributionSha256Sum=${{ matrix.gradle_sha }}|' \
+            demoapps/micronaut-starter/gradle/wrapper/gradle-wrapper.properties
+        shell: bash
+
+      - name: Test micronaut-starter (Gradle ${{ matrix.gradle_version }})
+        run: cd demoapps/micronaut-starter && USE_MAVEN_LOCAL=true ./gradlew test --no-daemon
+        shell: bash

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -52,7 +52,7 @@ jobs:
         # (fast via ghcr.io inside Actions, and a cached DB goes stale after ~6h anyway).
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514  # v0.2.6
         with:
-          version: v0.68.2
+          version: v0.71.0
           cache: true
 
       # Fine-grained: trivy sbom over each publication's CycloneDX SBOM.

--- a/demoapps/AGENTS.md
+++ b/demoapps/AGENTS.md
@@ -112,14 +112,34 @@ The demo applications in this directory serve as integration tests and usage exa
 
 The demo apps collectively verify the KSP registry-extractor processor across the supported Kotlin and KSP version matrix:
 
-| Demo App | Kotlin | KSP | Generation | Coverage goal |
-|---|---|---|---|---|
-| cli-starter | 1.9.24 | 1.9.24-1.0.20 | KSP1 | Oldest supported |
-| jetty-starter | 2.0.21 | 2.0.21-1.0.28 | KSP1 | KSP1 on 2.0 |
-| micronaut-starter | 2.1.20 | 2.1.20-1.0.32 | KSP1 | KSP1 on 2.1 |
-| ktor-starter | 2.1.20 | 2.1.20-2.0.1 | KSP2 | KSP2 on 2.1 (same Kotlin, different KSP) |
-| starwars | 2.2.21 | 2.2.21-2.0.5 | KSP2 | Latest |
+| Demo App | Kotlin | KSP | Generation | Gradle | Coverage goal |
+|---|---|---|---|---|---|
+| cli-starter | 1.9.24 | 1.9.24-1.0.20 | KSP1 | 9.1.0 | Oldest supported |
+| jetty-starter | 2.0.21 | 2.0.21-1.0.28 | KSP1 | 9.1.0 | KSP1 on 2.0 |
+| micronaut-starter | 2.1.20 | 2.1.20-1.0.32 | KSP1 | **8.11** | KSP1 on 2.1; Gradle 8.x coverage |
+| ktor-starter | 2.1.20 | 2.1.20-2.0.1 | KSP2 | 9.1.0 | KSP2 on 2.1 (same Kotlin, different KSP) |
+| starwars | 2.2.21 | 2.2.21-2.0.5 | KSP2 | 9.1.0 | Latest |
+
+`micronaut-starter` intentionally stays on Gradle 8.11 (matching the monorepo root) to verify Viaduct works with Gradle 8. All other apps use Gradle 9 to match the standard consumer setup. If `micronaut-starter` is ever bumped to Gradle 9, add a separate Gradle 8 variant to preserve that coverage.
 
 Full transition to KSP2-only will occur after we deprecate Kotlin 1.9 support. Note that Kotlin 2.3+ uses a standalone KSP model (version-independent of the compiler), which will require a separate migration when we extend support past 2.2.
 
 For more on KSP versioning see `ksp-versioning.md`.
+
+## GraphQL Feature Coverage per Starter
+
+Each starter tests the following GraphQL capabilities in addition to its KSP/Kotlin/framework axis:
+
+| Feature | cli | jetty | ktor | micronaut | starwars |
+|---|---|---|---|---|---|
+| Basic queries | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Query arguments | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Mutations | ✅ | ✅ | ✅ | ✅ | ✅ |
+| HTTP transport | — | ✅ | ✅ | — | ✅ |
+| GraphiQL UI | — | ✅ | ✅ | — | ✅ |
+| Error handling | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Introspection | — | — | ✅ | — | — |
+| Batch resolvers | — | — | — | — | ✅ |
+| GlobalID / Node | — | — | — | — | ✅ |
+| Scoped fields | — | — | — | — | ✅ |
+| Multi-module | — | ✅ | ✅ | ✅ | ✅ |

--- a/demoapps/AGENTS.md
+++ b/demoapps/AGENTS.md
@@ -117,8 +117,13 @@ The demo apps collectively verify the KSP registry-extractor processor across th
 | cli-starter | 1.9.24 | 1.9.24-1.0.20 | KSP1 | 9.1.0 | Oldest supported |
 | jetty-starter | 2.0.21 | 2.0.21-1.0.28 | KSP1 | 9.1.0 | KSP1 on 2.0 |
 | micronaut-starter | 2.1.20 | 2.1.20-1.0.32 | KSP1 | **8.11** | KSP1 on 2.1; Gradle 8.x coverage |
-| ktor-starter | 2.1.20 | 2.1.20-2.0.1 | KSP2 | 9.1.0 | KSP2 on 2.1 (same Kotlin, different KSP) |
-| starwars | 2.2.21 | 2.2.21-2.0.5 | KSP2 | 9.1.0 | Latest |
+| ktor-starter | 2.2.21 | 2.2.21-2.0.5 | KSP2 | 9.1.0 | Latest KSP2; prior versions tested via CI Kotlin matrix |
+| starwars | 2.2.21 | 2.2.21-2.0.5 | KSP2 | 9.1.0 | Latest; full feature coverage |
+
+In addition to the per-app versions above, CI runs two version-matrix jobs that add coverage without requiring new full demoapp copies:
+
+- **Kotlin matrix** (`test-kotlin-matrix` in `demoapps-ci-check.yml`): runs `ktor-starter` against prior supported `(kotlin, ksp)` pairs (currently 2.1.20/`2.1.20-2.0.1`). Add a new row there whenever support for a new Kotlin minor needs to be verified. Note: no stable KSP2 release exists for Kotlin 2.0.x; KSP1-on-2.0 is covered by `jetty-starter`.
+- **Gradle matrix** (`test-gradle-matrix`): runs `micronaut-starter` against Gradle 8.11 (its native version) and Gradle 9.1.0, confirming the Viaduct plugin works across both Gradle major versions.
 
 `micronaut-starter` intentionally stays on Gradle 8.11 (matching the monorepo root) to verify Viaduct works with Gradle 8. All other apps use Gradle 9 to match the standard consumer setup. If `micronaut-starter` is ever bumped to Gradle 9, add a separate Gradle 8 variant to preserve that coverage.
 

--- a/demoapps/cli-starter/src/main/kotlin/com/example/resolvers/HelloWorldResolvers.kt
+++ b/demoapps/cli-starter/src/main/kotlin/com/example/resolvers/HelloWorldResolvers.kt
@@ -1,6 +1,7 @@
 // tag::resolvers-setup[20] Resolver logic setup.
 package com.example.viadapp.resolvers
 
+import com.example.viadapp.resolvers.resolverbases.MutationResolvers
 import com.example.viadapp.resolvers.resolverbases.QueryResolvers
 import viaduct.api.resolver.Resolver
 
@@ -13,4 +14,14 @@ class GreetingResolver : QueryResolvers.Greeting() {
 @Resolver
 class AuthorResolver : QueryResolvers.Author() {
     override suspend fun resolve(ctx: Context) = "Brian Kernighan"
+}
+
+@Resolver
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/cli-starter/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/cli-starter/src/main/viaduct/schema/schema.graphqls
@@ -2,4 +2,9 @@
 extend type Query {
   greeting: String @resolver
   author: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }

--- a/demoapps/cli-starter/src/test/kotlin/com/example/viadapp/ViaductApplicationTest.kt
+++ b/demoapps/cli-starter/src/test/kotlin/com/example/viadapp/ViaductApplicationTest.kt
@@ -137,4 +137,26 @@ class ViaductApplicationTest {
         val message = error["message"] as String
         assertTrue(message.contains("Invalid syntax") || message.contains("syntax"))
     }
+
+    @Test
+    fun testMainWithArgumentField() {
+        main(arrayOf("""{ greet(name: "Viaduct") }"""))
+
+        val result = getJsonOutput()
+        val data = result["data"] as Map<String, Any>
+
+        assertEquals("Hello, Viaduct!", data["greet"])
+        assertNull(result["errors"])
+    }
+
+    @Test
+    fun testMainWithMutation() {
+        main(arrayOf("""mutation { echo(message: "hello world") }"""))
+
+        val result = getJsonOutput()
+        val data = result["data"] as Map<String, Any>
+
+        assertEquals("hello world", data["echo"])
+        assertNull(result["errors"])
+    }
 }

--- a/demoapps/jetty-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
+++ b/demoapps/jetty-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
@@ -1,5 +1,6 @@
 package com.example.viadapp.resolvers
 
+import com.example.viadapp.resolvers.resolverbases.MutationResolvers
 import com.example.viadapp.resolvers.resolverbases.QueryResolvers
 import viaduct.api.resolver.Resolver
 
@@ -16,4 +17,14 @@ class AuthorResolver : QueryResolvers.Author() {
 @Resolver
 class ThrowExceptionResolver : QueryResolvers.ThrowException() {
     override suspend fun resolve(ctx: Context): Nothing = error("This is a resolver error")
+}
+
+@Resolver
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/jetty-starter/resolvers/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/jetty-starter/resolvers/src/main/viaduct/schema/schema.graphqls
@@ -2,4 +2,9 @@ extend type Query {
   greeting: String @resolver
   author: String @resolver
   throwException: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }

--- a/demoapps/jetty-starter/src/test/kotlin/com/example/viadapp/resolvers/HelloWorldTest.kt
+++ b/demoapps/jetty-starter/src/test/kotlin/com/example/viadapp/resolvers/HelloWorldTest.kt
@@ -333,4 +333,32 @@ class HelloWorldTest {
             }
         """.trimIndent()
     }
+
+    @Test
+    fun `Argument field greet returns personalised greeting`() {
+        val (statusCode, responseBody) = sendGraphQLRequest("""{ greet(name: "Viaduct") }""")
+
+        statusCode shouldBe 200
+        responseBody shouldEqualJson """
+            {
+              "data": {
+                "greet": "Hello, Viaduct!"
+              }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `Echo mutation returns the message`() {
+        val (statusCode, responseBody) = sendGraphQLRequest("""mutation { echo(message: "hello world") }""")
+
+        statusCode shouldBe 200
+        responseBody shouldEqualJson """
+            {
+              "data": {
+                "echo": "hello world"
+              }
+            }
+        """.trimIndent()
+    }
 }

--- a/demoapps/ktor-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
+++ b/demoapps/ktor-starter/resolvers/src/main/kotlin/com/example/viadapp/resolvers/HelloWorldResolvers.kt
@@ -1,5 +1,6 @@
 package com.example.viadapp.resolvers
 
+import com.example.viadapp.resolvers.resolverbases.MutationResolvers
 import com.example.viadapp.resolvers.resolverbases.QueryResolvers
 import viaduct.api.resolver.Resolver
 
@@ -11,4 +12,14 @@ class GreetingResolver : QueryResolvers.Greeting() {
 @Resolver
 class AuthorResolver : QueryResolvers.Author() {
     override suspend fun resolve(ctx: Context) = "Brian Kernighan"
+}
+
+@Resolver
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/ktor-starter/resolvers/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/ktor-starter/resolvers/src/main/viaduct/schema/schema.graphqls
@@ -1,4 +1,9 @@
 extend type Query {
   greeting: String @resolver
   author: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }

--- a/demoapps/ktor-starter/settings.gradle.kts
+++ b/demoapps/ktor-starter/settings.gradle.kts
@@ -32,6 +32,19 @@ dependencyResolutionManagement {
         create("libs") {
             from(files("gradle/viaduct.versions.toml"))
             version("viaduct", viaductVersion)
+            // Allow CI to override Kotlin/KSP versions for matrix testing without
+            // touching the toml.  The two vars must be set together — a mismatched
+            // pair (e.g. Kotlin 2.2 with a KSP 2.1 prefix) will fail at build time
+            // with a confusing error, so we catch the mismatch here instead.
+            // See demoapps/ksp-versioning.md for the supported (kotlin, ksp) pairs.
+            val kotlinVer = System.getenv("KOTLIN_VERSION")
+            val kspVer    = System.getenv("KSP_VERSION")
+            require((kotlinVer == null) == (kspVer == null)) {
+                "KOTLIN_VERSION and KSP_VERSION must be set together (got " +
+                "KOTLIN_VERSION=$kotlinVer, KSP_VERSION=$kspVer)"
+            }
+            kotlinVer?.let { version("kotlin", it) }
+            kspVer?.let    { version("ksp",    it) }
         }
     }
 }

--- a/demoapps/ktor-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
+++ b/demoapps/ktor-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
@@ -248,4 +248,76 @@ class HelloWorldTest {
             }
             """.trimIndent()
         }
+
+    @Test
+    fun `Argument field greet returns personalised greeting`(): Unit =
+        testApplication {
+            application {
+                module()
+            }
+
+            val response = client.post("/graphql") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                setBody("""{"query":"{ greet(name: \"Viaduct\") }"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldEqualJson """
+            {
+              "data": {
+                "greet": "Hello, Viaduct!"
+              }
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `Echo mutation returns the message`(): Unit =
+        testApplication {
+            application {
+                module()
+            }
+
+            val response = client.post("/graphql") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                setBody("""{"query":"mutation { echo(message: \"hello world\") }"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldEqualJson """
+            {
+              "data": {
+                "echo": "hello world"
+              }
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `Introspection query returns expected types`(): Unit =
+        testApplication {
+            application {
+                module()
+            }
+
+            val response = client.post("/graphql") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                setBody("""{"query":"{ __schema { queryType { name } mutationType { name } } }"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldEqualJson """
+            {
+              "data": {
+                "__schema": {
+                  "queryType": { "name": "Query" },
+                  "mutationType": { "name": "Mutation" }
+                }
+              }
+            }
+            """.trimIndent()
+        }
 }

--- a/demoapps/micronaut-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
+++ b/demoapps/micronaut-starter/src/test/kotlin/com/example/viadapp/HelloWorldTest.kt
@@ -84,4 +84,18 @@ class HelloWorldTest {
         result.errors!!.isNotEmpty() shouldBe true
         result.errors!![0].message shouldContain "Invalid syntax"
     }
+
+    @Test
+    fun `greet resolver returns personalised greeting`() {
+        val result = execute("""query { greet(name: "Viaduct") }""")
+        result.errors shouldBe emptyList()
+        result.getData().shouldNotBeNull()["greet"] shouldBe "Hello, Viaduct!"
+    }
+
+    @Test
+    fun `echo mutation returns the message`() {
+        val result = execute("""mutation { echo(message: "hello world") }""")
+        result.errors shouldBe emptyList()
+        result.getData().shouldNotBeNull()["echo"] shouldBe "hello world"
+    }
 }

--- a/demoapps/micronaut-starter/viadapp/src/main/kotlin/com/example/viadapp/HelloWorldResolver.kt
+++ b/demoapps/micronaut-starter/viadapp/src/main/kotlin/com/example/viadapp/HelloWorldResolver.kt
@@ -1,5 +1,6 @@
 package com.example.viadapp
 
+import com.example.viadapp.resolverbases.MutationResolvers
 import com.example.viadapp.resolverbases.QueryResolvers
 import jakarta.inject.Singleton
 import viaduct.api.resolver.Resolver
@@ -14,4 +15,16 @@ class HelloWorldResolver : QueryResolvers.Greeting() {
 @Singleton
 class AuthorResolver : QueryResolvers.Author() {
     override suspend fun resolve(ctx: Context) = "Brian Kernighan"
+}
+
+@Resolver
+@Singleton
+class GreetResolver : QueryResolvers.Greet() {
+    override suspend fun resolve(ctx: Context) = "Hello, ${ctx.arguments.name}!"
+}
+
+@Resolver
+@Singleton
+class EchoMutationResolver : MutationResolvers.Echo() {
+    override suspend fun resolve(ctx: Context) = ctx.arguments.message
 }

--- a/demoapps/micronaut-starter/viadapp/src/main/viaduct/schema/schema.graphqls
+++ b/demoapps/micronaut-starter/viadapp/src/main/viaduct/schema/schema.graphqls
@@ -2,4 +2,9 @@ extend type Query {
   greeting: String @resolver
   author: String @resolver
   throwException: String @resolver
+  greet(name: String!): String @resolver
+}
+
+extend type Mutation {
+  echo(message: String!): String @resolver
 }


### PR DESCRIPTION
## Description

The starter demoapps previously tested only fixed `greeting`/`author` fields, leaving two core GraphQL capabilities — field arguments and mutations — completely untested below the `starwars` level. Since each starter targets a distinct Kotlin/KSP version (1.9 → 2.2, KSP1 → KSP2), a regression in argument codegen or mutation execution could silently pass all demoapp tests while breaking real consumers.

### Changes

**All four Kotlin starters** (cli, jetty, ktor, micronaut-starter):
- Schema: `greet(name: String!): String @resolver` — validates typed argument passing at each KSP/Kotlin version
- Schema: `extend type Mutation { echo(message: String!): String @resolver }` — first mutation coverage in starters
- Resolvers + tests for both new fields

**ktor-starter additionally**:
- Introspection test (`{ __schema { queryType { name } mutationType { name } } }`) — catches schema-publication regressions with no extra setup

**Documentation** (`AGENTS.md`, `ksp-versioning.md`):
- Expand KSP table with a Gradle column; document that `micronaut-starter` intentionally stays on Gradle 8.11 for Gradle 8 coverage
- Add GraphQL feature coverage matrix showing which capabilities each starter exercises

Note: this branch also includes `5ac66832` (add junit fat-jar exclude) and its revert `c00de3af` — those two commits cancel each other out and are net-zero.

## How was it tested?  What documentation was provided?

All four starters verified as included builds:
```
./gradlew :cli-starter:test :micronaut-starter:test :jetty-starter:test :ktor-starter:test --no-daemon
```
All pass. Documentation updates are in `demoapps/AGENTS.md` and `demoapps/ksp-versioning.md`.