### PR TITLE
build: retry flaky tests on CI via gradle test-retry plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(plugin(libs.plugins.shadow))
     implementation(plugin(libs.plugins.cyclonedx.bom))
     implementation(plugin(libs.plugins.jk1.license.report))
+    implementation(plugin(libs.plugins.test.retry))
     compileOnly(libs.detekt.api)
 
     // settings dependencies

--- a/build-logic/src/main/kotlin/conventions/gradle-plugin-kotlin.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/gradle-plugin-kotlin.gradle.kts
@@ -25,6 +25,7 @@ package conventions
 plugins {
     java // idempotent — both kotlin-dsl and kotlin-jvm already apply this
     id("conventions.jacoco")
+    id("conventions.test-retry")
 }
 
 java {

--- a/build-logic/src/main/kotlin/conventions/kotlin.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/kotlin.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("conventions.kotlin-compile-config")
     id("conventions.kotlin-without-tests")
     id("conventions.jacoco")
+    id("conventions.test-retry")
 }
 
 val libs = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")

--- a/build-logic/src/main/kotlin/conventions/test-retry.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/test-retry.gradle.kts
@@ -1,0 +1,18 @@
+package conventions
+
+plugins {
+    id("org.gradle.test-retry")
+}
+
+// Retry flaky tests on CI only, so local runs stay honest. A test that fails and
+// then passes on retry is still reported as flaky in the test report and the
+// Develocity build scan, so flakiness stays visible rather than masked.
+val onCi = providers.environmentVariable("CI").orNull == "true"
+
+tasks.withType<Test>().configureEach {
+    retry {
+        maxRetries.set(if (onCi) 2 else 0)
+        maxFailures.set(5) // >5 failures = systemic breakage; don't retry
+        failOnPassedAfterRetry.set(false) // passed-on-retry stays green
+    }
+}

--- a/build-logic/src/main/kotlin/conventions/test-retry.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/test-retry.gradle.kts
@@ -4,10 +4,15 @@ plugins {
     id("org.gradle.test-retry")
 }
 
-// Retry flaky tests on CI only, so local runs stay honest. A test that fails and
-// then passes on retry is still reported as flaky in the test report and the
-// Develocity build scan, so flakiness stays visible rather than masked.
-val onCi = providers.environmentVariable("CI").orNull == "true"
+// Retry flaky tests only on CI, so local runs stay honest by default. Enable via the
+// `CI` env var (set by GitHub Actions) or `-PonCI=true`. A test that fails and then
+// passes on retry is still reported as flaky in the test report and the Develocity
+// build scan, so flakiness stays visible rather than masked.
+val onCi =
+    providers.gradleProperty("onCI")
+        .orElse(providers.environmentVariable("CI"))
+        .map(String::toBoolean)
+        .getOrElse(false)
 
 tasks.withType<Test>().configureEach {
     retry {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ idea-gradle-plugin = "1.3"
 shadow = "8.3.9"
 cyclonedx-gradle = "1.10.0"
 jk1-license-report = "2.9"
+test-retry = "1.6.5"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -65,6 +66,7 @@ shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx-gradle" }
 jk1-license-report = { id = "com.github.jk1.dependency-license-report", version.ref = "jk1-license-report" }
+test-retry = { id = "org.gradle.test-retry", version.ref = "test-retry" }
 
 [libraries]
 # Project


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The public CI intermittently fails on flaky tests: a single flaky leg reds the whole check and forces a manual "re-run failed jobs", which generates recurring alerts. A concrete recent example is `KotlinFieldBatchResolverContractTest > field batch resolver batches multiple field requests` (`:core:tenant:runtime`), which failed once and passed on re-run. The OSS build had no test-retry configured, so every flake required a human to re-run the job.

This adds the Gradle `org.gradle.test-retry` plugin (1.6.5) as a **CI-only** safety net:

- New `conventions.test-retry` convention, applied via `conventions.kotlin` so it reaches all 32 test modules.
- `maxRetries = 2` only when `CI=true` (a GitHub Actions default env var); `0` locally, so local runs stay honest.
- `maxFailures = 5`, so systemic breakage (>5 failing tests) fails fast instead of retrying.
- `failOnPassedAfterRetry = false`, so a test that passes on retry keeps the build green.

Flakiness stays **visible** rather than hidden — a retried test is reported as flaky in the JUnit test report and the Develocity build scan we already publish. This is a safety net to stop flakes from blocking CI; it is **not** a fix for the underlying flaky test, which should be addressed separately.

Relates to: https://github.com/airbnb/viaduct/actions/runs/27070144561/attempts/1

## How was it tested?  What documentation was provided?

- `./gradlew -p build-logic compileKotlin --rerun-tasks` → `BUILD SUCCESSFUL` — confirms the new convention compiles from scratch and the `test-retry` plugin + `retry { }` task extension resolve
- `CI=true ./gradlew -p core :tenant:runtime:test --tests "*KotlinFieldBatchResolverContractTest*"` → `BUILD SUCCESSFUL` — the convention applies to a real test module without breaking existing test config (JUnit Platform, JaCoCo) and Gradle's configuration cache stays compatible ("Configuration cache entry stored")
- Coverage check: confirmed all modules applying `conventions.kotlin` inherit the convention and no Java-only test module is missed
- Local behavior is a no-op by construction: `maxRetries` resolves to `0` when `CI` is not `true` so local test runs are unchanged