### PR TITLE
fix(ci): cache demo app Gradle distributions to stop repeat downloads

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -10,6 +10,12 @@ inputs:
     description: 'Whether to use read-only Gradle cache mode'
     required: false
     default: 'false'
+  cache-demoapp-distributions:
+    description: >-
+      Cache the Gradle distributions the demo app wrappers use. The root build pins a
+      different Gradle version, so demo app jobs otherwise fetch theirs on every run.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -24,3 +30,16 @@ runs:
       uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c  # v5
       with:
         cache-read-only: ${{ inputs.cache-read-only }}
+
+    # Distributions pinned by the demo app wrappers, keyed on those wrapper properties so
+    # a version bump invalidates the entry. The key is deliberately not OS-scoped: a
+    # distribution unpacks to a URL-derived path that is identical on every platform and
+    # holds only JARs and scripts, so one entry serves every runner. setup-gradle only
+    # offers a job the distributions recorded against its own OS, so without this the
+    # runners that never populate it fetch theirs from services.gradle.org each run.
+    - name: Cache demo app Gradle distributions
+      if: inputs.cache-demoapp-distributions == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.gradle/wrapper/dists
+        key: gradle-demoapp-dists-v1-${{ hashFiles('demoapps/*/gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/demoapps-ci-check.yml
+++ b/.github/workflows/demoapps-ci-check.yml
@@ -56,6 +56,18 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           java-version: '17'
+          cache-demoapp-distributions: 'true'
+
+      # The only job here that writes the Gradle cache, and every test job waits on it.
+      # Resolving each demo app's distribution here is what makes it available to those
+      # jobs, which read the cache read-only. Output is kept so the log shows whether a
+      # distribution was fetched or served from cache.
+      - name: Warm demo app Gradle distributions
+        run: |
+          for dir in demoapps/*/; do
+            (cd "$dir" && ./gradlew --version)
+          done
+        shell: bash
 
       - name: Publish to Maven Local
         run: ./gradlew publishToMavenLocal -PpublishMinimal --no-daemon
@@ -88,6 +100,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache-read-only: 'true'
+          cache-demoapp-distributions: 'true'
 
       - name: Download Maven Local repository
         uses: actions/download-artifact@v7
@@ -118,6 +131,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache-read-only: 'true'
+          cache-demoapp-distributions: 'true'
 
       - name: Download Maven Local repository
         uses: actions/download-artifact@v7
@@ -162,6 +176,7 @@ jobs:
         with:
           java-version: '17'
           cache-read-only: 'true'
+          cache-demoapp-distributions: 'true'
 
       - name: Download Maven Local repository
         uses: actions/download-artifact@v7
@@ -203,6 +218,7 @@ jobs:
         with:
           java-version: '17'
           cache-read-only: 'true'
+          cache-demoapp-distributions: 'true'
 
       - name: Download Maven Local repository
         uses: actions/download-artifact@v7
@@ -214,7 +230,9 @@ jobs:
         # Edit gradle-wrapper.properties directly instead of running
         # `./gradlew wrapper`, which would evaluate build.gradle.kts and try to
         # resolve the Viaduct SNAPSHOT plugin before USE_MAVEN_LOCAL is in scope.
-        # Both the URL and the SHA256 checksum must be updated together.
+        # Both the URL and the SHA256 checksum must be updated together. A version that
+        # no demo app commits is fetched at run time, because the distribution cache is
+        # keyed on the committed wrapper properties rather than on this matrix.
         run: |
           sed -i \
             -e 's|distributionUrl=.*|distributionUrl=https\\://services.gradle.org/distributions/gradle-${{ matrix.gradle_version }}-bin.zip|' \


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Fourteen jobs in the demo app workflow download the same 135 MB Gradle distribution from `services.gradle.org` on every run, and when that download fails the job dies in about 25 seconds without running a single test.

The reason is a version mismatch that nothing currently bridges. The root build's wrapper pins Gradle 8.11, while five of the six demo apps pin 9.1.0. `setup-gradle` caches the distributions a job actually resolves, one cache entry per distribution, and the only job in this workflow that writes the cache — `Publish to Maven Local` — runs the *root* wrapper and so only ever records 8.11. Every demo app test job then sets `cache-read-only: 'true'`, so none of them can record 9.1.0 either. The result is that 9.1.0 never enters the cache and all fourteen jobs that need it fetch it themselves, concurrently, on every push.

You can watch it happen in a job log: the wrapper-zips cache is restored successfully, to `~/.gradle/wrapper/dists/gradle-8.11-bin/`, and the very next Gradle line is `Downloading https://services.gradle.org/distributions/gradle-9.1.0-bin.zip`.

Under that concurrency the download sometimes returns a truncated response — `java.net.SocketException: Unexpected end of file from server`. In run 31620287639 it took three attempts to get a green build: the first failed every demo app job, the second only the four starwars jobs, the third passed. I should be precise that no HTTP status appears in the logs, so while the pattern is consistent with the server shedding load, that part is inference rather than something I can show.

The fix has two halves. `Publish to Maven Local` now resolves each demo app's distribution before publishing, which is enough on its own for any runner sharing that job's platform: `setup-gradle` sees 9.1.0 in the Gradle home it saves and records an entry for it, and the Linux test jobs restore that entry. Alongside it, an opt-in `cache-demoapp-distributions` input on the `setup-build` action caches `~/.gradle/wrapper/dists` keyed on the demo apps' wrapper properties. That input lives in the composite action rather than being pasted into each job so the cache key has a single definition — a key that drifted between copies would silently stop matching and quietly reintroduce the downloads.

The distribution cache key is deliberately **not** scoped by runner OS, so every job shares one entry. That is safe because a distribution unpacks to a path derived from its URL rather than the platform, and contains only JARs and scripts: this repo already restores the single 8.11 entry onto both Linux and macOS runners, into the identical `dists/gradle-8.11-bin/c4te04g51qsyw1bxcb929u7br` directory, and runs Gradle from it on both. Sharing one entry also means the Linux publish job populates the cache that the macOS jobs read, so they get a hit on the first run rather than having to seed a second entry of their own.

Worth being straight about what each half buys, measured on the first CI run of this branch (31713997747). On Linux the two halves overlap: the warm-up alone gets 9.1.0 into `setup-gradle`'s own per-distribution entry, and the Linux jobs had it on disk about six seconds before the new cache entry restored. The reason to keep the explicit entry anyway is that `setup-gradle` only offers a job the distributions recorded against its own OS — on that run the macOS jobs restored 8.11 and missed 9.1.0 entirely, despite the entry existing and having been saved forty seconds earlier. The explicit cache is what covers those runners without special-casing them, and it states the guarantee directly instead of depending on how `setup-gradle` decides which entries a job is offered, which I could only infer from logs rather than read anywhere.

The alternative — dropping the explicit cache and running the warm-up on a matrix of both platforms — would avoid the extra entry, but at the cost of a new job and, more importantly, a new macOS *writer* of the shared Gradle cache. Given that partial cache entries written by interrupted jobs are the problem #402 was addressing, adding cache writers seemed like the wrong direction to trade into.

I chose caching over the other alternatives deliberately. Retrying the Gradle invocation or capping `max-parallel` would both paper over the repeat downloads while still making them. Aligning the root build to 9.1.0 would fix it at the source but is a major-version upgrade rather than a CI change, and `gradle-plugins` still has deprecated `exec {}` usages that Gradle 9 removes. Pinning the demo apps down to 8.11 would throw away deliberate coverage of current Gradle.

One known edge, documented at the point where someone would hit it: `test-gradle-matrix` rewrites micronaut-starter's wrapper after `setup-build` has run, so the cache key only ever reflects committed wrapper properties. It works today because the versions that matrix selects are pinned by other demo apps anyway; a future entry for a version no demo app commits would be fetched at run time.

## How was it tested?  What documentation was provided?

Both edited files parse as YAML, and the warm-up loop was run locally exactly as written against all six demo apps: `./gradlew --version` succeeds in each one. That check mattered because this workflow already documents that some Gradle invocations in these directories try to resolve the Viaduct SNAPSHOT plugin before `USE_MAVEN_LOCAL` is in scope; `--version` does not evaluate build scripts, and now that is demonstrated rather than assumed.

The rest is only observable in CI, and the first run on this branch (31713997747, green) confirmed the mechanics: `hashFiles` resolves correctly inside the composite action, the publish job saved both the new distribution entry and a `setup-gradle` entry for 9.1.0, and downloads across the workflow dropped from fourteen to three on that very first run. The two remaining downloads were the macOS starwars legs, which is exactly what removing the OS from the cache key addresses.

So the check on the next run is specific: `Downloading .../gradle-9.1.0-bin.zip` should be absent from **every** demo app job log including the macOS starwars legs, and those legs should report a hit on `gradle-demoapp-dists-v1-<hash>` — the same key, with no OS segment, that the Linux publish job wrote. The warm-up step's output is no longer discarded, so the publish job's own log now shows plainly whether it fetched a distribution or was served from cache; if a future key change ever silently reintroduces per-run downloads, that log is where it will show up.