### PR TITLE
fix(viaductschema): match partition paths regardless of file separator

### DIFF
--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/validation/rules/ApplicationOnlyDefinitionsRule.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/validation/rules/ApplicationOnlyDefinitionsRule.kt
@@ -59,7 +59,5 @@ class ApplicationOnlyDefinitionsRule(
      *
      * This pattern comes from ViaductModulePlugin's module schema directory layout
      */
-    private fun isModuleLocation(location: ViaductSchema.SourceLocation?): Boolean {
-        return location?.sourceName?.contains(modulePathPattern) == true
-    }
+    private fun isModuleLocation(location: ViaductSchema.SourceLocation?): Boolean = isUnderModulePartition(location, modulePathPattern)
 }

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/validation/rules/ModulePartitionPaths.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/validation/rules/ModulePartitionPaths.kt
@@ -1,0 +1,19 @@
+package viaduct.graphql.schema.validation.rules
+
+import viaduct.graphql.schema.ViaductSchema
+
+/**
+ * The '/'-separated form of this location's source name, for comparing against module partition
+ * path prefixes.
+ *
+ * Source names come from two producers: URLs, whose paths always use '/', and [java.io.File] paths,
+ * which use the platform separator. Normalizing here lets the partition path prefixes stay written
+ * as plain '/'-separated literals and behave identically on every platform.
+ */
+internal fun ViaductSchema.SourceLocation.partitionMatchPath(): String = sourceName.replace('\\', '/')
+
+/** True when [location] sits under a module partition directory. */
+internal fun isUnderModulePartition(
+    location: ViaductSchema.SourceLocation?,
+    modulePathPrefix: String
+): Boolean = location?.partitionMatchPath()?.contains(modulePathPrefix) == true

--- a/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/validation/rules/NoCrossModuleInputExtensionsRule.kt
+++ b/core/shared/viaductschema/src/main/kotlin/viaduct/graphql/schema/validation/rules/NoCrossModuleInputExtensionsRule.kt
@@ -80,7 +80,7 @@ internal fun tenantFromLocation(
     location: ViaductSchema.SourceLocation?,
     modulePathPrefix: String
 ): String? {
-    val sourceName = location?.sourceName ?: return null
+    val sourceName = location?.partitionMatchPath() ?: return null
     if (!sourceName.contains(modulePathPrefix)) return null
     return sourceName.substringAfter(modulePathPrefix).substringBefore("/")
 }

--- a/core/shared/viaductschema/src/test/kotlin/viaduct/graphql/schema/validation/rules/ModulePartitionPathsTest.kt
+++ b/core/shared/viaductschema/src/test/kotlin/viaduct/graphql/schema/validation/rules/ModulePartitionPathsTest.kt
@@ -1,0 +1,97 @@
+package viaduct.graphql.schema.validation.rules
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import viaduct.graphql.schema.ViaductSchema
+
+/**
+ * Source names reach the validation rules from two producers: URLs, which always use '/', and
+ * java.io.File paths, which use the platform separator. These tests pin the matching behaviour for
+ * both shapes so the rules behave identically regardless of which producer supplied the path and
+ * which platform the build runs on.
+ *
+ * The backslash cases are written as literals rather than derived from the running platform, so they
+ * exercise Windows-shaped input on every OS.
+ */
+class ModulePartitionPathsTest {
+    private val prefix = "partition/"
+
+    private fun location(sourceName: String) = ViaductSchema.SourceLocation(sourceName)
+
+    @Test
+    fun `isUnderModulePartition detects a partition in a backslash-separated path`() {
+        val windowsPath = "central-schema\\partition\\mymodule\\graphql\\schema.graphqls"
+
+        assertTrue(isUnderModulePartition(location(windowsPath), prefix))
+    }
+
+    @Test
+    fun `isUnderModulePartition detects a partition in a slash-separated path`() {
+        val posixPath = "central-schema/partition/mymodule/graphql/schema.graphqls"
+
+        assertTrue(isUnderModulePartition(location(posixPath), prefix))
+    }
+
+    @Test
+    fun `isUnderModulePartition detects a partition when separators are mixed`() {
+        val mixedPath = "central-schema/partition\\mymodule/graphql\\schema.graphqls"
+
+        assertTrue(isUnderModulePartition(location(mixedPath), prefix))
+    }
+
+    @Test
+    fun `isUnderModulePartition returns false for an application-level path`() {
+        val applicationPath = "central-schema\\application\\graphql\\schema.graphqls"
+
+        assertFalse(isUnderModulePartition(location(applicationPath), prefix))
+    }
+
+    @Test
+    fun `isUnderModulePartition returns false for a null location`() {
+        assertFalse(isUnderModulePartition(null, prefix))
+    }
+
+    @Test
+    fun `tenantFromLocation extracts the module from a backslash-separated path`() {
+        val windowsPath = "central-schema\\partition\\mymodule\\graphql\\schema.graphqls"
+
+        assertEquals("mymodule", tenantFromLocation(location(windowsPath), prefix))
+    }
+
+    @Test
+    fun `tenantFromLocation extracts the module from a slash-separated path`() {
+        val posixPath = "central-schema/partition/mymodule/graphql/schema.graphqls"
+
+        assertEquals("mymodule", tenantFromLocation(location(posixPath), prefix))
+    }
+
+    /**
+     * Distinct from the case above: even when the prefix matches, the trailing-segment split has its
+     * own separator assumption. Without normalization this returns the whole remainder of the path
+     * rather than just the module name.
+     */
+    @Test
+    fun `tenantFromLocation stops at the module segment in a backslash-separated path`() {
+        val windowsPath = "central-schema\\partition\\mymodule\\graphql\\nested\\schema.graphqls"
+
+        val tenant = tenantFromLocation(location(windowsPath), prefix)
+
+        assertEquals("mymodule", tenant)
+        assertFalse(tenant!!.contains('\\'), "module name should not carry trailing path segments")
+    }
+
+    @Test
+    fun `tenantFromLocation returns null for an application-level path`() {
+        val applicationPath = "central-schema\\application\\graphql\\schema.graphqls"
+
+        assertNull(tenantFromLocation(location(applicationPath), prefix))
+    }
+
+    @Test
+    fun `tenantFromLocation returns null for a null location`() {
+        assertNull(tenantFromLocation(null, prefix))
+    }
+}


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

