### PR TITLE
build!: stop publishing shared thin JARs

### DIFF
--- a/build-logic/src/main/kotlin/conventions/viaduct-fat-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-fat-plugin.gradle.kts
@@ -1,0 +1,76 @@
+package conventions
+
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+
+// `bundled` holds viaduct.shared/* library deps whose classes are merged directly into the plugin
+// JAR. Third-party transitives (graphql-java, kotlin, etc.) stay as explicit POM deps so
+// consumers resolve them from Maven Central at their own version.
+val bundled: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+configurations.named("implementation") {
+    extendsFrom(configurations["bundled"])
+}
+
+// Merge viaduct.* classes from bundled deps into the plugin JAR.
+// Using a plain FileCollection (not a lambda) avoids the configuration-cache restriction on
+// capturing a script object reference.
+val bundledViaductClasses: FileCollection = files(
+    configurations.named("bundled").map { cfg ->
+        cfg.map { jar -> zipTree(jar).matching { include("viaduct/**") } }
+    }
+)
+
+// Suppress Gradle module metadata: viaduct.shared.* classes are bundled into this JAR and absent
+// from the published POM, so the .module file would produce unresolvable coordinates. Gradle falls
+// back to the POM, which is correct.
+tasks.withType<GenerateModuleMetadata> {
+    enabled = false
+}
+
+tasks.named<Jar>("jar") {
+    from(bundledViaductClasses)
+    duplicatesStrategy = DuplicatesStrategy.WARN
+    exclude("META-INF/*.SF")
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
+    exclude("META-INF/INDEX.LIST")
+}
+
+afterEvaluate {
+    // Promote non-viaduct transitive deps of `bundled` to direct implementation deps so they
+    // appear in the published POM. Only viaduct.* classes are merged into the JAR; third-party
+    // classes live on the consumer's classpath via normal dependency resolution.
+    configurations["bundled"].resolvedConfiguration.resolvedArtifacts.forEach { artifact ->
+        val group = artifact.moduleVersion.id.group
+        if (!group.startsWith("com.airbnb.viaduct")) {
+            dependencies.add(
+                "implementation",
+                "${group}:${artifact.name}:${artifact.moduleVersion.id.version}",
+            )
+        }
+    }
+
+    // Strip viaduct.shared.* from the published POM: those classes are bundled in this JAR and
+    // have no separate Maven artifact for consumers to download.
+    project.extensions.getByType(PublishingExtension::class.java)
+        .publications.withType(MavenPublication::class.java).configureEach {
+            pom.withXml {
+                (asNode().get("dependencies") as groovy.util.NodeList)
+                    .filterIsInstance<groovy.util.Node>()
+                    .forEach { depsContainer ->
+                        val toRemove = (depsContainer.children() as groovy.util.NodeList)
+                            .filterIsInstance<groovy.util.Node>()
+                            .filter { dep ->
+                                val groupId = ((dep.get("groupId") as groovy.util.NodeList)
+                                    .firstOrNull() as? groovy.util.Node)?.text() ?: ""
+                                groupId.startsWith("com.airbnb.viaduct.shared")
+                            }
+                        toRemove.forEach { depsContainer.remove(it) }
+                    }
+            }
+        }
+}

--- a/core/service/api/build.gradle.kts
+++ b/core/service/api/build.gradle.kts
@@ -1,4 +1,6 @@
 import viaduct.gradle.internal.repoRoot
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
     `java-library`
@@ -35,6 +37,36 @@ dependencies {
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotest.property.jvm)
     testImplementation(libs.kotlinx.coroutines.test)
