### PR TITLE
fix(ci): compile and test in one job to stop flaky cache handoff

### DIFF
--- a/.github/impldocs/actions-arch.md
+++ b/.github/impldocs/actions-arch.md
@@ -18,6 +18,8 @@ This document describes the architectural principles, workflow taxonomy, and not
 
 4. **Two-layer workflow architecture: atomics and orchestrators.** See [Workflow Taxonomy](#workflow-taxonomy) below.
 
+5. **Caching is an accelerator, not a handoff.** The `gradle/actions/setup-gradle` cache (the `~/.gradle` GitHub Actions cache) is a best-effort, cross-run speed optimization — not a deterministic channel for passing build outputs between jobs. Every job must succeed on a cold cache with no restored state; a cache hit or miss may change speed but must never change correctness. Any output one job genuinely requires from another must be transferred explicitly — via `actions/upload-artifact`/`download-artifact` or a remote build cache — never by assuming a job will restore another job's local Gradle cache. (Restoring a shared cache is also a correctness *hazard*: a cancelled job can save a partially-written cache that later jobs restore — see `cancel-in-progress` note under [Explicit permissions and concurrency](#explicit-permissions-and-concurrency).)
+
 ## Workflow Taxonomy
 
 Every workflow is classified as an **atomic**, an **orchestrator**, or an **orchestrator helper**.
@@ -217,8 +219,8 @@ push/PR to main
 ci-manual-trigger.yml  [orchestrator]
   |
   |--- build-and-test.yml  [atomic]
-  |      validate-inputs --> build --> test
-  |                                --> detekt
+  |      validate-inputs --> test   (self-contained: compiles + runs tests, no build dep)
+  |                     '--> build --> detekt
   |                                --> ktlint
   |                                --> coverage-verification
   |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -125,7 +125,7 @@ jobs:
         os: ${{ fromJSON(inputs.os || '["ubuntu-latest","macos-latest"]') }}
         java: ${{ fromJSON(inputs.java_versions || '["11", "17", "21"]') }}
     name: Test (Java ${{ matrix.java }}) ${{ matrix.os }}
-    needs: build
+    needs: validate-inputs
     env:
       GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false"
       BUILDSCAN_PUBLISH: "true"
@@ -136,12 +136,6 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           java-version: ${{ matrix.java }}
-          cache-read-only: 'true'
-
-      - uses: actions/download-artifact@v7
-        with:
-          name: build-java-${{ matrix.java }}-${{ matrix.os }}
-          path: build/
 
       - name: Run tests
         id: run_tests


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Viaduct `main` has been intermittently red on the `build-and-test` "Test" jobs: six consecutive commits failed (7c174a5 → ff3f740) before `main` went green again on the next commit with no code change — the signature of a flaky pipeline, not a real regression.

The cause is the `build` → `test` job split. The `build` job compiles main + test sources (`./gradlew buildRepoForCI`) to prime the Gradle local build cache and the `test` job is meant to reuse those compiled outputs. But nothing transfers the compiled classes directly: the uploaded artifact is jars only (never `build/classes`), there is no remote build cache and the sole channel carrying compiled classes from `build` to `test` is the `~/.gradle` cache that `gradle/actions/setup-gradle` stores in GitHub Actions.
When the `test` job restores that cache it reuses the classes and passes; when it misses — restoring a stale prior-commit cache instead — it recompiles from scratch under `-Dorg.gradle.parallel=true` and that recompile intermittently emits 0-byte/missing `.class` files, so `compileTestKotlin` and test execution fail with "size in bytes: 0" / FileNotFoundException / Unresolved reference / ClassNotFoundException. Which module and matrix leg fail varies run to run — exactly what a cache-restore race produces.
The `build` job itself always passes because it compiles once in a clean job; only the `test` job's recompile, polluted by the stale cache, is affected.

This makes the `test` job self-sufficient: it compiles and runs tests in a single clean job (checkout → setup-build → `./gradlew test`), the same pattern the `build` job and the `./gradlew check` gate already run reliably. It no longer depends on the `build` job or the fragile cache hand-off — `needs: build`, the `cache-read-only` restore and the jar-artifact download are removed.
This is the first of two steps; a follow-up applies the same self-sufficiency to the coverage/detekt/ktlint/dokka jobs and removes the now-unused `build` job.

Representative failed runs this addresses:
- 7c174a5 — https://github.com/airbnb/viaduct/actions/runs/29115502063
- 8646fcd — https://github.com/airbnb/viaduct/actions/runs/29118824304
- 6af855f — https://github.com/airbnb/viaduct/actions/runs/29131952433
- 0c6eabc — https://github.com/airbnb/viaduct/actions/runs/29141159466
- 1362350 — https://github.com/airbnb/viaduct/actions/runs/29161464369
- ff3f740 — https://github.com/airbnb/viaduct/actions/runs/29238294624

## How was it tested?  What documentation was provided?

The `test` job now runs the same single-job compile-and-test pattern that the `build` job in this workflow — and the `./gradlew check` gate — already run reliably, so compilation happens in a clean environment instead of the stale-cache one that caused the flake. It is exercised by the `build-and-test` matrix (Java 11/17/21 × ubuntu/macos); the key signal is a cold-cache run, since that is the condition under which the old design failed.