### PR TITLE
fix(build-logic): pin Spotless line endings to LF

### DIFF
--- a/build-logic/src/main/kotlin/conventions/java-static-analysis.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/java-static-analysis.gradle.kts
@@ -1,5 +1,6 @@
 package conventions
 
+import com.diffplug.spotless.LineEnding
 import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.compile.JavaCompile
 
@@ -11,6 +12,8 @@ plugins {
 val libs = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
 
 spotless {
+    // Enforce the repository's LF policy for Java sources independently of host Git settings
+    lineEndings = LineEnding.UNIX
     java {
         target("src/*/java/**/*.java")
         googleJavaFormat(libs.findVersion("googleJavaFormat").get().requiredVersion)


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The Windows core check fails in `:service:wiring:spotlessJavaCheck` because Spotless expects CRLF while the checked-in Java sources use LF. This mismatch makes every line appear reformatted.

Configure Spotless to use LF explicitly, matching the repository’s `.editorconfig` policy across platforms.

This is intentionally scoped to Spotless. A repository-wide `.gitattributes` rule would also normalize existing CRLF Windows wrapper scripts.

## How was it tested?  What documentation was provided?

- Reproduced with Spotless 7.0.2 and `core.eol=crlf`: the check failed before this change and passed with `LineEnding.UNIX`.
- `./gradlew -p core :service:wiring:spotlessJavaCheck :shared:codegen:spotlessJavaCheck`
- `./gradlew -p build-logic check`
- The Windows Java 17 and Java 21 PR checks exercise the original failure environment.