+}
+
+// Suppress Gradle module metadata: the .module file would list apiannotations and graphql as
+// dependencies, but those have no separate Maven artifact. Gradle falls back to the POM instead.
+tasks.withType<GenerateModuleMetadata> {
+    enabled = false
+}
+
+// Strip viaduct.shared.* from the published POM: those classes are bundled inside the Gradle
+// plugin JARs that consume this module, so consumers do not need to resolve them separately.
+pluginManager.withPlugin("maven-publish") {
+    project.extensions.getByType(PublishingExtension::class.java)
+        .publications.withType(MavenPublication::class.java).configureEach {
+            pom.withXml {
+                // asNode().get("dependencies") returns the <dependencies> container node(s);
+                // children() yields the individual <dependency> entries inside it.
+                (asNode().get("dependencies") as groovy.util.NodeList)
+                    .filterIsInstance<groovy.util.Node>()
+                    .forEach { depsContainer ->
+                        val toRemove = (depsContainer.children() as groovy.util.NodeList)
+                            .filterIsInstance<groovy.util.Node>()
+                            .filter { dep ->
+                                val groupId = ((dep.get("groupId") as groovy.util.NodeList)
+                                    .firstOrNull() as? groovy.util.Node)?.text() ?: ""
+                                groupId == "com.airbnb.viaduct.shared"
+                            }
+                        toRemove.forEach { depsContainer.remove(it) }
+                    }
+            }
+        }
 }
 
 dokka {

--- a/core/shared/apiannotations/build.gradle.kts
+++ b/core/shared/apiannotations/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
     id("conventions.kotlin-without-tests")
     id("conventions.kotlin-static-analysis")
-    id("conventions.viaduct-publishing")
 }

--- a/core/shared/graphql/build.gradle.kts
+++ b/core/shared/graphql/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     `java-test-fixtures`
     id("conventions.kotlin")
     id("conventions.kotlin-static-analysis")