Four schema-validation rules detect module partitions by looking for `partition/` in a definition's source name. Source names reach those rules from two producers: URLs, whose paths always use forward slashes, and `java.io.File` paths, which use the platform separator. The Gradle plugin validates real files, so on Windows a source name looks like `central-schema\partition\mymodule\graphql\schema.graphqls` and never matches `partition/`.

The consequence is worse than a crash: `ApplicationOnlyDefinitions`, `NoCrossModuleInputExtensions`, `CrossModuleExtensionFieldsResolver` and `PageInfoLocation` silently pass on Windows instead of reporting errors. A developer on Windows sees no schema errors where a developer on macOS or Linux sees them, and can commit a schema that breaks everyone else's build. `tenantFromLocation` has a second, independent separator assumption in the same area: it splits the remainder of the path on `/` to extract the module name, so even a successful prefix match would have yielded `mymodule\graphql\schema.graphqls` rather than `mymodule`.

This normalizes the source name to forward slashes at the point of comparison, so the rules behave identically on every platform and the partition prefixes stay written as plain forward-slash literals. There is no behaviour change on macOS or Linux, where source names contain no backslashes.

**For reviewers**

The fix deliberately normalizes at the two comparison sites rather than at the producer. The tempting one-line alternative is to make `readTypesFromFiles` emit `file.invariantSeparatorsPath` instead of `file.path`, which would establish a single invariant for every consumer. I left that out on purpose: `ReadFilesTest` has five assertions pinning `sourceName` to `File.path` exactly, which pass on macOS but would fail on Windows — trading one Windows-only failure for another, on the platform that is hardest to iterate on. That change is worth making separately, together with its test updates. The same producer-side issue also affects the `schema/presentation` and `schema/data` matching in the graphql-java extensions, which is out of scope here.

`isUnderModulePartition` is a new extraction of the check previously inlined in `ApplicationOnlyDefinitionsRule`, so both comparison sites now share one normalization helper and one place to test.

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

## How was it tested?  What documentation was provided?

New unit tests in `ModulePartitionPathsTest` cover both helpers against backslash, forward-slash, mixed-separator, non-partition and null inputs. The backslash cases are written as literals rather than derived from the running platform, so they exercise Windows-shaped input on every OS — which means the regression is caught by the normal test suite rather than only by the Windows nightly job.

The helpers were first extracted with the original un-normalized logic to confirm the tests fail for the right reason. That run failed exactly four cases: the backslash and mixed-separator detection cases, the backslash module-extraction case, and the trailing-segment case. All ten pass after normalization.

- `ModulePartitionPathsTest`: 10 tests, 0 failures
- `:core:shared:viaductschema:test`: 1134 tests across 89 classes, 0 failures
- `./gradlew -p core check`: passes, including detekt and ktlint on the new files
