### PR TITLE
feat(scope): introduce SchemaScoping data class and DSL accumulation surface (Slice 1, #366)

### DIFF
--- a/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
+++ b/core/service/api/src/main/kotlin/viaduct/service/api/scoping/SchemaScoping.kt
@@ -1,0 +1,35 @@
+package viaduct.service.api.scoping
+
+import java.io.Serializable
+
+/**
+ * Canonical, build-to-runtime description of schema scoping for a Viaduct application.
+ *
+ * This type is the contract between the Viaduct Gradle plugin (which emits it from the
+ * `viaductApplication { ... }` DSL) and the runtime (which consumes it when materializing
+ * scoped schemas). It is a sibling of [viaduct.service.api.SchemaId] in `service/api`
+ * because it is the same kind of build-to-runtime public type.
+ *
+ * @property scopeUniverse the complete set of scope IDs declared for the application.
+ * @property scopedSchemas a mapping from scoped-schema ID to the set of scope IDs that
+ *   schema is restricted to. A scoped schema with an empty scope set denotes an alias for
+ *   the full schema.
+ * @property version the version of this configuration format.
+ */
+data class SchemaScoping(
+    val scopeUniverse: Set<String>,
+    val scopedSchemas: Map<String, Set<String>>,
+    val version: String = CURRENT_VERSION,
+) : Serializable {
+    /** True when at least one scope has been declared. */
+    val isScoped: Boolean get() = scopeUniverse.isNotEmpty()
+
+    companion object {
+        const val CURRENT_VERSION = "1"
+
+        /** The empty (unscoped) configuration. */
+        val EMPTY = SchemaScoping(emptySet(), emptyMap())
+
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
+++ b/gradle-plugins/application/src/test/kotlin/viaduct/gradle/ViaductApplicationExtensionTest.kt
@@ -1,0 +1,111 @@
+package viaduct.gradle
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import viaduct.service.api.scoping.SchemaScoping
+
+/**
+ * ProjectBuilder tests for the schema-scoping DSL surface on [ViaductApplicationExtension].
+ *
+ * These cover only the accumulation/snapshot behavior and duplicate-rejection diagnostics.
+ * ID-format validation, subset checks, and plugin/task wiring are deferred to later slices.
+ */
+class ViaductApplicationExtensionTest {
+    private lateinit var project: Project
+    private lateinit var extension: ViaductApplicationExtension
+
+    @BeforeEach
+    fun setUp() {
+        project = ProjectBuilder.builder().build()
+        extension = project.extensions.create(
+            "viaductApplication",
+            ViaductApplicationExtension::class.java,
+            project.objects,
+        )
+    }
+
+    @Test
+    fun `schemaScoping is empty by default`() {
+        assertEquals(SchemaScoping.EMPTY, extension.schemaScoping.get())
+    }
+
+    @Test
+    fun `declaredSchemaScopes populates the universe`() {
+        extension.declaredSchemaScopes(setOf("public", "internal"))
+        assertEquals(setOf("public", "internal"), extension.schemaScoping.get().scopeUniverse)
+    }
+
+    @Test
+    fun `multiple declaredSchemaScopes calls accumulate`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        extension.declaredSchemaScopes(setOf("internal", "admin"))
+        assertEquals(
+            setOf("public", "internal", "admin"),
+            extension.schemaScoping.get().scopeUniverse,
+        )
+    }
+
+    @Test
+    fun `duplicate scope IDs across multiple declaredSchemaScopes calls fail`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        val ex = assertFailsWith<GradleException> {
+            extension.declaredSchemaScopes(setOf("public", "internal"))
+        }
+        assertTrue(ex.message!!.contains("public"), "message should name the duplicate: ${ex.message}")
+    }
+
+    @Test
+    fun `declaredScopedSchema populates the map`() {
+        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
+        extension.declaredScopedSchema("INTERNAL_API", setOf("public", "internal"))
+        val scoped = extension.schemaScoping.get().scopedSchemas
+        assertEquals(setOf("public"), scoped["PUBLIC_API"])
+        assertEquals(setOf("public", "internal"), scoped["INTERNAL_API"])
+    }
+
+    @Test
+    fun `duplicate schema IDs across multiple declaredScopedSchema calls fail`() {
+        extension.declaredScopedSchema("PUBLIC_API", setOf("public"))
+        val ex = assertFailsWith<GradleException> {
+            extension.declaredScopedSchema("PUBLIC_API", setOf("internal"))
+        }
+        assertTrue(ex.message!!.contains("PUBLIC_API"), "message should name the duplicate: ${ex.message}")
+    }
+
+    @Test
+    fun `declaredScopedSchema with empty scope set is allowed`() {
+        extension.declaredScopedSchema("FULL_ALIAS", emptySet())
+        assertEquals(emptySet(), extension.schemaScoping.get().scopedSchemas["FULL_ALIAS"])
+    }
+
+    @Test
+    fun `isScoped is false when scopeUniverse is empty`() {
+        assertFalse(extension.schemaScoping.get().isScoped)
+    }
+
+    @Test
+    fun `isScoped is true when scopeUniverse is non-empty even if scopedSchemas is empty`() {
+        extension.declaredSchemaScopes(setOf("public"))
+        val scoping = extension.schemaScoping.get()
+        assertTrue(scoping.isScoped)
+        assertTrue(scoping.scopedSchemas.isEmpty())
+    }
+
+    @Test
+    fun `schemaScoping is a snapshot, not a live view`() {
+        val before = extension.schemaScoping.get()
+        extension.declaredSchemaScopes(setOf("public"))
+        val after = extension.schemaScoping.get()
+        assertNotEquals(before, after)
+        assertEquals(SchemaScoping.EMPTY, before)
+        assertEquals(setOf("public"), after.scopeUniverse)
+    }
+}

--- a/gradle-plugins/common/build.gradle.kts
+++ b/gradle-plugins/common/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 dependencies {
     api(gradleApi())
 
+    // SchemaScoping is the build-to-runtime API contract emitted by the plugin DSL. It
+    // appears in the public API of ViaductApplicationExtension, so expose it via `api`.
+    api(libs.viaduct.service.api)
+
     implementation(libs.idea.gradle.plugin)
 }
 

--- a/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ScopedSchemaDefinition.kt
+++ b/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ScopedSchemaDefinition.kt
@@ -1,0 +1,16 @@
+package viaduct.gradle
+
+import java.io.Serializable
+
+/**
+ * Internal wrapper to satisfy Gradle's `MapProperty<K, V>` value-type constraint
+ * (which can't take a parameterized value type like `Set<String>` directly).
+ * Kept internal so it doesn't pollute the public OSS API.
+ */
+internal data class ScopedSchemaDefinition(
+    val scopeSet: Set<String>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
+++ b/gradle-plugins/common/src/main/kotlin/viaduct/gradle/ViaductApplicationExtension.kt
@@ -1,6 +1,13 @@
 package viaduct.gradle
 
-open class ViaductApplicationExtension(objects: org.gradle.api.model.ObjectFactory) {
+import org.gradle.api.GradleException
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import viaduct.service.api.scoping.SchemaScoping
+
+open class ViaductApplicationExtension(objects: ObjectFactory) {
     /** Kotlin package name for generated GRT classes. */
     val grtPackageName = objects.property(String::class.java).convention("viaduct.api.grts")
 
@@ -12,4 +19,67 @@ open class ViaductApplicationExtension(objects: org.gradle.api.model.ObjectFacto
 
     /** Host address for the development server. Defaults to "0.0.0.0". */
     val serveHost = objects.property(String::class.java).convention("0.0.0.0")
+
+    // --- Schema scoping -----------------------------------------------------
+
+    /** Private storage for the declared scope universe. */
+    private val _scopeUniverse: SetProperty<String> =
+        objects.setProperty(String::class.java)
+
+    /** Private storage for the declared scoped schemas. */
+    private val _scopedSchemas: MapProperty<String, ScopedSchemaDefinition> =
+        objects.mapProperty(String::class.java, ScopedSchemaDefinition::class.java)
+
+    // Eager bookkeeping used solely to reject duplicate declarations loudly, with a
+    // precise stack trace at the offending DSL call. The lazy Gradle Properties above
+    // remain the source of truth for the materialized SchemaScoping value.
+    private val seenScopes = mutableSetOf<String>()
+    private val seenSchemaIds = mutableSetOf<String>()
+
+    /**
+     * The canonical, public scope-state surface: a [Provider] that materializes the
+     * accumulated DSL declarations into a [SchemaScoping] snapshot. Re-evaluated on each
+     * `get()`, so it always reflects the declarations made so far.
+     */
+    @get:org.gradle.api.tasks.Input
+    val schemaScoping: Provider<SchemaScoping> =
+        _scopeUniverse.zip(_scopedSchemas) { universe, schemas ->
+            SchemaScoping(
+                scopeUniverse = universe,
+                scopedSchemas = schemas.mapValues { it.value.scopeSet },
+            )
+        }
+
+    /**
+     * Declares scope IDs that make up the application's scope universe. Multiple calls
+     * accumulate. Declaring a scope ID that was already declared (in this or a prior call)
+     * fails the build, naming the duplicate.
+     */
+    fun declaredSchemaScopes(scopes: Set<String>) {
+        val duplicates = scopes.filter { !seenScopes.add(it) }
+        if (duplicates.isNotEmpty()) {
+            throw GradleException(
+                "declaredSchemaScopes was given scope id(s) that were already declared: " +
+                    "${duplicates.sorted()}."
+            )
+        }
+        _scopeUniverse.addAll(scopes)
+    }
+
+    /**
+     * Declares a scoped schema [id] restricted to the given [scopes]. An empty [scopes] set
+     * denotes an alias for the full schema. Declaring an [id] that was already declared fails
+     * the build, naming the duplicate.
+     */
+    fun declaredScopedSchema(
+        id: String,
+        scopes: Set<String>
+    ) {
+        if (!seenSchemaIds.add(id)) {
+            throw GradleException(
+                "declaredScopedSchema was given a scoped-schema id that was already declared: '$id'."
+            )
+        }
+        _scopedSchemas.put(id, ScopedSchemaDefinition(scopes))
+    }
 }


### PR DESCRIPTION
## Summary

Implements **Slice 1** of the Schema Scoping work — the canonical `SchemaScoping` build-to-runtime contract plus the DSL surface on `ViaductApplicationExtension` that accumulates scope declarations into it.

### Why

Issue #366 (the foundation slice) was **closed as completed**, but its implementing PR (#367) was **closed without being merged** — so none of these symbols actually exist in the codebase. This silently blocks every open downstream slice (#371, #372, … #381), all of which declare a dependency on Slice 1. This PR lands the missing foundation.

### Scope

Per the Slice 1 spec: **no validation, no task wiring, no resource emission** — those are deferred to later slices (PR 2/3/8/9).

- **`core/service/api/.../scoping/SchemaScoping.kt`** (new) — serializable data class with `scopeUniverse`, `scopedSchemas`, `version`, the `isScoped` predicate, and `EMPTY` / `CURRENT_VERSION` companions. Sibling to `SchemaId.kt`.
- **`gradle-plugins/common/.../ScopedSchemaDefinition.kt`** (new) — `internal` wrapper to satisfy Gradle's `MapProperty` value-type constraint.
- **`ViaductApplicationExtension`** — `declaredSchemaScopes(...)` / `declaredScopedSchema(...)` setters that accumulate state and reject duplicate IDs with a `GradleException`; public `schemaScoping: Provider<SchemaScoping>` snapshot.
- **`gradle-plugins/common/build.gradle.kts`** — dependency edge to `core/service/api`.
- **`ViaductApplicationExtensionTest`** (new) — 10 ProjectBuilder tests covering the issue's test plan.

### Deviation from the spec

The issue suggested `implementation(libs.viaduct.service.api)`, but `SchemaScoping` appears in the extension's **public** API (`schemaScoping: Provider<SchemaScoping>`), so it must be exposed via **`api`** — otherwise it's invisible to consuming modules (the `:application` test module failed to compile with `implementation`).

### Testing

- `:application:test` → all 10 tests pass (0 failures/errors).
- `:common:check` + `:application:check` → BUILD SUCCESSFUL (ktlint clean).

### Note for maintainers

Issue #366 is currently closed-as-completed despite never having a merged PR — worth reopening/relinking to this PR so the dependent slices are correctly unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)