### PR TITLE
fix(ci): make demoapp pipeline re-run-safe and reap stale tmp branches

### DIFF
--- a/.github/workflows/check-published-demoapps.yml
+++ b/.github/workflows/check-published-demoapps.yml
@@ -43,8 +43,12 @@ jobs:
           REF: ${{ inputs.ref }}
           DEMOAPP: ${{ matrix.demoapp }}
         run: |
-          git clone --branch "$REF" --depth 1 \
-            "https://github.com/viaduct-dev/${DEMOAPP}.git" app
+          if ! git clone --branch "$REF" --depth 1 \
+              "https://github.com/viaduct-dev/${DEMOAPP}.git" app; then
+            echo "::error::Could not clone '${REF}' from viaduct-dev/${DEMOAPP} — the branch may not exist."
+            echo "::error::Ephemeral tmp/* branches are cleaned up after a run; 'Re-run failed jobs' will not recreate them. Dispatch a fresh run instead."
+            exit 1
+          fi
         shell: bash
 
       - uses: actions/setup-java@v5

--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -169,11 +169,14 @@ jobs:
     secrets: inherit
 
   # ---------------------------------------------------------------------------
-  # Delete temporary branches in viaduct-dev/* repos (ephemeral refs only)
+  # Delete temporary branches in viaduct-dev/* repos (ephemeral refs only).
+  # Runs only when check-demoapps succeeded, so a failed run keeps its branches and
+  # "Re-run failed jobs" can re-clone them. Stale tmp/* branches from failed or
+  # cleanup-less runs are reaped by sweep-tmp-branches.yml.
   # ---------------------------------------------------------------------------
   cleanup:
     needs: [push-demoapps, check-demoapps]
