### PR TITLE
test(demoapps): exercise installDist in micronaut-starter

### DIFF
--- a/demoapps/micronaut-starter/build.gradle.kts
+++ b/demoapps/micronaut-starter/build.gradle.kts
@@ -2,11 +2,16 @@ plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.ksp)
     alias(libs.plugins.viaduct.application)
+    application
     jacoco
 }
 
 viaductApplication {
     modulePackagePrefix.set("com.example")
+}
+
+application {
+    mainClass.set("com.example.viadapp.AppKt")
 }
 
 dependencies {
@@ -18,6 +23,12 @@ dependencies {
     implementation(libs.viaduct.api)
     implementation(libs.viaduct.runtime)
 
+    // Viaduct's fat jars exclude these (bring-your-own-version),
+    // so a runnable consumer must put them on its own runtime classpath.
+    runtimeOnly(libs.kotlinx.coroutines.core)
+    runtimeOnly(libs.kotlinx.coroutines.jdk8)
+    runtimeOnly(libs.reactive.streams)
+
     implementation(libs.kotlin.reflect)
 
     implementation(project(":common"))
@@ -28,9 +39,10 @@ dependencies {
     testImplementation(libs.junit.jupiter)
 
     testRuntimeOnly(libs.junit.platform.launcher)
-    // Viaduct's scalar definitions (ExtendedScalars) depend on this at runtime, but it isn't
-    // pulled transitively into testRuntimeClasspath, so it must be declared explicitly here.
-    testRuntimeOnly(libs.graphql.java.extended.scalars)
+    // Viaduct's scalar definitions (ExtendedScalars) are needed at runtime to assemble the
+    // schema but aren't pulled in transitively, so declare it on the runtime classpath. This is
+    // also what lets the packaged dist (installDist / smokeTestDist) start; tests inherit it.
+    runtimeOnly(libs.graphql.java.extended.scalars)
 
     testImplementation(libs.kotest.runner.junit)
     testImplementation(libs.kotest.assertions.core)
@@ -38,4 +50,21 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+// Build the application distribution and run the produced start script, so the packaged
+// classpath is actually assembled and the JVM is started. An in-process `test` never exercises
+// the dist; this catches packaging/classpath regressions before publish. Wired into `test`
+// so the existing CI invocation (`./gradlew test`) runs it.
+val smokeTestDist by tasks.registering(Exec::class) {
+    group = "verification"
+    description = "Builds the application dist and runs its start script (installDist smoke test)."
+    dependsOn("installDist")
+    val startScript = layout.buildDirectory.file("install/${rootProject.name}/bin/${rootProject.name}")
+    inputs.file(startScript)
+    commandLine(startScript.get().asFile.absolutePath)
+}
+
+tasks.named("test") {
+    dependsOn(smokeTestDist)
 }

--- a/demoapps/micronaut-starter/gradle/libs.versions.toml
+++ b/demoapps/micronaut-starter/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotest = "6.1.4"
 junit5 = "5.11.3"
 junitPlatform = "1.11.3"
 graphql-java-extension = "24.0"
+coroutines = "1.5.2"
 
 [plugins]
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -20,6 +21,11 @@ viaduct-module = { id = "com.airbnb.viaduct.module-gradle-plugin", version.ref =
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
 viaduct-api = { group = "com.airbnb.viaduct", name = "api", version.ref = "viaduct" }
 viaduct-runtime = { group = "com.airbnb.viaduct", name = "runtime", version.ref = "viaduct" }
+
+# Bring-your-own-version runtime deps that Viaduct's fat jars exclude — a runnable consumer must supply them.
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-jdk8 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-jdk8", version.ref = "coroutines" }
+reactive-streams = { group = "org.reactivestreams", name = "reactive-streams", version = "1.0.4" }
 
 # Micronaut
 micronaut-inject = { module = "io.micronaut:micronaut-inject", version.ref = "micronautCore" }

--- a/demoapps/micronaut-starter/src/main/kotlin/com/example/viadapp/App.kt
+++ b/demoapps/micronaut-starter/src/main/kotlin/com/example/viadapp/App.kt
@@ -1,0 +1,23 @@
+package com.example.viadapp
+
+import io.micronaut.context.ApplicationContext
+import viaduct.service.api.ExecutionInput
+import viaduct.service.api.Viaduct
+
+/**
+ * Minimal runnable entry point.
+ *
+ * Its job is to make this module packageable via the Gradle `application` plugin so it can be
+ * exercised through `installDist` (see the `smokeTestDist` task in `build.gradle.kts`): it boots
+ * the Micronaut context exactly like the tests, runs one query end-to-end, prints the result and
+ * exits. Running the *packaged distribution* (rather than in-process classes) is what surfaces
+ * packaging/classpath regressions that an in-process test cannot catch.
+ */
+fun main() {
+    ApplicationContext.run().use { context ->
+        val viaduct = context.getBean(Viaduct::class.java)
+        val result = viaduct.execute(ExecutionInput.create(operationText = "query { greeting }"))
+        check(result.errors.isEmpty()) { "Smoke query returned errors: ${result.errors}" }
+        println(result.getData())
+    }
+}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

micronaut-starter previously only ran in-process tests — `./gradlew test` boots a Micronaut context and executes queries, but never builds an application distribution or starts the packaged JVM. That means a packaging/classpath problem (e.g. a dependency missing from the *runtime* classpath, which only shows up as a `NoClassDefFoundError` at startup) could pass every test and still ship broken. This closes that gap.

**Key changes**:

- **Make it runnable.** Add Gradle's `application` plugin and a small run-to-completion `main` (`App.kt`) that boots the Micronaut context, runs `query { greeting }`, prints the result and exits. (micronaut-starter was previously a DI *library* with no `main`)
- **Add a dist smoke wired into the test path.** A new `smokeTestDist` task runs `installDist` and then executes the produced start script (failing on a non-zero exit). It's a dependency of `test`, so the existing CI invocation (`./gradlew test`) now builds the distribution and starts the packaged JVM — no CI changes needed.
- **Declare the runtime deps the packaged app needs.** Viaduct's fat jars exclude kotlinx-coroutines and reactive-streams (bring-your-own-version), so a runnable consumer must supply them: this adds `kotlinx-coroutines-core`/`-jdk8` and `reactive-streams` as `runtimeOnly` and promotes `graphql-java-extended-scalars` from `testRuntimeOnly` to `runtimeOnly`. The smoke surfaced that these were only present transitively via test dependencies.

## How was it tested?  What documentation was provided?

- Published Viaduct to mavenLocal from the repo root (`./gradlew publishToMavenLocal -PpublishMinimal`), then ran `USE_MAVEN_LOCAL=true ./gradlew test` in `demoapps/micronaut-starter`.
- `:smokeTestDist` builds the dist and runs the packaged JVM → prints `{greeting=Hello, World!}` and exits 0; `./gradlew test` is BUILD SUCCESSFUL.
- No CI changes: the smoke rides on the `test` task that both `demoapps-ci-check.yml` and `check-published-demoapps.yml` already run, so it's exercised against locally-published and published artifacts respectively.