-    id("conventions.viaduct-publishing")
 }
 
 dependencies {

--- a/core/shared/invariants/build.gradle.kts
+++ b/core/shared/invariants/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("conventions.kotlin")
     id("conventions.kotlin-static-analysis")
-    id("conventions.viaduct-publishing")
 }
 
 dependencies {

--- a/core/shared/utils/build.gradle.kts
+++ b/core/shared/utils/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("conventions.kotlin")
     id("conventions.kotlin-static-analysis")
     id("me.champeau.jmh").version("0.7.3")
-    id("conventions.viaduct-publishing")
 }
 
 dependencies {

--- a/core/shared/viaductschema/build.gradle.kts
+++ b/core/shared/viaductschema/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("me.champeau.jmh").version("0.7.3")
     `java-test-fixtures`
     id("conventions.kotlin-static-analysis")
-    id("conventions.viaduct-publishing")
 }
 
 tasks.test {

--- a/gradle-plugins/application/build.gradle.kts
+++ b/gradle-plugins/application/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("conventions.kotlin-static-analysis")
     id("com.gradle.plugin-publish") version "2.0.0"
     id("conventions.viaduct-publishing")
+    id("conventions.viaduct-fat-plugin")
 }
 
 java {
@@ -17,8 +18,9 @@ dependencies {
     // Libraries the plugin source imports directly (binary schema generation).
     // tenant-codegen is NOT here — it is an external tool artifact resolved at
     // build time via the viaductCodegenClasspath Configuration.
-    implementation(libs.viaduct.shared.graphql)
-    implementation(libs.viaduct.shared.viaductschema)
+    // Classes bundled directly into this plugin JAR via conventions.viaduct-fat-plugin.
+    bundled(libs.viaduct.shared.graphql)
+    bundled(libs.viaduct.shared.viaductschema)
     // Do NOT leak the Kotlin Gradle Plugin at runtime
     compileOnly(libs.kotlin.gradle.plugin)
 

--- a/gradle-plugins/module-java/build.gradle.kts
+++ b/gradle-plugins/module-java/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("conventions.kotlin-static-analysis")
     id("com.gradle.plugin-publish") version "2.0.0"
     id("conventions.viaduct-publishing")
+    id("conventions.viaduct-fat-plugin")
 }
 
 java {
@@ -16,8 +17,9 @@ dependencies {
     // Reuse AssembleSchemaPartitionTask + ViaductModuleExtension from the Kotlin module plugin
     implementation(project(":module"))
 
-    implementation(libs.viaduct.shared.graphql)
-    implementation(libs.viaduct.shared.viaductschema)
+    // Classes bundled directly into this plugin JAR via conventions.viaduct-fat-plugin.
+    bundled(libs.viaduct.shared.graphql)
+    bundled(libs.viaduct.shared.viaductschema)
 
     testImplementation(gradleTestKit())
     testImplementation(project(":application"))

--- a/gradle-plugins/module/build.gradle.kts
+++ b/gradle-plugins/module/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("conventions.kotlin-static-analysis")
     id("com.gradle.plugin-publish") version "2.0.0"
     id("conventions.viaduct-publishing")
+    id("conventions.viaduct-fat-plugin")
 }
 
 java {
@@ -17,8 +18,9 @@ dependencies {
     // Libraries the plugin source imports directly (binary schema generation).
     // tenant-codegen is NOT here — it is an external tool artifact resolved at
     // build time via the viaductCodegenClasspath Configuration.
-    implementation(libs.viaduct.shared.graphql)
-    implementation(libs.viaduct.shared.viaductschema)
+    // Classes bundled directly into this plugin JAR via conventions.viaduct-fat-plugin.
+    bundled(libs.viaduct.shared.graphql)
+    bundled(libs.viaduct.shared.viaductschema)
 
     // Do NOT leak the Kotlin Gradle Plugin at runtime
     compileOnly(libs.kotlin.gradle.plugin)

--- a/publications/bom/build.gradle.kts
+++ b/publications/bom/build.gradle.kts
@@ -25,15 +25,11 @@ dependencies {
         api("com.airbnb.viaduct.tenant:api:${version}")
         api("com.airbnb.viaduct.tenant:runtime:${version}")
 
-        // Shared modules
-        api("com.airbnb.viaduct.shared:apiannotations:${version}")
+        // Shared modules (graphql, viaductschema, apiannotations, invariants, utils are bundled
+        // inside the plugin JARs and the fat JARs — no separate Maven artifact)
         api("com.airbnb.viaduct.shared:arbitrary:${version}")
         api("com.airbnb.viaduct.shared:dataloader:${version}")
-        api("com.airbnb.viaduct.shared:utils:${version}")
         api("com.airbnb.viaduct.shared:deferred:${version}")
-        api("com.airbnb.viaduct.shared:graphql:${version}")
-        api("com.airbnb.viaduct.shared:viaductschema:${version}")
-        api("com.airbnb.viaduct.shared:invariants:${version}")
         api("com.airbnb.viaduct.shared:codegen:${version}")
         api("com.airbnb.viaduct.shared:mapping:${version}")
         api("com.airbnb.viaduct.shared:errors:${version}")


### PR DESCRIPTION
## Summary

This ports the Treehouse Viaduct OSS publication cleanup into the GitHub repository so it can be validated through the OSS publication flow.

The change stops publishing the remaining shared thin JARs for `graphql`, `viaductschema`, `apiannotations`, `invariants`, and `utils`. The Gradle plugins now bundle the shared classes they need, suppress Gradle module metadata where those unpublished coordinates would leak, and keep non-Viaduct transitive dependencies in the generated POMs. The BOM and `service:api` POM metadata are also cleaned up so consumers no longer resolve unpublished shared artifacts.

## How was it validated?

* `git diff --check`
* `./gradlew -p gradle-plugins check` -- passed
* `./gradlew publishToMavenLocal -PpublishMinimal -PexcludeDemoApps -Dmaven.repo.local=/tmp/rm-thin-jars-m2-1782280372` -- passed
* Sanity-checked the fresh Maven repo: no standalone `com/airbnb/viaduct/shared` publication directory, no `com.airbnb.viaduct.shared` dependencies in plugin or `service:api` POMs, and no plugin `.module` metadata files were published.

Co-Authored-By: Codex <noreply@openai.com>