-    if: always() && startsWith(needs.push-demoapps.outputs.destination_branch, 'tmp/')
+    if: always() && startsWith(needs.push-demoapps.outputs.destination_branch, 'tmp/') && needs.check-demoapps.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/sweep-tmp-branches.yml
+++ b/.github/workflows/sweep-tmp-branches.yml
@@ -1,0 +1,100 @@
+name: Sweep Stale tmp/* Branches
+# Reaps leftover tmp/<ref> branches in the viaduct-dev/* demoapp repos.
+#
+# The demoapp pipelines push ephemeral tmp/<ref> branches to those repos. The in-run
+# cleanup in demoapps-nightly-check.yml only deletes them when the run succeeded (so a
+# failed run stays re-runnable), and some dispatch paths (e.g. e2e-snapshot-test.yml)
+# don't clean up at all. This scheduled sweep bounds the resulting leak by deleting
+# tmp/* branches whose latest commit is older than the TTL.
+
+on:
+  schedule:
+    - cron: '30 6 * * 1-5'   # 06:30 UTC weekdays, just after the nightly build
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: "Delete tmp/* branches whose latest commit is older than this many days"
+        required: false
+        default: "7"
+        type: string
+      dry_run:
+        description: "List what would be deleted without deleting (manual runs preview by default)"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sweep-tmp-branches
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demoapp: [cli-starter, jetty-starter, ktor-starter, micronaut-starter, starwars]
+    name: Sweep ${{ matrix.demoapp }}
+    steps:
+      - name: Delete stale tmp/* branches
+        env:
+          GH_TOKEN: ${{ secrets.VIADUCT_GRAPHQL_GITHUB_ACCESS_TOKEN }}
+          DEMOAPP: ${{ matrix.demoapp }}
+          # On schedule these inputs are empty -> default to a real sweep with a 7-day TTL.
+          MAX_AGE_DAYS: ${{ inputs.max_age_days || '7' }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          REPO="viaduct-dev/${DEMOAPP}"
+          MAX_AGE_DAYS="${MAX_AGE_DAYS:-7}"
+          DRY_RUN="${DRY_RUN:-false}"
+          now=$(date -u +%s)
+          cutoff=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
+          echo "Sweeping ${REPO}: deleting tmp/* branches older than ${MAX_AGE_DAYS}d (dry_run=${DRY_RUN})"
+
+          refs=$(gh api "repos/${REPO}/git/matching-refs/heads/tmp/" --jq '.[].ref' 2>/dev/null || true)
+          if [ -z "$refs" ]; then
+            echo "No tmp/* branches found."
+            exit 0
+          fi
+
+          while IFS= read -r ref; do
+            branch="${ref#refs/heads/}"
+
+            # Defense-in-depth: only ever touch tmp/* branches.
+            if [[ "$branch" != tmp/* ]]; then
+              echo "  skipping non-tmp ref '${branch}'"
+              continue
+            fi
+
+            sha=$(gh api "repos/${REPO}/git/refs/heads/${branch}" --jq '.object.sha' 2>/dev/null || true)
+            if ! [[ "$sha" =~ ^[0-9a-f]{40,64}$ ]]; then
+              echo "  ${branch}: no commit SHA (already gone?) — skipping"
+              continue
+            fi
+
+            committed=$(gh api "repos/${REPO}/commits/${sha}" --jq '.commit.committer.date' 2>/dev/null || true)
+            if [ -z "$committed" ]; then
+              echo "  ${branch}: could not read commit date — skipping"
+              continue
+            fi
+            committed_ts=$(date -u -d "$committed" +%s)
+            age_days=$(( (now - committed_ts) / 86400 ))
+
+            if [ "$committed_ts" -ge "$cutoff" ]; then
+              echo "  ${branch}: ${age_days}d old — keep"
+            elif [ "$DRY_RUN" = "true" ]; then
+              echo "  ${branch}: ${age_days}d old — WOULD DELETE (dry run)"
+            else
+              if gh api -X DELETE "repos/${REPO}/git/refs/heads/${branch}"; then
+                echo "  ${branch}: ${age_days}d old — deleted (was ${sha})"
+              else
+                echo "  ${branch}: delete failed (already gone?)"
+              fi
+            fi
+          done <<< "$refs"
+        shell: bash


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Re-running the demoapp pipeline can't currently succeed: the in-run `cleanup` deletes the `tmp/<ref>` branches in `viaduct-dev/*`, but "Re-run failed jobs" doesn't re-run `push-demoapps`, so `check-demoapps` has nothing to clone → "remote branch not found" (this is what alerted on [#383](https://github.com/airbnb/viaduct/pull/383)). Separately, ~12 `tmp/*` branches have already leaked from dispatch paths that never clean up (e.g. `e2e-snapshot-test.yml` has no cleanup job).

This makes the pipeline re-run-safe and bounds the leak:

1. **Gate in-run cleanup on success** (`demoapps-nightly-check.yml`): only delete the `tmp/*` branches when `check-demoapps` succeeded. A failed run keeps its branches, so "Re-run failed jobs" can re-clone and pass.
2. **Scheduled sweep** (`sweep-tmp-branches.yml`): daily, deletes `tmp/*` branches whose latest commit is older than 7 days across the 5 `viaduct-dev` repos. Reaps the existing leak and bounds the branches kept by (1). `tmp/*`-only, reusing the validate-before-delete guard from [#386](https://github.com/airbnb/viaduct/pull/386). Manual dispatch previews by default (`dry_run=true`).
3. **Clearer clone failure** (`check-published-demoapps.yml`): if the branch is gone (e.g. re-running a run older than the sweep TTL), print "dispatch a fresh run; re-running won't recreate it" instead of a raw git error.

Degrades gracefully: even if GitHub doesn't re-run the (now-skipped) cleanup on a partial re-run, the scheduled sweep is the backstop, so re-run safety doesn't hinge on exact "Re-run failed jobs" semantics.

## How was it tested?  What documentation was provided?

- `actionlint` passes on all three workflows (YAML + shellcheck of the `run:` scripts).
- **Sweep logic dry-run against the live repos** (read-only): with TTL=7d it correctly flags all 12 stale branches (26–45 days old, across cli/jetty/micronaut/starwars) as WOULD-DELETE and finds none in ktor-starter. Confirmed the `tmp/*` branches are Copybara commits whose committer date tracks push time (distinct dates per dispatch), so committer date is a sound age signal.