### PR TITLE
fix(ci): make demoappsStandaloneTest work on Windows

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -77,6 +77,9 @@ jobs:
           java-version: ${{ matrix.java }}
           cache-read-only: 'true'
 
+      # --stacktrace because the task's failures are process-start failures, and Gradle reports
+      # those naming only the executable — the working directory and the OS error live in the
+      # cause, so without it a failure here cannot be diagnosed from the log alone.
       - name: Demoapps standalone test
-        run: ./gradlew :demoappsStandaloneTest
+        run: ./gradlew :demoappsStandaloneTest --stacktrace
         shell: bash

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,6 +1,6 @@
 name: Nightly Build
-# Thin cron wrapper — delegates to demoapps-nightly-check.yml.
-# No domain logic belongs here. This is just a scheduling entrypoint.
+# Weekday scheduling entrypoint. Snapshot validation is delegated to demoapps-nightly-check.yml;
+# the Windows jobs live here because no pull request triggers them.
 
 on:
   schedule:
@@ -48,4 +48,35 @@ jobs:
 
       - name: Check
         run: ./gradlew check --scan
+        shell: bash
+
+  # Exercises demoappsStandaloneTest on its own. As a finalizer of root `check` it is skipped
+  # whenever anything else in that build fails, so windows-check alone leaves it unreported.
+  demoapps-standalone-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ["17", "21"]
+    name: Demoapps Standalone (Windows, Java ${{ matrix.java }})
+    env:
+      # fromEnv lets Gradle's daemon JVM discovery find Java 21 via JAVA_HOME_21_X64 when JAVA_HOME != Java 21.
+      GRADLE_OPTS: "-Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.daemon=false -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_21_X64"
+      BUILDSCAN_PUBLISH: "true"
+      BUILDSCAN_AUTOACCEPTTERMS: "true"
+    steps:
+      # Ensure Windows runners use core.autocrlf=false for parity with Linux/macOS.
+      - name: Disable autocrlf
+        shell: bash
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: ${{ matrix.java }}
+          cache-read-only: 'true'
+
+      - name: Demoapps standalone test
+        run: ./gradlew :demoappsStandaloneTest
         shell: bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,17 @@ val demoappsStandaloneTest by tasks.registering {
         "Shells out to independent per-demoapp Gradle builds; not representable as a task graph."
     )
 
