### PR TITLE
fix(ci): skip demoapp cleanup when tmp branch already deleted

### DIFF
--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -195,11 +195,13 @@ jobs:
             exit 1
           fi
 
-          # Log current SHA for recovery before deleting
+          # Resolve the branch SHA (logged for recovery) and require a real commit
+          # SHA before deleting. gh api emits its JSON error body on stdout for a
+          # missing ref, so a non-empty value alone does not mean the branch exists.
           SHA=$(gh api "repos/viaduct-dev/${DEMOAPP}/git/refs/heads/${DEST_BRANCH}" \
-            --jq '.object.sha' 2>/dev/null || echo "")
-          if [ -z "$SHA" ]; then
-            echo "Branch '${DEST_BRANCH}' does not exist in viaduct-dev/${DEMOAPP} — skipping"
+            --jq '.object.sha' 2>/dev/null || true)
+          if ! [[ "$SHA" =~ ^[0-9a-f]{40,64}$ ]]; then
+            echo "Branch '${DEST_BRANCH}' not found in viaduct-dev/${DEMOAPP} (already deleted?) — skipping"
             exit 0
           fi
           echo "Branch '${DEST_BRANCH}' in viaduct-dev/${DEMOAPP} points to ${SHA}"


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The `cleanup` jobs in the demoapp nightly/dispatch pipeline fail with HTTP 422 whenever the `tmp/<ref>` branch in a `viaduct-dev/*` repo is already gone — which happens when failed jobs are re-run (the first attempt's cleanup already deleted the branches) or when a concurrent run deletes them. This piles spurious red jobs onto the run.

Root cause: `gh api` prints its JSON error body to **stdout** on a 404, so

    SHA=$(gh api ".../git/refs/heads/${DEST_BRANCH}" --jq '.object.sha' 2>/dev/null || echo "")

captures `{"message":"Not Found",...}` (non-empty). The `[ -z "$SHA" ]` skip never fires, so the step proceeds to `DELETE` a non-existent ref and fails with 422.

Fix: require `$SHA` to be a real commit SHA (`^[0-9a-f]{40,64}$`) before deleting; otherwise the branch is already gone, so skip. The `DELETE` itself is unchanged.

Scope: this stops `cleanup` from emitting false failures. It does **not** make the pipeline re-runnable — `check-demoapps` still can't clone a deleted `tmp/` branch on a re-run; making the pipeline safe to re-run is a separate follow-up.

## How was it tested?  What documentation was provided?

- `actionlint` passes (validates the workflow YAML and shellchecks the `run:` script)
- Verified the new guard against the live API: a non-existent branch → **skips (exit 0)**; an existing branch (`main`) → **proceeds** with the real SHA