### PR TITLE
ci: surface security-scan report in the job summary for fork PRs

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -161,7 +161,11 @@ jobs:
       # no peter-evans actions are used here). Finds the existing comment by the
       # marker the script emits and updates it, else creates one.
       - name: Post sticky PR comment
-        if: always() && github.event_name == 'pull_request'
+        # Same-repo PRs only: PRs from forks get a read-only GITHUB_TOKEN that can't
+        # post comments. Those still get the report via the job summary + artifact.
+        if: >-
+          always() && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v8
         with:
@@ -191,19 +195,35 @@ jobs:
               core.info('No PR context; skipping comment.');
               return;
             }
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              { owner, repo, issue_number, per_page: 100 },
-            );
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment(
-                { owner, repo, comment_id: existing.id, body },
+            try {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number, per_page: 100 },
               );
-              core.info(`Updated sticky comment ${existing.id}`);
-            } else {
-              await github.rest.issues.createComment(
-                { owner, repo, issue_number, body },
-              );
-              core.info('Created sticky comment');
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment(
+                  { owner, repo, comment_id: existing.id, body },
+                );
+                core.info(`Updated sticky comment ${existing.id}`);
+              } else {
+                await github.rest.issues.createComment(
+                  { owner, repo, issue_number, body },
+                );
+                core.info('Created sticky comment');
+              }
+            } catch (err) {
+              // A read-only GITHUB_TOKEN (e.g. a PR from a fork, or a repo/org
+              // "read-only workflow permissions" setting) can't post comments and
+              // returns 403. That's expected — the report is already in the job
+              // summary and the security-scan-reports artifact — so log a notice
+              // instead of failing the step with an unhandled error.
+              if (err.status === 403) {
+                core.notice(
+                  'Skipping sticky comment: read-only GITHUB_TOKEN (e.g. a PR from a ' +
+                  'fork). The report is in the job summary and the security-scan-reports artifact.',
+                );
+              } else {
+                core.warning(`Could not post sticky comment: ${err.message}`);
+              }
             }

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -132,6 +132,18 @@ jobs:
             } > security-scan-report.md
           fi
 
+      # Surface the CVE-parity report in the job summary too, so it's visible on
+      # every run — including fork PRs, where the read-only token can't post the
+      # sticky comment below. Writing a job summary needs no token or permissions.
+      - name: CVE parity summary (job summary)
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          if [ -f security-scan-report.md ]; then
+            cat security-scan-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload scan reports
         if: always()
         continue-on-error: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -140,6 +140,10 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
+          # Intentionally unbounded: GitHub caps $GITHUB_STEP_SUMMARY at 1 MiB, and as
+          # of mid-2026 this report runs well under ~50 KB, so we don't truncate it.
+          # Revisit if the project grows enough to approach the cap (e.g. truncate here
+          # with a pointer to the security-scan-reports artifact).
           if [ -f security-scan-report.md ]; then
             cat security-scan-report.md >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

PRs from forks run the Security Scan with a **read-only `GITHUB_TOKEN`** (GitHub's security default, untrusted PR code must not receive a write token or secrets). Two consequences today:

- The CVE-parity report was delivered **only** via the sticky PR comment, which a read-only token can't post, so fork/outside contributors never saw it inline.
- The comment step threw `HttpError: Resource not accessible by integration` and exited 1, leaving two red **annotations** on every fork PR (the run still passed, since the step is `continue-on-error`).

**Key changes**:

1. **`ci`:** the `cve-parity` job also appends `security-scan-report.md` to the **job summary** (`$GITHUB_STEP_SUMMARY`) — token-free, so the report is visible on every run, forks included (matching how the SBOM summary already works).
2. **`fix(ci)`:** the sticky-comment step now runs only on same-repo PRs, and its API calls are wrapped in try/catch — a read-only 403 logs a `core.notice` instead of failing with an unhandled error.

The sticky comment still posts on same-repo PRs; the uploaded artifact is unchanged.

## How was it tested?  What documentation was provided?

- `actionlint` clean on `security-scan.yml`.
- `node --check` on the extracted github-script body — syntax OK.
- End-to-end will confirm on the next fork PR (report in the job summary, no annotations) and a same-repo PR (sticky comment still posts).
- Workflow-only change; no script/unit-test changes.