+    // Nested builds go through the wrapper scripts, not the wrapper jar: the root script injects
+    // flags this task relies on, including the --project-cache-dir noted below. `exec` provides no
+    // shell to resolve a script name, so the name is platform-specific and the path absolute — a
+    // relative executable resolves against a different directory depending on the launcher.
+    val wrapperScript = if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+        "gradlew.bat"
+    } else {
+        "gradlew"
+    }
+    val rootWrapper = layout.projectDirectory.file(wrapperScript).asFile.absolutePath
+
     doLast {
         // Explicitly forward the CI mirror across the nested Gradle process boundary. These builds
         // use fresh dependency caches, so losing it would fall back to Plugin Portal/Maven Central.
@@ -124,7 +135,7 @@ val demoappsStandaloneTest by tasks.registering {
             exec {
                 environment(nestedGradleEnvironment)
                 commandLine(
-                    "./gradlew", "clean",
+                    rootWrapper, "clean",
                     "--gradle-user-home", publishGradleHome.absolutePath,
                     "-Dviaduct.distDir=${publishDistDir.absolutePath}",
                     "--no-build-cache", "--no-daemon"
@@ -135,7 +146,7 @@ val demoappsStandaloneTest by tasks.registering {
             exec {
                 environment(nestedGradleEnvironment)
                 commandLine(
-                    "./gradlew", "publishToMavenLocal", "-PpublishMinimal",
+                    rootWrapper, "publishToMavenLocal", "-PpublishMinimal",
                     "-Dmaven.repo.local=${mavenLocalRepo.absolutePath}",
                     "--gradle-user-home", publishGradleHome.absolutePath,
                     "-Dviaduct.distDir=${publishDistDir.absolutePath}",
@@ -158,7 +169,7 @@ val demoappsStandaloneTest by tasks.registering {
                     environment(nestedGradleEnvironment)
                     environment("USE_MAVEN_LOCAL", "true")
                     commandLine(
-                        "./gradlew", "test",
+                        File(demoappWorkspace, wrapperScript).absolutePath, "test",
                         "-Dmaven.repo.local=${mavenLocalRepo.absolutePath}",
                         "--gradle-user-home", demoappGradleHome.absolutePath,
                         "--project-cache-dir", demoappCacheDir.absolutePath,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,9 +96,8 @@ val demoappsStandaloneTest by tasks.registering {
     )
 
     // Nested builds go through the wrapper scripts, not the wrapper jar: the root script injects
-    // flags this task relies on, including the --project-cache-dir noted below. `exec` provides no
-    // shell to resolve a script name, so the name is platform-specific and the path absolute — a
-    // relative executable resolves against a different directory depending on the launcher.
+    // flags this task relies on, including the --project-cache-dir noted below. Each platform has
+    // its own wrapper script and `exec` launches it directly, so the name must match the platform.
     val wrapperScript = if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
         "gradlew.bat"
     } else {
@@ -113,10 +112,14 @@ val demoappsStandaloneTest by tasks.registering {
             providers.environmentVariable("VIADUCT_ARTIFACTORY_MIRROR").orNull
                 ?.let { mapOf("VIADUCT_ARTIFACTORY_MIRROR" to it) }
                 .orEmpty()
+        // Absolute, because paths derived from this are consumed two ways that resolve
+        // non-absolute paths differently: Gradle's `exec` resolves workingDir against the project
+        // directory, while plain File I/O resolves against the JVM's startup directory. On Windows
+        // "/tmp/mlc" is drive-relative, so the two would resolve to different places.
         val runRoot = Files.createTempDirectory(
             Files.createDirectories(Path.of("/tmp/mlc")),
             "demoapps-standalone-"
-        ).toFile()
+        ).toAbsolutePath().toFile()
         val mavenLocalRepo = File(runRoot, "m2").apply { mkdirs() }
         // Run-scoped --gradle-user-home + --no-build-cache so the publish step can't reuse
         // Gradle's dependency/build cache from a prior invocation or ambient developer state.

--- a/demoapps/micronaut-starter/build.gradle.kts
+++ b/demoapps/micronaut-starter/build.gradle.kts
@@ -54,7 +54,13 @@ val smokeTestDist by tasks.registering(Exec::class) {
     group = "verification"
     description = "Builds the application dist and runs its start script (installDist smoke test)."
     dependsOn("installDist")
-    val startScript = layout.buildDirectory.file("install/${rootProject.name}/bin/${rootProject.name}")
+    // The dist ships one launcher per platform, and only the matching one is executable here.
+    val launcher = if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+        "${rootProject.name}.bat"
+    } else {
+        rootProject.name
+    }
+    val startScript = layout.buildDirectory.file("install/${rootProject.name}/bin/$launcher")
     inputs.file(startScript)
     commandLine(startScript.get().asFile.absolutePath)
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

`demoappsStandaloneTest` is a finalizer of the root `check` task, and root `check` is what the Windows nightly and `release.yml` run — everyday PR CI only runs the scoped `-p core check`. The task has never worked on Windows, and it is why `Full Check (Windows)` in the nightly has been red on every run since 1 July. Detaching it from `check` was considered and rejected: the `finalizedBy` wiring is there to order it against the included-build checks, so Windows needed fixing inside the task instead.

That turned out to be three independent defects, one per commit.

**The wrapper was invoked by its Unix name.** The task shells out to Gradle three times, asking for `./gradlew`, which does not exist on Windows. Each invocation now picks `gradlew.bat` or `gradlew` by platform. The nested builds still go through the wrapper *scripts* rather than `java -cp gradle-wrapper.jar`, which would sidestep the platform question entirely, because the root script injects flags this task depends on — including the `--project-cache-dir` noted just below it in the file.

**The run root was drive-relative on Windows.** `Path.of("/tmp/mlc")` yields `\tmp\mlc`, with no drive letter, so `File.isAbsolute()` was false for the run root and for every path derived from it. That matters because those paths are consumed two ways that resolve non-absolute paths differently: plain `File` I/O resolves against the JVM's startup directory, while Gradle resolves an `exec` `workingDir` against the *project* directory. So `copyDemoappSources` created each demo app's workspace under one root while the nested build looked for it under another, and the process failed at spawn. Making the run root absolute fixes every derived path in one place, which is why the change is a single `.toAbsolutePath()`.

**micronaut-starter's dist smoke test ran the Unix launcher.** `installDist` ships one launcher per platform, `bin/<name>` and `bin/<name>.bat`, and `smokeTestDist` hardcoded the former. This one is a demo app change rather than a CI change, but the job cannot go green without it, so it belongs here. micronaut-starter is the only demo app with an `Exec` task or the `application` plugin, so it is the only place this can occur.

The nightly also gains a permanent `demoapps-standalone-windows` job, and that is the more durable half of this PR. Because the task is a finalizer, it is skipped whenever anything else in `check` fails, so any unrelated failure hides it completely — which is how a task that could not start a process on Windows went unnoticed for six weeks. Running it as its own job means it reports for itself. The job sets `fail-fast: false`, since the existing Windows matrix cancels one JDK leg when the other fails, which halves the evidence on the platform that is hardest to reproduce locally.

The job also passes `--stacktrace` permanently. Gradle reports a failed process start naming only the executable, never the working directory or the underlying OS error, so a failure here is otherwise undiagnosable from the log. That is not hypothetical: it cost a debugging cycle on this branch, because the message named a `gradlew.bat` that existed and was perfectly fine while the real cause was the missing working directory described above.

## How was it tested?  What documentation was provided?

Locally on macOS, `./gradlew :demoappsStandaloneTest` completed in 14m38s, publishing into an isolated repository and testing all six demo apps, with `smokeTestDist` executed rather than up-to-date. The task fails fast and any `exec` failure propagates, so a green run means every invocation form was exercised.

Windows cannot be reproduced locally, so the nightly was dispatched on a fork. The current run is green on all four Windows jobs:

- `Demoapps Standalone (Windows, Java 17)` and `(Java 21)` — pass, all six demo apps
- `Full Check (Windows, Java 17)` and `(Java 21)` — pass, 622 actionable tasks

`Full Check (Windows)` is green for the first time since 1 July. The comparison against the preceding dispatch is clean: that run failed the same job only on `:demoappsStandaloneTest`, with every other task in root `check` passing.

Two caveats for review. The other failures seen during the red streak — an `x:javaapi:runtime:compileTestKotlin` classpath error and `:core:shared:utils:test` timeouts — are intermittent and simply did not occur in this run, so this PR should not be read as retiring them. And `demoapps-ci-check`'s OS matrix covers only Ubuntu and macOS, so this is the first time the demo apps have been built on Windows at all; the micronaut-starter defect above is exactly that new coverage doing its job, and further Windows-specific demo app problems would be the same rather than a regression from this change.
