### PR TITLE
fix(ci): stop discarding Windows nightly failure evidence

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,6 +26,7 @@ jobs:
   windows-check:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         java: ["17", "21"]
     name: Full Check (Windows, Java ${{ matrix.java }})
@@ -46,8 +47,10 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
+      # --continue because this is the only job running the unscoped root `check`: without it a
+      # single failing task hides the rest of the platform's health until the next nightly.
       - name: Check
-        run: ./gradlew check --scan
+        run: ./gradlew check --scan --continue
         shell: bash
 
   # Exercises demoappsStandaloneTest on its own. As a finalizer of root `check` it is skipped

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -47,8 +47,9 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # --continue because this is the only job running the unscoped root `check`: without it a
-      # single failing task hides the rest of the platform's health until the next nightly.
+      # --continue because this is the only scheduled job running the unscoped root `check`, and the
+      # only place it runs on Windows: without it a single failing task hides the rest of the
+      # platform's health until that first failure is fixed.
       - name: Check
         run: ./gradlew check --scan --continue
         shell: bash


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

`windows-check` is the only scheduled job that runs the unscoped root `check`, which makes it the only place several tasks are exercised on Windows at all. It was discarding most of what it learned every night, in two independent ways, and the result was a platform nobody could see clearly.

The matrix had no `fail-fast: false`, so the moment the Java 17 leg failed the Java 21 leg was cancelled. Half the observations, thrown away nightly — in the most recent run before this change, Java 21 was cancelled with no result at all. And the check step ran without `--continue`, so the first failing task ended the build and nothing after it was attempted. A job that takes over half an hour reported, at most, one failure from one JDK.

**For reviewers.** The concern worth raising about `--continue` is whether it weakens failure signalling, so I checked and it does not. With two independent failing tasks under one lifecycle task on Gradle 8.11, the exit code is `1` both with and without the flag; the only difference is the report, which goes from `Build failed with an exception` naming one task to `Build completed with 2 failures` naming both. The job still goes red and still exits non-zero, so the failure signal itself is unchanged — see the caveat below on what is, and isn't, listening to it.

Two honest costs. A failing run now takes longer, since it keeps building past the first failure — acceptable on a nightly, and it buys a complete picture instead of one sample. And the report can include derivative failures, tasks that failed only because an earlier one did, which is worth knowing when reading it.

## How was it tested?  What documentation was provided?

The `--continue` exit-code and reporting behaviour was verified directly on Gradle 8.11 with a standalone build declaring two independent failing tasks plus one passing one: exit `1` in both modes, one failure reported without the flag and two with it, and the independent task completing only in the second case.

The workflow itself was dispatched on this branch, and the result is the clearest argument for the change. Both JDK legs reported independently for the first time, and they disagreed: Java 17 passed the full check while Java 21 failed. Under the previous configuration one of those would simply have been cancelled, and which one we learned about would have been a coin flip.

The failing leg then reported `Build completed with 2 failures`, naming both `:core:shared:utils:test` and `:core:x:javaapi:runtime:compileTestKotlin`. Only the first of those would have been visible before, because it failed first — the second would have been silently skipped, exactly the masking this change removes. The build still went red and still exited non-zero, so nothing about failure signalling changed.

For context, this is the nightly build executed: https://github.com/geovannefduarte/viaduct/actions/runs/31969892905