### PR TITLE
ci: surface CycloneDX SBOMs in the security-scan job summary

### DIFF
--- a/.github/scripts/format_sbom_summary.py
+++ b/.github/scripts/format_sbom_summary.py
@@ -27,11 +27,16 @@ Notes:
     object with `id` (SPDX), a license object with `name` (non-SPDX), or an SPDX
     `expression`. All three are handled; the bulky embedded license `text` is
     ignored.
+  - With multiple scan dirs, SBOMs are de-duplicated by file path (so passing a
+    parent dir and a nested module dir doesn't double-count), and a module name
+    found in more than one root is qualified with its scan root so same-named
+    modules stay distinct instead of overwriting each other.
 """
 
 import json
 import os
 import sys
+from collections import Counter
 
 
 def find_sbom_reports(scan_dir):
@@ -102,27 +107,53 @@ def format_component_table(rows):
 
 
 def format_summary(scan_dirs):
-    reports = []
+    # Collect one record per SBOM, keyed by absolute path — NOT by module name.
+    # De-duping by path means a file reached via overlapping roots (e.g. a parent
+    # dir and a nested module dir) is summarized once; keeping records in a list
+    # means same-named modules from different roots don't overwrite each other
+    # (which would silently drop components and skew the total).
+    records = []  # each: {module, path, scan_dir, label, rows, error}
+    seen_paths = set()
     for d in scan_dirs:
-        if os.path.isdir(d):
-            reports.extend(find_sbom_reports(d))
+        if not os.path.isdir(d):
+            continue
+        for module, path in find_sbom_reports(d):
+            abs_path = os.path.abspath(path)
+            if abs_path in seen_paths:
+                continue
+            seen_paths.add(abs_path)
+            records.append({"module": module, "path": path, "scan_dir": d})
 
-    if not reports:
+    if not records:
         return "⚠️ No SBOM reports found (build/reports/sbom/cyclonedx.json)."
 
-    # Parse each module once; remember failures so the overview can flag them.
-    parsed = {}  # module -> sorted rows
-    failed = {}  # module -> error message
-    for module, path in sorted(reports):
+    # If a module name maps to more than one distinct file (i.e. two scan roots),
+    # qualify each colliding label with its scan root so the sections stay
+    # distinct. Unique names keep their bare label, so single-directory output
+    # (the CI path) is unchanged.
+    name_counts = Counter(r["module"] for r in records)
+    for r in records:
+        r["label"] = (
+            f"{r['module']} ({r['scan_dir']})"
+            if name_counts[r["module"]] > 1
+            else r["module"]
+        )
+
+    # Parse each SBOM; attach its rows or a parse error to the record.
+    for r in records:
         try:
-            components = load_components(path)
-            rows = sorted(
+            components = load_components(r["path"])
+            r["rows"] = sorted(
                 (component_row(c) for c in components),
-                key=lambda r: (r[0].lower(), r[1]),
+                key=lambda row: (row[0].lower(), row[1]),
             )
-            parsed[module] = rows
+            r["error"] = None
         except (OSError, ValueError) as err:
-            failed[module] = str(err)
+            r["rows"] = None
+            r["error"] = str(err)
+
+    ok = sorted((r for r in records if r["error"] is None), key=lambda r: r["label"])
+    bad = sorted((r for r in records if r["error"] is not None), key=lambda r: r["label"])
 
     lines = ["### SBOM: fat JAR contents", ""]
     lines.append(
@@ -136,20 +167,19 @@ def format_summary(scan_dirs):
     lines.append("| Publication | Components |")
     lines.append("|---|---:|")
     total = 0
-    for module in sorted(parsed):
-        count = len(parsed[module])
-        total += count
-        lines.append(f"| `{module}` | {count} |")
-    for module in sorted(failed):
-        lines.append(f"| `{module}` | ⚠️ unreadable |")
+    for r in ok:
+        total += len(r["rows"])
+        lines.append(f"| `{r['label']}` | {len(r['rows'])} |")
+    for r in bad:
+        lines.append(f"| `{r['label']}` | ⚠️ unreadable |")
     lines.append(f"| **Total** | {total} |")
     lines.append("")
 
     # Per-publication detail.
-    for module in sorted(parsed):
-        rows = parsed[module]
+    for r in ok:
+        rows = r["rows"]
         lines.append("<details>")
-        lines.append(f"<summary>{module} — {len(rows)} components</summary>")
+        lines.append(f"<summary>{r['label']} — {len(rows)} components</summary>")
         lines.append("")
         if rows:
             lines.append(format_component_table(rows))
@@ -159,11 +189,11 @@ def format_summary(scan_dirs):
         lines.append("</details>")
         lines.append("")
 
-    for module in sorted(failed):
+    for r in bad:
         lines.append("<details>")
-        lines.append(f"<summary>{module} — ⚠️ unreadable</summary>")
+        lines.append(f"<summary>{r['label']} — ⚠️ unreadable</summary>")
         lines.append("")
-        lines.append(f"Could not parse SBOM: {failed[module]}")
+        lines.append(f"Could not parse SBOM: {r['error']}")
         lines.append("")
         lines.append("</details>")
         lines.append("")

--- a/.github/scripts/format_sbom_summary.py
+++ b/.github/scripts/format_sbom_summary.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Formats per-publication CycloneDX SBOMs as a GitHub-flavored Markdown summary.
+
+Scans one or more directory trees for per-module CycloneDX SBOMs
+(build/reports/sbom/cyclonedx.json) and renders, for each publication, the list
+of dependency components on its runtime classpath — i.e. what gets bundled into
+that publication's fat JAR.
+
+Usage: format_sbom_summary.py <dir> [<dir> ...]
+
+Output has two sections:
+  1. An overview table (not collapsed): publication -> component count, + total.
+  2. A collapsed <details> section per publication with a
+     Dependency / Version / License table, sorted by dependency.
+
+Exit codes:
+  0 - success (INCLUDING the "no SBOMs found" case: this feeds an advisory job,
+      so an empty/short scan should render a notice, not fail the step)
+  2 - usage error (no directory arguments)
+
+Notes:
+  - The SBOM is generated over `runtimeClasspath`, which is the dependency graph
+    a publication bundles. It is close to, but not byte-identical with, the
+    shaded fat-JAR contents (the shadow step resolves compileClasspath and
+    applies excludes). The caption reflects this.
+  - A component's license can be encoded three ways in CycloneDX: a license
+    object with `id` (SPDX), a license object with `name` (non-SPDX), or an SPDX
+    `expression`. All three are handled; the bulky embedded license `text` is
+    ignored.
+"""
+
+import json
+import os
+import sys
+
+
+def find_sbom_reports(scan_dir):
+    """Find all per-module cyclonedx.json files under scan_dir.
+
+    Returns a list of (module_name, json_path). The module name is the path
+    segment(s) between scan_dir and the `build/reports/sbom` directory, joined
+    with ':' (e.g. publications/api/build/reports/sbom -> "api").
+    """
+    reports = []
+    for dirpath, _, filenames in os.walk(scan_dir):
+        if "cyclonedx.json" not in filenames:
+            continue
+        rel = os.path.relpath(dirpath, scan_dir).replace("\\", "/")
+        if not rel.endswith("build/reports/sbom"):
+            continue
+        parts = rel.split("/")
+        build_idx = parts.index("build")
+        if build_idx > 0:
+            module = ":".join(parts[:build_idx])
+        else:
+            # The scan dir is itself the module root (rel == build/reports/sbom).
+            module = os.path.basename(os.path.normpath(scan_dir))
+        reports.append((module, os.path.join(dirpath, "cyclonedx.json")))
+    return reports
+
+
+def extract_license(component):
+    """Return a human-readable license string for a CycloneDX component.
+
+    Handles the license-object (`id` / `name`) and `expression` encodings,
+    de-duplicates while preserving order, and falls back to an em dash.
+    """
+    names = []
+    for entry in component.get("licenses") or []:
+        lic = entry.get("license")
+        if isinstance(lic, dict):
+            value = lic.get("id") or lic.get("name")
+            if value:
+                names.append(value)
+        elif entry.get("expression"):
+            names.append(entry["expression"])
+    deduped = list(dict.fromkeys(names))
+    return ", ".join(deduped) if deduped else "—"
+
+
+def component_row(component):
+    """Map a CycloneDX component to a (dependency, version, license) row."""
+    group = (component.get("group") or "").strip()
+    name = (component.get("name") or "?").strip()
+    dependency = f"{group}:{name}" if group else name
+    version = (component.get("version") or "—").strip() or "—"
+    return (dependency, version, extract_license(component))
+
+
+def load_components(sbom_path):
+    """Parse a CycloneDX JSON file and return its `components` list (may raise)."""
+    with open(sbom_path, encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("components") or []
+
+
+def format_component_table(rows):
+    lines = ["| Dependency | Version | License |", "|---|---|---|"]
+    for dependency, version, license_str in rows:
+        lines.append(f"| `{dependency}` | {version} | {license_str} |")
+    return "\n".join(lines)
+
+
+def format_summary(scan_dirs):
+    reports = []
+    for d in scan_dirs:
+        if os.path.isdir(d):
+            reports.extend(find_sbom_reports(d))
+
+    if not reports:
+        return "⚠️ No SBOM reports found (build/reports/sbom/cyclonedx.json)."
+
+    # Parse each module once; remember failures so the overview can flag them.
+    parsed = {}  # module -> sorted rows
+    failed = {}  # module -> error message
+    for module, path in sorted(reports):
+        try:
+            components = load_components(path)
+            rows = sorted(
+                (component_row(c) for c in components),
+                key=lambda r: (r[0].lower(), r[1]),
+            )
+            parsed[module] = rows
+        except (OSError, ValueError) as err:
+            failed[module] = str(err)
+
+    lines = ["### SBOM: fat JAR contents", ""]
+    lines.append(
+        "_Dependency components on each publication's runtime classpath "
+        "(CycloneDX SBOM). Close to, but not byte-identical with, the shaded "
+        "fat-JAR contents._"
+    )
+    lines.append("")
+
+    # Overview table.
+    lines.append("| Publication | Components |")
+    lines.append("|---|---:|")
+    total = 0
+    for module in sorted(parsed):
+        count = len(parsed[module])
+        total += count
+        lines.append(f"| `{module}` | {count} |")
+    for module in sorted(failed):
+        lines.append(f"| `{module}` | ⚠️ unreadable |")
+    lines.append(f"| **Total** | {total} |")
+    lines.append("")
+
+    # Per-publication detail.
+    for module in sorted(parsed):
+        rows = parsed[module]
+        lines.append("<details>")
+        lines.append(f"<summary>{module} — {len(rows)} components</summary>")
+        lines.append("")
+        if rows:
+            lines.append(format_component_table(rows))
+        else:
+            lines.append("_No components on the runtime classpath._")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    for module in sorted(failed):
+        lines.append("<details>")
+        lines.append(f"<summary>{module} — ⚠️ unreadable</summary>")
+        lines.append("")
+        lines.append(f"Could not parse SBOM: {failed[module]}")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <dir> [<dir> ...]", file=sys.stderr)
+        sys.exit(2)
+    print(format_summary(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_format_sbom_summary.py
+++ b/.github/scripts/tests/test_format_sbom_summary.py
@@ -1,0 +1,249 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from format_sbom_summary import (
+    component_row,
+    extract_license,
+    find_sbom_reports,
+    format_summary,
+    main,
+)
+
+
+def _write_sbom(scan_dir, module, components, *, raw=None):
+    """Write a CycloneDX SBOM for `module` under scan_dir/<module>/build/reports/sbom."""
+    report_dir = os.path.join(scan_dir, module, "build", "reports", "sbom")
+    os.makedirs(report_dir, exist_ok=True)
+    path = os.path.join(report_dir, "cyclonedx.json")
+    with open(path, "w", encoding="utf-8") as f:
+        if raw is not None:
+            f.write(raw)
+        else:
+            json.dump(
+                {
+                    "bomFormat": "CycloneDX",
+                    "specVersion": "1.5",
+                    "metadata": {"component": {"name": module}},
+                    "components": components,
+                },
+                f,
+            )
+    return path
+
+
+# A golden fixture mirroring real cyclonedx-gradle-plugin 1.10.0 output (trimmed:
+# the bulky base64 license `text` blobs are dropped — the formatter ignores them).
+GOLDEN_COMPONENTS = [
+    # Deliberately out of order to prove the formatter sorts by dependency.
+    {
+        "type": "library",
+        "group": "com.example",
+        "name": "beta",
+        "version": "2.0.0",
+        "licenses": [{"license": {"name": "Custom License"}}],
+    },
+    {
+        "type": "library",
+        "group": "com.example",
+        "name": "alpha",
+        "version": "1.0.0",
+        "licenses": [{"license": {"id": "Apache-2.0"}}],
+    },
+]
+
+GOLDEN_EXPECTED = """\
+### SBOM: fat JAR contents
+
+_Dependency components on each publication's runtime classpath (CycloneDX SBOM). Close to, but not byte-identical with, the shaded fat-JAR contents._
+
+| Publication | Components |
+|---|---:|
+| `api` | 2 |
+| **Total** | 2 |
+
+<details>
+<summary>api — 2 components</summary>
+
+| Dependency | Version | License |
+|---|---|---|
+| `com.example:alpha` | 1.0.0 | Apache-2.0 |
+| `com.example:beta` | 2.0.0 | Custom License |
+
+</details>
+"""
+
+
+class TestExtractLicense(unittest.TestCase):
+
+    def test_spdx_id(self):
+        self.assertEqual(
+            extract_license({"licenses": [{"license": {"id": "Apache-2.0"}}]}),
+            "Apache-2.0",
+        )
+
+    def test_named_license(self):
+        self.assertEqual(
+            extract_license({"licenses": [{"license": {"name": "Custom BSD"}}]}),
+            "Custom BSD",
+        )
+
+    def test_id_preferred_over_name(self):
+        self.assertEqual(
+            extract_license(
+                {"licenses": [{"license": {"id": "MIT", "name": "MIT License"}}]}
+            ),
+            "MIT",
+        )
+
+    def test_expression(self):
+        self.assertEqual(
+            extract_license({"licenses": [{"expression": "(MIT OR Apache-2.0)"}]}),
+            "(MIT OR Apache-2.0)",
+        )
+
+    def test_multiple_distinct_joined(self):
+        self.assertEqual(
+            extract_license(
+                {
+                    "licenses": [
+                        {"license": {"id": "MIT"}},
+                        {"license": {"id": "Apache-2.0"}},
+                    ]
+                }
+            ),
+            "MIT, Apache-2.0",
+        )
+
+    def test_multiple_duplicates_deduped(self):
+        self.assertEqual(
+            extract_license(
+                {"licenses": [{"license": {"id": "MIT"}}, {"license": {"id": "MIT"}}]}
+            ),
+            "MIT",
+        )
+
+    def test_no_license_is_dash(self):
+        self.assertEqual(extract_license({}), "—")
+        self.assertEqual(extract_license({"licenses": []}), "—")
+
+
+class TestComponentRow(unittest.TestCase):
+
+    def test_group_and_name(self):
+        self.assertEqual(
+            component_row({"group": "org.x", "name": "y", "version": "1.0"}),
+            ("org.x:y", "1.0", "—"),
+        )
+
+    def test_name_only_when_group_missing(self):
+        self.assertEqual(
+            component_row({"name": "y", "version": "1.0"}),
+            ("y", "1.0", "—"),
+        )
+
+    def test_missing_version_is_dash(self):
+        self.assertEqual(
+            component_row({"group": "org.x", "name": "y"}),
+            ("org.x:y", "—", "—"),
+        )
+
+
+class TestFindSbomReports(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_finds_module_and_derives_name(self):
+        _write_sbom(self.tmpdir, "api", [])
+        _write_sbom(self.tmpdir, "javaapi-runtime", [])
+        modules = sorted(m for m, _ in find_sbom_reports(self.tmpdir))
+        self.assertEqual(modules, ["api", "javaapi-runtime"])
+
+    def test_ignores_cyclonedx_outside_sbom_dir(self):
+        stray = os.path.join(self.tmpdir, "api", "build", "reports", "other")
+        os.makedirs(stray)
+        with open(os.path.join(stray, "cyclonedx.json"), "w") as f:
+            f.write("{}")
+        self.assertEqual(find_sbom_reports(self.tmpdir), [])
+
+
+class TestFormatSummaryGolden(unittest.TestCase):
+
+    def test_golden_full_output(self):
+        tmpdir = tempfile.mkdtemp()
+        _write_sbom(tmpdir, "api", GOLDEN_COMPONENTS)
+        self.assertEqual(format_summary([tmpdir]), GOLDEN_EXPECTED)
+
+
+class TestFormatSummaryBehavior(unittest.TestCase):
+
+    def test_no_sboms_found(self):
+        result = format_summary([tempfile.mkdtemp()])
+        self.assertTrue(result.startswith("⚠️ No SBOM reports found"))
+
+    def test_nonexistent_dir_is_skipped(self):
+        result = format_summary(["/no/such/dir/at/all"])
+        self.assertTrue(result.startswith("⚠️ No SBOM reports found"))
+
+    def test_overview_total_across_modules(self):
+        tmpdir = tempfile.mkdtemp()
+        _write_sbom(tmpdir, "api", GOLDEN_COMPONENTS)  # 2 components
+        _write_sbom(
+            tmpdir,
+            "runtime",
+            [{"group": "g", "name": "n", "version": "1", "licenses": []}],  # 1
+        )
+        result = format_summary([tmpdir])
+        self.assertIn("| `api` | 2 |", result)
+        self.assertIn("| `runtime` | 1 |", result)
+        self.assertIn("| **Total** | 3 |", result)
+        # Modules are sorted: api before runtime.
+        self.assertLess(result.index("summary>api"), result.index("summary>runtime"))
+
+    def test_expression_and_missing_license_render(self):
+        tmpdir = tempfile.mkdtemp()
+        _write_sbom(
+            tmpdir,
+            "api",
+            [
+                {"group": "g", "name": "expr", "version": "1", "licenses": [{"expression": "(MIT OR Apache-2.0)"}]},
+                {"group": "g", "name": "none", "version": "2"},
+            ],
+        )
+        result = format_summary([tmpdir])
+        self.assertIn("| `g:expr` | 1 | (MIT OR Apache-2.0) |", result)
+        self.assertIn("| `g:none` | 2 | — |", result)
+
+    def test_empty_components_renders_note(self):
+        tmpdir = tempfile.mkdtemp()
+        _write_sbom(tmpdir, "bom", [])
+        result = format_summary([tmpdir])
+        self.assertIn("| `bom` | 0 |", result)
+        self.assertIn("_No components on the runtime classpath._", result)
+
+    def test_unreadable_sbom_is_flagged_not_fatal(self):
+        tmpdir = tempfile.mkdtemp()
+        _write_sbom(tmpdir, "api", [], raw="{ not valid json")
+        result = format_summary([tmpdir])
+        self.assertIn("| `api` | ⚠️ unreadable |", result)
+        self.assertIn("Could not parse SBOM", result)
+
+
+class TestMain(unittest.TestCase):
+
+    def test_usage_error_without_args(self):
+        with mock.patch.object(sys, "argv", ["format_sbom_summary.py"]):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_format_sbom_summary.py
+++ b/.github/scripts/tests/test_format_sbom_summary.py
@@ -236,6 +236,52 @@ class TestFormatSummaryBehavior(unittest.TestCase):
         self.assertIn("Could not parse SBOM", result)
 
 
+class TestFormatSummaryMultiRoot(unittest.TestCase):
+
+    def test_same_name_across_roots_no_data_loss(self):
+        # Two scan roots that each contain a DISTINCT module named `api`.
+        root_a = tempfile.mkdtemp()
+        root_b = tempfile.mkdtemp()
+        _write_sbom(
+            root_a,
+            "api",
+            [{"group": "g", "name": "only-in-a", "version": "1", "licenses": []}],
+        )
+        _write_sbom(
+            root_b,
+            "api",
+            [
+                {"group": "g", "name": "only-in-b", "version": "2", "licenses": []},
+                {"group": "g", "name": "also-in-b", "version": "3", "licenses": []},
+            ],
+        )
+        result = format_summary([root_a, root_b])
+        # No data loss: components from BOTH api's are present...
+        self.assertIn("`g:only-in-a`", result)
+        self.assertIn("`g:only-in-b`", result)
+        self.assertIn("`g:also-in-b`", result)
+        # ...and the total sums both rather than collapsing to one `api`.
+        self.assertIn("| **Total** | 3 |", result)
+        # Colliding labels are disambiguated by their scan root.
+        self.assertIn(f"api ({root_a})", result)
+        self.assertIn(f"api ({root_b})", result)
+
+    def test_overlapping_roots_dedupe_same_file(self):
+        # A parent dir and one of its nested module dirs resolve to the SAME file.
+        parent = tempfile.mkdtemp()
+        _write_sbom(
+            parent,
+            "api",
+            [{"group": "g", "name": "n", "version": "1", "licenses": []}],
+        )
+        nested = os.path.join(parent, "api")
+        result = format_summary([parent, nested])
+        # Counted exactly once (path de-dupe), not doubled, not disambiguated.
+        self.assertIn("| **Total** | 1 |", result)
+        self.assertEqual(result.count("<summary>api"), 1)
+        self.assertIn("<summary>api — 1 components</summary>", result)
+
+
 class TestMain(unittest.TestCase):
 
     def test_usage_error_without_args(self):

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -62,6 +62,14 @@ jobs:
         continue-on-error: true
         run: ./gradlew -p publications securityScan --no-daemon --continue
 
+      # Render the CycloneDX SBOMs generated above into the job summary, so reviewers
+      # can see what each publication fat JAR bundles without downloading anything.
+      - name: SBOM summary (job summary)
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: python3 .github/scripts/format_sbom_summary.py publications >> "$GITHUB_STEP_SUMMARY"
+
       # Build the shadow (fat) JARs so we can scan them as binaries.
       - name: Build fat JARs (publications)
         continue-on-error: true
@@ -134,6 +142,7 @@ jobs:
           path: |
             security-scan-report.md
             publications/*/build/reports/trivy/cve-report.json
+            publications/*/build/reports/sbom/cyclonedx.json
             build/reports/trivy-fatjar/*.json
 
       # Sticky PR comment via github-script (the repo's PR-interaction convention;

--- a/build-logic/src/main/kotlin/conventions/security-scanning.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/security-scanning.gradle.kts
@@ -48,6 +48,20 @@ abstract class SecurityScanningExtension @Inject constructor(objects: ObjectFact
 
 val securityScanning = extensions.create<SecurityScanningExtension>("securityScanning")
 
+// CycloneDX 1.10.0 invokes Task.project at execution time, which is unsupported under
+// Gradle's configuration cache. With the cache on (the repo default) the task doesn't
+// fail loudly — it silently resolves nothing and writes an EMPTY SBOM (no `components`).
+// Declaring it incompatible makes Gradle run it without the config cache, so the
+// dependency graph is actually resolved. This is marked unconditionally (not only inside
+// the `java` guard below): the plugin is applied to every project this convention touches,
+// including the java-platform `bom`, whose unmarked cyclonedxBom would otherwise hard-fail
+// the build under the config cache. Upstream: https://github.com/CycloneDX/cyclonedx-gradle-plugin
+tasks.withType(CycloneDxTask::class.java).configureEach {
+    notCompatibleWithConfigurationCache(
+        "CycloneDX 1.10.0 accesses Task.project at execution time (config-cache incompatible)"
+    )
+}
+
 // Only configure scans for projects with a Java/Kotlin runtimeClasspath.
 // java-platform (BOM) projects are skipped — their dependencies are constraints,
 // not a resolvable runtime classpath.

--- a/config/security/README.md
+++ b/config/security/README.md
@@ -37,6 +37,30 @@ ls -R */build/reports/{trivy,sbom,license}
 Trivy auto-fetches its vulnerability DB on first run and caches it at
 `~/.cache/trivy/`. Subsequent runs reuse the cache.
 
+## SBOM in the CI job summary
+
+The `cve-parity` job in `.github/workflows/security-scan.yml` renders every
+publication's CycloneDX SBOM into the **GitHub Actions job summary** — an
+overview table plus a collapsible component list (dependency, version, license)
+per fat JAR — and uploads the raw `cyclonedx.json` files in the
+`security-scan-reports` artifact. This lets you see what each published fat JAR
+bundles without building or downloading anything.
+
+To reproduce that summary locally:
+
+```bash
+# Generate the SBOMs (no Trivy required for SBOM generation alone)
+./gradlew -p publications cyclonedxBom
+
+# Format them into the same Markdown CI appends to the job summary
+python3 .github/scripts/format_sbom_summary.py publications
+```
+
+> `cyclonedxBom` runs without Gradle's configuration cache by design: the
+> CycloneDX 1.10.0 plugin is config-cache-incompatible and would otherwise emit
+> an empty SBOM. The `conventions.security-scanning` plugin marks the task so
+> this is handled automatically — no extra flags needed.
+
 ## Suppression Policy
 
 `.trivyignore` is plain text — one CVE ID per line. To suppress a finding:


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

SBOM generation was recently added, but its output was only visible by running the build locally and digging through per-module `build/reports/sbom/` directories — so it was hard to see what our published fat JARs actually bundle.

- The `cve-parity` job now renders each publication's CycloneDX SBOM into the **GitHub Actions job summary**: an overview table plus a collapsible component list (dependency / version / license) per fat JAR. The raw `cyclonedx.json` files are also uploaded in the `security-scan-reports` artifact.
- Also fixes a latent bug: the CycloneDX 1.10.0 plugin is incompatible with Gradle's configuration cache (on by default), under which it **silently emits an empty SBOM** — so the existing fine-grained `trivy sbom` scans had nothing to scan. The task is now marked `notCompatibleWithConfigurationCache`, so SBOMs are populated both locally and in CI.

## How was it tested?  What documentation was provided?

- Generated SBOMs for all 7 publications (302 components) and verified the formatter output both as text and rendered through GitHub's GFM engine.
- Confirmed the config-cache fix by counterfactual: `0 → 38` components; the build now succeeds (previously failed/empty).
- Added 20 unit + golden tests for the formatter, run by the existing `python-tests` job (`python3 -m unittest discover -s .github/scripts/tests`). `actionlint` clean on the workflow.
- Docs: added a "SBOM in the CI job summary" section to `config/security/README.md`.

<img width="974" height="863" alt="image" src="https://github.com/user-attachments/assets/64babde2-d6a1-4e0a-a80d-01e419b21646" />
