### PR TITLE
feat(gradle-plugins): support application projects below the Gradle root

### DIFF
--- a/gradle-plugins/AGENTS.md
+++ b/gradle-plugins/AGENTS.md
@@ -24,6 +24,6 @@ Included builds under `execution-tests/` contain small Viaduct projects used to 
 - `one-project` - a single Gradle project containing both the application and module plugins
 - `two-project` - two Gradle projects separating the application and module plugins
 
-These builds exercise task-execution paths of the plugins, including codegen execution and `serve` behavior.
+These builds exercise task-execution paths of the plugins, including codegen execution and schema assembly behavior.
 
 Note that the demoapps represent an additional source of task-execution testing.  The execution tests here are a deliberately designed test suite; the demoapps supplement that with less surgical, real-worldish test cases.

--- a/gradle-plugins/application/build.gradle.kts
+++ b/gradle-plugins/application/build.gradle.kts
@@ -15,8 +15,8 @@ dependencies {
     implementation(project(":common"))
 
     // Libraries the plugin source imports directly (binary schema generation).
-    // tenant-codegen and serve are NOT here — they are external tool artifacts resolved at
-    // build time via viaductCodegenClasspath / viaductServeClasspath Configurations.
+    // tenant-codegen is NOT here — it is an external tool artifact resolved at
+    // build time via the viaductCodegenClasspath Configuration.
     implementation(libs.viaduct.shared.graphql)
     implementation(libs.viaduct.shared.viaductschema)
     // Do NOT leak the Kotlin Gradle Plugin at runtime

--- a/gradle-plugins/application/src/main/kotlin/viaduct/gradle/ViaductApplicationPlugin.kt
+++ b/gradle-plugins/application/src/main/kotlin/viaduct/gradle/ViaductApplicationPlugin.kt
@@ -20,6 +20,7 @@ import viaduct.gradle.ViaductPluginCommon.createOrGetCodegenClasspath
 import viaduct.gradle.ViaductPluginCommon.createOrGetJavaCodegenClasspath
 import viaduct.gradle.ViaductPluginCommon.createOrGetJavaGRTCompileClasspath
 import viaduct.gradle.ViaductPluginCommon.pluginVersion
+import viaduct.gradle.ViaductPluginCommon.validateApplicationProjectPlacement
 import viaduct.gradle.task.AssembleCentralSchemaTask
 import viaduct.gradle.task.GenerateGRTClassFilesTask
 import viaduct.gradle.task.GenerateJavaGRTSourcesTask
@@ -27,9 +28,7 @@ import viaduct.gradle.task.GenerateJavaGRTSourcesTask
 abstract class ViaductApplicationPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit =
         with(project) {
-            require(this == rootProject) {
-                "Apply 'com.airbnb.viaduct.application-gradle-plugin' only to the root project."
-            }
+            validateApplicationProjectPlacement()
 
             extensions.create("viaductApplication", ViaductApplicationExtension::class.java, objects)
 
@@ -52,8 +51,8 @@ abstract class ViaductApplicationPlugin : Plugin<Project> {
                 javaGRTJar.flatMap { it.archiveFile },
             )
 
-            // Expose the Kotlin GRT jar on the root project's own classpath so root sources
-            // (main + tests) can reference generated types. Java-specific root projects can
+            // Expose the Kotlin GRT jar on the application project's own classpath so local sources
+            // (main + tests) can reference generated types. Java-specific application projects can
             // depend on generateViaductJavaGRTs explicitly.
             this.dependencies.add("api", files(kotlinGRTJar.flatMap { it.archiveFile }))
         }

--- a/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationPluginTest.kt
+++ b/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationPluginTest.kt
@@ -5,10 +5,12 @@ import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import viaduct.gradle.task.AssembleCentralSchemaTask
 
@@ -43,6 +45,67 @@ class ViaductApplicationPluginTest {
     fun `task should be created successfully`() {
         assertNotNull(task)
         assertTrue(task is AssembleCentralSchemaTask)
+    }
+
+    @Test
+    fun `application plugin can be applied to a non-root project`() {
+        val rootDir = tempDir.resolve("root").toFile().apply { mkdirs() }
+        val appDir = tempDir.resolve("root/app").toFile().apply { mkdirs() }
+
+        val root = ProjectBuilder.builder()
+            .withName("root")
+            .withProjectDir(rootDir)
+            .build()
+        root.pluginManager.apply("java-library")
+
+        val appProject = ProjectBuilder.builder()
+            .withName("app")
+            .withParent(root)
+            .withProjectDir(appDir)
+            .build()
+        appProject.pluginManager.apply("java-library")
+
+        appProject.pluginManager.apply(ViaductApplicationPlugin::class.java)
+
+        assertNotNull(appProject.extensions.findByType(ViaductApplicationExtension::class.java))
+    }
+
+    @Test
+    fun `application plugin rejects nested application projects`() {
+        val rootDir = tempDir.resolve("tree").toFile().apply { mkdirs() }
+        val appDir = tempDir.resolve("tree/app").toFile().apply { mkdirs() }
+        val nestedDir = tempDir.resolve("tree/app/nested").toFile().apply { mkdirs() }
+
+        val root = ProjectBuilder.builder()
+            .withName("root")
+            .withProjectDir(rootDir)
+            .build()
+        root.pluginManager.apply("java-library")
+
+        val appProject = ProjectBuilder.builder()
+            .withName("app")
+            .withParent(root)
+            .withProjectDir(appDir)
+            .build()
+        appProject.pluginManager.apply("java-library")
+
+        val nestedProject = ProjectBuilder.builder()
+            .withName("nested")
+            .withParent(appProject)
+            .withProjectDir(nestedDir)
+            .build()
+        nestedProject.pluginManager.apply("java-library")
+
+        appProject.pluginManager.apply(ViaductApplicationPlugin::class.java)
+
+        val ex = assertThrows<GradleException> {
+            nestedProject.pluginManager.apply(ViaductApplicationPlugin::class.java)
+        }
+        val allMessages = generateSequence(ex as Throwable?) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString("\n")
+        assertTrue(allMessages.contains(":app"))
+        assertTrue(allMessages.contains("containing Viaduct application project"))
     }
 
     @Test

--- a/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductPluginCommon.kt
+++ b/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductPluginCommon.kt
@@ -1,6 +1,7 @@
 package viaduct.gradle
 
 import java.util.Properties
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
@@ -11,6 +12,10 @@ import org.jetbrains.gradle.ext.taskTriggers
 import viaduct.gradle.shared.BuildFlags
 
 object ViaductPluginCommon {
+    val APPLICATION_PLUGIN_IDS = listOf(
+        "com.airbnb.viaduct.application-gradle-plugin",
+    )
+
     val VIADUCT_KIND: Attribute<String> =
         Attribute.of("viaduct.kind", String::class.java)
 
@@ -121,4 +126,30 @@ object ViaductPluginCommon {
      * Generates the content for a Viaduct build flags file in .bzl format.
      */
     fun buildFlagFileContent(flags: Map<String, String>): String = BuildFlags.toFileContent(flags)
+
+    fun Project.findContainingViaductApplicationProject(): Project? =
+        generateSequence(this) { it.parent }
+            .firstOrNull { candidate -> candidate.hasViaductApplicationPlugin() }
+
+    fun Project.requireContainingViaductApplicationProject(modulePluginId: String): Project =
+        findContainingViaductApplicationProject()
+            ?: throw GradleException(
+                "Apply one of ${APPLICATION_PLUGIN_IDS.joinToString(", ") { "'$it'" }} " +
+                    "to this project or an ancestor project before applying '$modulePluginId'.",
+            )
+
+    fun Project.validateApplicationProjectPlacement() {
+        val containingAncestor = parent?.findContainingViaductApplicationProject()
+        if (containingAncestor != null) {
+            throw GradleException(
+                "Project ${prettyPath()} cannot apply 'com.airbnb.viaduct.application-gradle-plugin' " +
+                    "because ancestor ${containingAncestor.prettyPath()} is already the containing " +
+                    "Viaduct application project for this subtree.",
+            )
+        }
+    }
+
+    fun Project.hasViaductApplicationPlugin(): Boolean = APPLICATION_PLUGIN_IDS.any { pluginId -> plugins.hasPlugin(pluginId) }
+
+    fun Project.prettyPath(): String = if (path == ":") ": (root)" else path
 }

--- a/gradle-plugins/module-java/src/main/kotlin/viaduct/gradle/ViaductJavaModulePlugin.kt
+++ b/gradle-plugins/module-java/src/main/kotlin/viaduct/gradle/ViaductJavaModulePlugin.kt
@@ -1,100 +1,43 @@
 package viaduct.gradle
 
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.LibraryElements
-import org.gradle.api.attributes.Usage
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import schemaPartitionDirectory
 import viaduct.gradle.ViaductPluginCommon.configureIdeaIntegration
 import viaduct.gradle.ViaductPluginCommon.createOrGetJavaCodegenClasspath
 import viaduct.gradle.ViaductPluginCommon.pluginVersion
-import viaduct.gradle.task.AssembleSchemaPartitionTask
 import viaduct.gradle.task.GenerateJavaResolverBasesTask
 
 class ViaductJavaModulePlugin : Plugin<Project> {
-    companion object {
-        private val SUPPORTED_APPLICATION_PLUGIN_IDS = listOf(
-            "com.airbnb.viaduct.application-gradle-plugin",
-        )
-    }
-
     override fun apply(project: Project): Unit =
         with(project) {
             val moduleExt = extensions.findByType(ViaductModuleExtension::class.java)
                 ?: extensions.create("viaductModule", ViaductModuleExtension::class.java, objects)
 
-            pluginManager.withPlugin("java") { enforceNoDirectModuleDeps() }
-            pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { enforceNoDirectModuleDeps() }
+            ViaductModulePluginSupport.configureDirectModuleDependencyChecks(this)
+            ViaductModulePluginSupport.configureModulePackageSuffixConvention(this, moduleExt)
 
-            SUPPORTED_APPLICATION_PLUGIN_IDS.forEach { pluginId ->
-                pluginManager.withPlugin(pluginId) {
-                    moduleExt.modulePackageSuffix.convention("")
-                }
-            }
+            val grtIncomingCfg = ViaductModulePluginSupport.createGRTIncomingConfiguration(
+                this,
+                ViaductPluginCommon.Configs.GRT_CLASSES_JAVA_INCOMING,
+                ViaductPluginCommon.Kind.JAVA_GRT_CLASSES,
+            )
 
-            val grtIncomingCfg = configurations.create(ViaductPluginCommon.Configs.GRT_CLASSES_JAVA_INCOMING).apply {
-                description = "Resolvable configuration for the GRT jar file."
-                isCanBeConsumed = false
-                isCanBeResolved = true
-                attributes {
-                    attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.JAVA_GRT_CLASSES)
-                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
-                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.LIBRARY))
-                    attribute(
-                        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                        objects.named(LibraryElements::class.java, LibraryElements.JAR)
-                    )
-                }
-            }
+            val assembleSchemaPartitionTask =
+                ViaductModulePluginSupport.setupAssembleSchemaPartitionTask(this, moduleExt)
+            ViaductModulePluginSupport.setupOutgoingConfigurationForPartitionSchema(this, assembleSchemaPartitionTask)
 
-            val assembleSchemaPartitionTask = setupAssembleSchemaPartitionTask(moduleExt)
-            setupOutgoingConfigurationForPartitionSchema(assembleSchemaPartitionTask)
-
-            val centralSchemaIncomingCfg = setupIncomingConfigurationForCentralSchema()
+            val centralSchemaIncomingCfg = ViaductModulePluginSupport.setupIncomingConfigurationForCentralSchema(this)
             val generateResolverBasesTask = setupGenerateResolverBasesTask(moduleExt, centralSchemaIncomingCfg)
 
-            // Register wiring with the root application plugin (Kotlin or Java variant)
-            SUPPORTED_APPLICATION_PLUGIN_IDS.forEach { pluginId ->
-                rootProject.pluginManager.withPlugin(pluginId) {
-                    rootProject.dependencies.add(
-                        ViaductPluginCommon.Configs.ALL_SCHEMA_PARTITIONS_INCOMING,
-                        rootProject.dependencies.project(
-                            mapOf(
-                                "path" to project.path,
-                                "configuration" to ViaductPluginCommon.Configs.SCHEMA_PARTITION_OUTGOING
-                            )
-                        )
-                    )
-                    rootProject.dependencies.add("runtimeOnly", project)
-
-                    dependencies.add(
-                        ViaductPluginCommon.Configs.CENTRAL_SCHEMA_INCOMING,
-                        project.dependencies.project(
-                            mapOf(
-                                "path" to rootProject.path,
-                                "configuration" to ViaductPluginCommon.Configs.CENTRAL_SCHEMA_OUTGOING
-                            )
-                        )
-                    )
-
-                    dependencies.add(
-                        ViaductPluginCommon.Configs.GRT_CLASSES_JAVA_INCOMING,
-                        project.dependencies.project(
-                            mapOf(
-                                "path" to rootProject.path,
-                                "configuration" to ViaductPluginCommon.Configs.GRT_CLASSES_JAVA_OUTGOING
-                            )
-                        )
-                    )
-                }
-            }
+            ViaductModulePluginSupport.wireToContainingApplicationProject(
+                this,
+                ViaductPluginCommon.Configs.GRT_CLASSES_JAVA_INCOMING,
+                ViaductPluginCommon.Configs.GRT_CLASSES_JAVA_OUTGOING,
+            )
 
             // GRT classes into source sets
             plugins.withId("java") {
@@ -124,47 +67,6 @@ class ViaductJavaModulePlugin : Plugin<Project> {
             }
         }
 
-    private fun Project.setupAssembleSchemaPartitionTask(moduleExt: ViaductModuleExtension): TaskProvider<AssembleSchemaPartitionTask> {
-        return tasks.register<AssembleSchemaPartitionTask>("prepareViaductSchemaPartition") {
-            val schemaDir = layout.projectDirectory.dir("src/main/viaduct/schema")
-            graphqlSrcDir.set(schemaDir)
-            schemaFiles.setFrom(fileTree(schemaDir).matching { include("**/*.graphqls") })
-            prefixPath.set(
-                moduleExt.modulePackageSuffix.map { raw ->
-                    val trimmed = raw.trim()
-                    (if (trimmed.isEmpty()) "" else trimmed.replace('.', '/')) + "/graphql"
-                }
-            )
-            outputDirectory.set(schemaPartitionDirectory())
-        }
-    }
-
-    private fun Project.setupOutgoingConfigurationForPartitionSchema(assembleSchemaPartitionTask: TaskProvider<AssembleSchemaPartitionTask>) {
-        val schemaPartitionCfg =
-            configurations.create(ViaductPluginCommon.Configs.SCHEMA_PARTITION_OUTGOING).apply {
-                description = "Consumable configuration containing the module's schema partition (aka, 'local schema')."
-                isCanBeConsumed = true
-                isCanBeResolved = false
-                attributes {
-                    attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.SCHEMA_PARTITION)
-                }
-            }
-        schemaPartitionCfg.outgoing.artifact(assembleSchemaPartitionTask.flatMap { it.outputDirectory })
-    }
-
-    private fun Project.setupIncomingConfigurationForCentralSchema(): Configuration {
-        val centralSchemaIncomingCfg =
-            configurations.create(ViaductPluginCommon.Configs.CENTRAL_SCHEMA_INCOMING).apply {
-                description = "Resolvable configuration for the central schema (used to generate resolver base classes)."
-                isCanBeConsumed = false
-                isCanBeResolved = true
-                attributes {
-                    attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.CENTRAL_SCHEMA)
-                }
-            }
-        return centralSchemaIncomingCfg
-    }
-
     private fun Project.setupGenerateResolverBasesTask(
         moduleExt: ViaductModuleExtension,
         centralSchemaIncomingCfg: Configuration
@@ -178,62 +80,13 @@ class ViaductJavaModulePlugin : Plugin<Project> {
             classpath.setFrom(codegenClasspath)
         }
 
-        afterEvaluate {
-            val appliedAppPluginId = SUPPORTED_APPLICATION_PLUGIN_IDS.firstOrNull {
-                rootProject.plugins.hasPlugin(it)
-            }
-            if (appliedAppPluginId == null) {
-                throw GradleException(
-                    "Apply one of ${SUPPORTED_APPLICATION_PLUGIN_IDS.joinToString(", ") { "'$it'" }} " +
-                        "to the root project before applying 'com.airbnb.viaduct.module-java-gradle-plugin'."
-                )
-            }
-            val appExt = rootProject.extensions.getByType(ViaductApplicationExtension::class.java)
-            val prefix = appExt.modulePackagePrefix.orNull
-            if (prefix.isNullOrBlank()) {
-                throw GradleException(
-                    "viaductApplication.modulePackagePrefix must be set in the root project. " +
-                        "Add it to your root build file:\n" +
-                        "  viaductApplication {\n" +
-                        "    modulePackagePrefix = \"com.example.myapp\"\n" +
-                        "  }"
-                )
-            }
+        ViaductModulePluginSupport.validateContainingApplicationProject(
+            this,
+            "com.airbnb.viaduct.module-java-gradle-plugin",
+        ) { appExt ->
             taskProvider.configure { wireToExtensions(moduleExt, appExt) }
         }
 
         return taskProvider
     }
-
-    private fun Project.enforceNoDirectModuleDeps() {
-        configurations.configureEach {
-            withDependencies {
-                filterIsInstance<ProjectDependency>().forEach { pd ->
-                    val target = this@enforceNoDirectModuleDeps.findProject(pd.path)
-                    if (target != null &&
-                        isViaductModule(target) &&
-                        this@enforceNoDirectModuleDeps != rootProject &&
-                        target != rootProject
-                    ) {
-                        val from = this@enforceNoDirectModuleDeps.prettyPath()
-                        val to = target.prettyPath()
-                        val build = this@enforceNoDirectModuleDeps.buildFile
-
-                        throw GradleException(
-                            "Module $from must not depend directly on $to; " +
-                                "used in $build, use the central schema for inter-module references."
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private fun isViaductModule(target: Project): Boolean {
-        if (target.plugins.hasPlugin(ViaductJavaModulePlugin::class.java)) return true
-        // Detect the sibling Kotlin module plugin by ID to avoid a compile dep on :plugins-module.
-        return target.plugins.hasPlugin("com.airbnb.viaduct.module-gradle-plugin")
-    }
 }
-
-private fun Project.prettyPath(): String = if (path == ":") ": (root)" else path

--- a/gradle-plugins/module/src/main/kotlin/viaduct/gradle/ViaductModulePlugin.kt
+++ b/gradle-plugins/module/src/main/kotlin/viaduct/gradle/ViaductModulePlugin.kt
@@ -15,9 +15,13 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import schemaPartitionDirectory
+import viaduct.gradle.ViaductPluginCommon.APPLICATION_PLUGIN_IDS
 import viaduct.gradle.ViaductPluginCommon.configureIdeaIntegration
 import viaduct.gradle.ViaductPluginCommon.createOrGetCodegenClasspath
+import viaduct.gradle.ViaductPluginCommon.findContainingViaductApplicationProject
 import viaduct.gradle.ViaductPluginCommon.pluginVersion
+import viaduct.gradle.ViaductPluginCommon.prettyPath
+import viaduct.gradle.ViaductPluginCommon.requireContainingViaductApplicationProject
 import viaduct.gradle.task.AssembleSchemaPartitionTask
 import viaduct.gradle.task.AssembleTenantModuleConfigFileTask
 import viaduct.gradle.task.GenerateResolverBasesTask
@@ -33,73 +37,29 @@ class ViaductModulePlugin : Plugin<Project> {
             val moduleExt = extensions.findByType(ViaductModuleExtension::class.java)
                 ?: extensions.create("viaductModule", ViaductModuleExtension::class.java, objects)
 
-            pluginManager.withPlugin("java") { enforceNoDirectModuleDeps() }
-            pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { enforceNoDirectModuleDeps() }
+            ViaductModulePluginSupport.configureDirectModuleDependencyChecks(this)
+            ViaductModulePluginSupport.configureModulePackageSuffixConvention(this, moduleExt)
 
-            SUPPORTED_APPLICATION_PLUGIN_IDS.forEach { pluginId ->
-                pluginManager.withPlugin(pluginId) {
-                    moduleExt.modulePackageSuffix.convention("")
-                }
-            }
+            val grtIncomingCfg = ViaductModulePluginSupport.createGRTIncomingConfiguration(
+                this,
+                ViaductPluginCommon.Configs.GRT_CLASSES_KOTLIN_INCOMING,
+                ViaductPluginCommon.Kind.KOTLIN_GRT_CLASSES,
+            )
 
-            val grtIncomingCfg = configurations.create(ViaductPluginCommon.Configs.GRT_CLASSES_KOTLIN_INCOMING).apply {
-                description = "Resolvable configuration for the GRT jar file."
-                isCanBeConsumed = false
-                isCanBeResolved = true
-                attributes {
-                    attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.KOTLIN_GRT_CLASSES)
-                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
-                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.LIBRARY))
-                    attribute(
-                        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                        objects.named(LibraryElements::class.java, LibraryElements.JAR)
-                    )
-                }
-            }
+            val assembleSchemaPartitionTask =
+                ViaductModulePluginSupport.setupAssembleSchemaPartitionTask(this, moduleExt)
+            ViaductModulePluginSupport.setupOutgoingConfigurationForPartitionSchema(this, assembleSchemaPartitionTask)
 
-            val assembleSchemaPartitionTask = setupAssembleSchemaPartitionTask(moduleExt)
-            setupOutgoingConfigurationForPartitionSchema(assembleSchemaPartitionTask)
-
-            val centralSchemaIncomingCfg = setupIncomingConfigurationForCentralSchema()
+            val centralSchemaIncomingCfg = ViaductModulePluginSupport.setupIncomingConfigurationForCentralSchema(this)
             val generateResolverBasesTask = setupGenerateResolverBasesTask(moduleExt, centralSchemaIncomingCfg)
 
             setupKspRegistryExtractor(moduleExt)
 
-            // Register wiring with the root application plugin (Kotlin or Java variant) if present
-            SUPPORTED_APPLICATION_PLUGIN_IDS.forEach { pluginId ->
-                rootProject.pluginManager.withPlugin(pluginId) {
-                    rootProject.dependencies.add(
-                        ViaductPluginCommon.Configs.ALL_SCHEMA_PARTITIONS_INCOMING,
-                        rootProject.dependencies.project(
-                            mapOf(
-                                "path" to project.path,
-                                "configuration" to ViaductPluginCommon.Configs.SCHEMA_PARTITION_OUTGOING
-                            )
-                        )
-                    )
-                    rootProject.dependencies.add("runtimeOnly", project)
-
-                    dependencies.add(
-                        ViaductPluginCommon.Configs.CENTRAL_SCHEMA_INCOMING,
-                        project.dependencies.project(
-                            mapOf(
-                                "path" to rootProject.path,
-                                "configuration" to ViaductPluginCommon.Configs.CENTRAL_SCHEMA_OUTGOING
-                            )
-                        )
-                    )
-
-                    dependencies.add(
-                        ViaductPluginCommon.Configs.GRT_CLASSES_KOTLIN_INCOMING,
-                        project.dependencies.project(
-                            mapOf(
-                                "path" to rootProject.path,
-                                "configuration" to ViaductPluginCommon.Configs.GRT_CLASSES_KOTLIN_OUTGOING
-                            )
-                        )
-                    )
-                }
-            }
+            ViaductModulePluginSupport.wireToContainingApplicationProject(
+                this,
+                ViaductPluginCommon.Configs.GRT_CLASSES_KOTLIN_INCOMING,
+                ViaductPluginCommon.Configs.GRT_CLASSES_KOTLIN_OUTGOING,
+            )
 
             // GRT classes into source sets
             plugins.withId("java") {
@@ -128,47 +88,6 @@ class ViaductModulePlugin : Plugin<Project> {
                 dependsOn(generateResolverBasesTask)
             }
         }
-
-    private fun Project.setupAssembleSchemaPartitionTask(moduleExt: ViaductModuleExtension): TaskProvider<AssembleSchemaPartitionTask> {
-        return tasks.register<AssembleSchemaPartitionTask>("prepareViaductSchemaPartition") {
-            val schemaDir = layout.projectDirectory.dir("src/main/viaduct/schema")
-            graphqlSrcDir.set(schemaDir)
-            schemaFiles.setFrom(fileTree(schemaDir).matching { include("**/*.graphqls") })
-            prefixPath.set(
-                moduleExt.modulePackageSuffix.map { raw ->
-                    val trimmed = raw.trim()
-                    (if (trimmed.isEmpty()) "" else trimmed.replace('.', '/')) + "/graphql"
-                }
-            )
-            outputDirectory.set(schemaPartitionDirectory())
-        }
-    }
-
-    private fun Project.setupOutgoingConfigurationForPartitionSchema(assembleSchemaPartitionTask: TaskProvider<AssembleSchemaPartitionTask>) {
-        val schemaPartitionCfg =
-            configurations.create(ViaductPluginCommon.Configs.SCHEMA_PARTITION_OUTGOING).apply {
-                description = "Consumable configuration containing the module's schema partition (aka, 'local schema')."
-                isCanBeConsumed = true
-                isCanBeResolved = false
-                attributes {
-                    attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.SCHEMA_PARTITION)
-                }
-            }
-        schemaPartitionCfg.outgoing.artifact(assembleSchemaPartitionTask.flatMap { it.outputDirectory })
-    }
-
-    private fun Project.setupIncomingConfigurationForCentralSchema(): Configuration {
-        val centralSchemaIncomingCfg =
-            configurations.create(ViaductPluginCommon.Configs.CENTRAL_SCHEMA_INCOMING).apply {
-                description = "Resolvable configuration for the central schema (used to generate resolver base classes)."
-                isCanBeConsumed = false
-                isCanBeResolved = true
-                attributes {
-                    attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.CENTRAL_SCHEMA)
-                }
-            }
-        return centralSchemaIncomingCfg
-    }
 
     private fun Project.setupKspRegistryExtractor(moduleExt: ViaductModuleExtension) {
         val version = pluginVersion(ViaductModulePlugin::class.java)
@@ -225,7 +144,9 @@ class ViaductModulePlugin : Plugin<Project> {
 
             // Wire tenant package (needs afterEvaluate to read appExt)
             afterEvaluate {
-                val appExt = rootProject.extensions.findByType(ViaductApplicationExtension::class.java)
+                val appExt = findContainingViaductApplicationProject()
+                    ?.extensions
+                    ?.findByType(ViaductApplicationExtension::class.java)
                 if (appExt != null) {
                     val pkg = computeTenantPackage(moduleExt, appExt)
                     assembleTask.configure { tenantPackage.set(pkg) }
@@ -267,10 +188,6 @@ class ViaductModulePlugin : Plugin<Project> {
     internal companion object {
         private const val RESOLVER_CODEGEN_MAIN_CLASS = "viaduct.tenant.codegen.cli.ViaductGenerator\$Main"
 
-        private val SUPPORTED_APPLICATION_PLUGIN_IDS = listOf(
-            "com.airbnb.viaduct.application-gradle-plugin",
-        )
-
         fun validateKotlinVersion(kotlinVersion: String): String? {
             val major = kotlinVersion.substringBefore('.').toIntOrNull() ?: return null
             val minor = kotlinVersion.substringAfter('.').substringBefore('.').toIntOrNull() ?: return null
@@ -291,7 +208,7 @@ class ViaductModulePlugin : Plugin<Project> {
         return kotlinExt.coreLibrariesVersion
     }
 
-    private fun computeTenantPackage(
+    internal fun computeTenantPackage(
         moduleExt: ViaductModuleExtension,
         appExt: ViaductApplicationExtension
     ): String {
@@ -324,31 +241,172 @@ class ViaductModulePlugin : Plugin<Project> {
         // - OK: plugin presence checks, reading final extension values, configuring already-registered tasks
         // - NOT OK: filesystem probing, task registration, dependency resolution, task-graph inspection,
         //           or any other late configuration unrelated to extension validation
-        afterEvaluate {
-            val appliedAppPluginId = SUPPORTED_APPLICATION_PLUGIN_IDS.firstOrNull {
-                rootProject.plugins.hasPlugin(it)
-            }
-            if (appliedAppPluginId == null) {
-                throw GradleException(
-                    "Apply one of ${SUPPORTED_APPLICATION_PLUGIN_IDS.joinToString(", ") { "'$it'" }} " +
-                        "to the root project before applying 'com.airbnb.viaduct.module-gradle-plugin'."
-                )
-            }
-            val appExt = rootProject.extensions.getByType(ViaductApplicationExtension::class.java)
-            val prefix = appExt.modulePackagePrefix.orNull
-            if (prefix.isNullOrBlank()) {
-                throw GradleException(
-                    "viaductApplication.modulePackagePrefix must be set in the root project. " +
-                        "Add it to your root build file:\n" +
-                        "  viaductApplication {\n" +
-                        "    modulePackagePrefix = \"com.example.myapp\"\n" +
-                        "  }"
-                )
-            }
+        ViaductModulePluginSupport.validateContainingApplicationProject(
+            this,
+            "com.airbnb.viaduct.module-gradle-plugin",
+        ) { appExt ->
             taskProvider.configure { wireToExtensions(moduleExt, appExt) }
         }
 
         return taskProvider
+    }
+}
+
+object ViaductModulePluginSupport {
+    private val MODULE_PLUGIN_IDS = listOf(
+        "com.airbnb.viaduct.module-gradle-plugin",
+        "com.airbnb.viaduct.module-java-gradle-plugin",
+    )
+
+    fun configureDirectModuleDependencyChecks(project: Project) {
+        project.pluginManager.withPlugin("java") { project.enforceNoDirectModuleDeps() }
+        project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { project.enforceNoDirectModuleDeps() }
+    }
+
+    fun configureModulePackageSuffixConvention(
+        project: Project,
+        moduleExt: ViaductModuleExtension
+    ) {
+        APPLICATION_PLUGIN_IDS.forEach { pluginId ->
+            project.pluginManager.withPlugin(pluginId) {
+                moduleExt.modulePackageSuffix.convention("")
+            }
+        }
+    }
+
+    fun createGRTIncomingConfiguration(
+        project: Project,
+        configurationName: String,
+        kind: String,
+    ): Configuration =
+        project.configurations.create(configurationName).apply {
+            description = "Resolvable configuration for the GRT jar file."
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            attributes {
+                attribute(ViaductPluginCommon.VIADUCT_KIND, kind)
+                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
+                attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category::class.java, Category.LIBRARY))
+                attribute(
+                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                    project.objects.named(LibraryElements::class.java, LibraryElements.JAR),
+                )
+            }
+        }
+
+    fun setupAssembleSchemaPartitionTask(
+        project: Project,
+        moduleExt: ViaductModuleExtension,
+    ): TaskProvider<AssembleSchemaPartitionTask> =
+        project.tasks.register<AssembleSchemaPartitionTask>("prepareViaductSchemaPartition") {
+            val schemaDir = project.layout.projectDirectory.dir("src/main/viaduct/schema")
+            graphqlSrcDir.set(schemaDir)
+            schemaFiles.setFrom(project.fileTree(schemaDir).matching { include("**/*.graphqls") })
+            prefixPath.set(
+                moduleExt.modulePackageSuffix.map { raw ->
+                    val trimmed = raw.trim()
+                    (if (trimmed.isEmpty()) "" else trimmed.replace('.', '/')) + "/graphql"
+                },
+            )
+            outputDirectory.set(project.schemaPartitionDirectory())
+        }
+
+    fun setupOutgoingConfigurationForPartitionSchema(
+        project: Project,
+        assembleSchemaPartitionTask: TaskProvider<AssembleSchemaPartitionTask>,
+    ) {
+        val schemaPartitionCfg =
+            project.configurations.create(ViaductPluginCommon.Configs.SCHEMA_PARTITION_OUTGOING).apply {
+                description = "Consumable configuration containing the module's schema partition (aka, 'local schema')."
+                isCanBeConsumed = true
+                isCanBeResolved = false
+                attributes {
+                    attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.SCHEMA_PARTITION)
+                }
+            }
+        schemaPartitionCfg.outgoing.artifact(assembleSchemaPartitionTask.flatMap { it.outputDirectory })
+    }
+
+    fun setupIncomingConfigurationForCentralSchema(project: Project): Configuration =
+        project.configurations.create(ViaductPluginCommon.Configs.CENTRAL_SCHEMA_INCOMING).apply {
+            description = "Resolvable configuration for the central schema (used to generate resolver base classes)."
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            attributes {
+                attribute(ViaductPluginCommon.VIADUCT_KIND, ViaductPluginCommon.Kind.CENTRAL_SCHEMA)
+            }
+        }
+
+    fun validateContainingApplicationProject(
+        project: Project,
+        modulePluginId: String,
+        configure: Project.(ViaductApplicationExtension) -> Unit,
+    ) {
+        project.afterEvaluate {
+            val applicationProject = requireContainingViaductApplicationProject(modulePluginId)
+            val appExt = applicationProject.extensions.getByType(ViaductApplicationExtension::class.java)
+            val prefix = appExt.modulePackagePrefix.orNull
+            if (prefix.isNullOrBlank()) {
+                throw GradleException(
+                    "viaductApplication.modulePackagePrefix must be set in the containing Viaduct " +
+                        "application project ${applicationProject.prettyPath()}. " +
+                        "Add it to that build file:\n" +
+                        "  viaductApplication {\n" +
+                        "    modulePackagePrefix = \"com.example.myapp\"\n" +
+                        "  }",
+                )
+            }
+            project.configure(appExt)
+        }
+    }
+
+    fun wireToContainingApplicationProject(
+        project: Project,
+        grtIncomingConfigName: String,
+        grtOutgoingConfigName: String,
+    ) {
+        var wired = false
+
+        generateSequence(project) { it.parent }.forEach { candidate ->
+            APPLICATION_PLUGIN_IDS.forEach { pluginId ->
+                candidate.pluginManager.withPlugin(pluginId) {
+                    if (wired || project.findContainingViaductApplicationProject() != candidate) return@withPlugin
+
+                    candidate.dependencies.add(
+                        ViaductPluginCommon.Configs.ALL_SCHEMA_PARTITIONS_INCOMING,
+                        candidate.dependencies.project(
+                            mapOf(
+                                "path" to project.path,
+                                "configuration" to ViaductPluginCommon.Configs.SCHEMA_PARTITION_OUTGOING,
+                            ),
+                        ),
+                    )
+                    candidate.dependencies.add("runtimeOnly", project)
+
+                    project.dependencies.add(
+                        ViaductPluginCommon.Configs.CENTRAL_SCHEMA_INCOMING,
+                        project.dependencies.project(
+                            mapOf(
+                                "path" to candidate.path,
+                                "configuration" to ViaductPluginCommon.Configs.CENTRAL_SCHEMA_OUTGOING,
+                            ),
+                        ),
+                    )
+
+                    project.dependencies.add(
+                        grtIncomingConfigName,
+                        project.dependencies.project(
+                            mapOf(
+                                "path" to candidate.path,
+                                "configuration" to grtOutgoingConfigName,
+                            ),
+                        ),
+                    )
+
+                    wired = true
+                }
+            }
+        }
     }
 
     private fun Project.enforceNoDirectModuleDeps() {
@@ -356,10 +414,11 @@ class ViaductModulePlugin : Plugin<Project> {
             withDependencies {
                 filterIsInstance<ProjectDependency>().forEach { pd ->
                     val target = this@enforceNoDirectModuleDeps.findProject(pd.path)
+                    val applicationProject = this@enforceNoDirectModuleDeps.findContainingViaductApplicationProject()
                     if (target != null &&
                         isViaductModule(target) &&
-                        this@enforceNoDirectModuleDeps != rootProject &&
-                        target != rootProject
+                        this@enforceNoDirectModuleDeps != applicationProject &&
+                        target != applicationProject
                     ) {
                         val from = this@enforceNoDirectModuleDeps.prettyPath()
                         val to = target.prettyPath()
@@ -367,7 +426,7 @@ class ViaductModulePlugin : Plugin<Project> {
 
                         throw GradleException(
                             "Module $from must not depend directly on $to; " +
-                                "used in $build, use the central schema for inter-module references."
+                                "used in $build, use the central schema for inter-module references.",
                         )
                     }
                 }
@@ -375,11 +434,5 @@ class ViaductModulePlugin : Plugin<Project> {
         }
     }
 
-    private fun isViaductModule(target: Project): Boolean {
-        if (target.plugins.hasPlugin(ViaductModulePlugin::class.java)) return true
-        // Detect the sibling Java module plugin by ID to avoid a compile dep on :plugins-module-java.
-        return target.plugins.hasPlugin("com.airbnb.viaduct.module-java-gradle-plugin")
-    }
+    private fun isViaductModule(target: Project): Boolean = MODULE_PLUGIN_IDS.any { pluginId -> target.plugins.hasPlugin(pluginId) }
 }
-
-private fun Project.prettyPath(): String = if (path == ":") ": (root)" else path

--- a/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductModulePluginFunctionalTest.kt
+++ b/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductModulePluginFunctionalTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.io.TempDir
  * TestKit functional tests for the module plugin.
  *
  * These tests cover diagnostics, configuration-time enforcement, and model wiring only.
- * Real execution (codegen, serve) is validated through demoapps.
+ * Real execution (codegen, schema assembly) is validated through demoapps.
  */
 class ViaductModulePluginFunctionalTest {
     @TempDir

--- a/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductModulePluginFunctionalTest.kt
+++ b/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductModulePluginFunctionalTest.kt
@@ -88,6 +88,80 @@ class ViaductModulePluginFunctionalTest {
     }
 
     @Test
+    fun `module resolves schema and grt dependencies from nearest application ancestor`() {
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            rootProject.name = "test"
+            include("app")
+            include("app:mymodule")
+            """.trimIndent()
+        )
+        File(projectDir, "build.gradle.kts").writeText("")
+
+        val appDir = File(projectDir, "app").also { it.mkdirs() }
+        File(appDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                `java-library`
+                id("com.airbnb.viaduct.application-gradle-plugin")
+            }
+            viaductApplication {
+                modulePackagePrefix.set("com.example.test")
+            }
+            """.trimIndent()
+        )
+
+        val moduleDir = File(projectDir, "app/mymodule").also { it.mkdirs() }
+        File(moduleDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                `java-library`
+                kotlin("jvm")
+                id("com.airbnb.viaduct.module-gradle-plugin")
+                id("com.google.devtools.ksp")
+            }
+            viaductModule {
+                modulePackageSuffix.set("mymodule")
+            }
+
+            tasks.register("printViaductApplicationAnchor") {
+                doLast {
+                    val projectDependencyType = org.gradle.api.artifacts.ProjectDependency::class.java
+                    val centralSchemaProject =
+                        configurations.getByName("viaductCentralSchemaIn")
+                            .dependencies
+                            .withType(projectDependencyType)
+                            .single()
+                            .dependencyProject
+                            .path
+                    val grtProject =
+                        configurations.getByName("viaductKotlinGRTClassesIn")
+                            .dependencies
+                            .withType(projectDependencyType)
+                            .single()
+                            .dependencyProject
+                            .path
+
+                    println("CENTRAL_SCHEMA_PROJECT=${'$'}centralSchemaProject")
+                    println("KOTLIN_GRT_PROJECT=${'$'}grtProject")
+                }
+            }
+            """.trimIndent()
+        )
+        val schemaDir = File(moduleDir, "src/main/viaduct/schema").also { it.mkdirs() }
+        File(schemaDir, "schema.graphqls").writeText("type Query { field: String }")
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath(combinedPluginClasspath())
+            .withArguments(":app:mymodule:printViaductApplicationAnchor")
+            .build()
+
+        assertTrue(result.output.contains("CENTRAL_SCHEMA_PROJECT=:app"), "Expected central schema dependency to target ':app'")
+        assertTrue(result.output.contains("KOTLIN_GRT_PROJECT=:app"), "Expected Kotlin GRT dependency to target ':app'")
+    }
+
+    @Test
     fun `missing modulePackagePrefix fails with clear message`() {
         File(projectDir, "settings.gradle.kts").writeText(
             """

--- a/publications/buildtime/build.gradle.kts
+++ b/publications/buildtime/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 viaductPublishing {
     name.set("Build Time Tools")
-    description.set("Fat jar bundling all Viaduct build-time tools (codegen and serve) for plugin tool classpaths")
+    description.set("Fat jar bundling Viaduct build-time code generation tools for plugin tool classpaths")
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

The Gradle plugins currently assume the Viaduct application plugin is applied to the Gradle root project. That makes hierarchical multi-project builds awkward, because modules under a non-root application project still try to wire schema and GRT dependencies through `rootProject`, and the application plugin rejects being applied anywhere else.

This PR changes that anchor from "the Gradle root" to "the nearest ancestor with the application plugin". The application plugin now only rejects nested application projects inside an existing Viaduct application subtree, and the module/module-java plugins share common helpers that find the containing application project, wire central schema and GRT dependencies to it, and scope the direct-module-dependency checks to that application subtree.

This PR also removes stale references to the deleted `serve` task and artifact from the Gradle plugin docs and buildtime publication metadata.

## Documentation

Developer docs and Gradle publication descriptions were updated.

## How was it validated?

* Added unit tests in `ViaductApplicationPluginTest` covering non-root application projects and rejecting nested application projects.
* Added functional tests in `ViaductModulePluginFunctionalTest` covering same-project topology support and wiring modules to their nearest containing application project.
* `./gradlew :gradle-plugins:application:test :gradle-plugins:module:test :gradle-plugins:module-java:test :gradle-plugins:common:test` -- BUILD SUCCESSFUL

Co-Authored-By: Codex <noreply@openai.com>
