### PR TITLE
ci(build-and-test): stop discarding matrix and task failure evidence

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,6 +121,8 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      # Nothing in this workflow needs: test, and each OS/JDK pair is an independent observation.
+      fail-fast: false
       matrix:
         os: ${{ fromJSON(inputs.os || '["ubuntu-latest","macos-latest"]') }}
         java: ${{ fromJSON(inputs.java_versions || '["11", "17", "21"]') }}
@@ -160,6 +162,8 @@ jobs:
   core-windows:
     runs-on: windows-latest
     strategy:
+      # Push/PR CI's only Windows coverage of core; the nightly runs the root check there separately.
+      fail-fast: false
       matrix:
         java: ${{ fromJSON(inputs.java_versions || '["17", "21"]') }}
     name: Core Check (Windows, Java ${{ matrix.java }})
@@ -181,7 +185,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Check core
-        run: ./gradlew -p core check --scan
+        run: ./gradlew -p core check --scan --continue
         shell: bash
 
   verify-publication-classpaths:
@@ -205,12 +209,14 @@ jobs:
       # if two would collide when a consumer flattens the classpath into a distribution lib/.
       # Replaces the heavier composite demoapp assemble; resolves from source, no Maven Local.
       - name: Check publication runtime classpath filenames are unique
-        run: ./gradlew -p publications checkRuntimeClasspathArtifactNamesAreUnique --scan
+        run: ./gradlew -p publications checkRuntimeClasspathArtifactNamesAreUnique --scan --continue
         shell: bash
 
   coverage-reports:
     runs-on: ${{ matrix.os }}
     strategy:
+      # Independent per-project runs; an infra failure in one shouldn't cancel the others.
+      fail-fast: false
       matrix:
         os: ${{ inputs.os && fromJSON(format('["{0}"]', fromJSON(inputs.os)[0])) || fromJSON('["ubuntu-latest"]') }}
         java: ${{ inputs.java_versions && fromJSON(format('["{0}"]', fromJSON(inputs.java_versions)[0])) || fromJSON('["17"]') }}
@@ -332,8 +338,8 @@ jobs:
         run: |
           echo "🧹 Running Detekt static analysis..."
           EXIT=0
-          ./gradlew detekt --scan --no-daemon || EXIT=1
-          ./gradlew -p build-logic detekt --no-daemon || EXIT=1
+          ./gradlew detekt --scan --no-daemon --continue || EXIT=1
+          ./gradlew -p build-logic detekt --no-daemon --continue || EXIT=1
           if [ $EXIT -eq 0 ]; then
             echo "✅ Detekt analysis passed"
           else
@@ -373,7 +379,7 @@ jobs:
         id: run_ktlint
         run: |
           echo "🧹 Running Ktlint code formatting check..."
-          if ./gradlew ktlintCheck --scan --no-daemon; then
+          if ./gradlew ktlintCheck --scan --no-daemon --continue; then
             echo "✅ Ktlint formatting check passed"
           else
             echo "❌ Ktlint found code formatting violations"
@@ -419,7 +425,7 @@ jobs:
           cd ..
 
           echo "🔨 Generating Dokka API documentation..."
-          ./gradlew :core:tenant:api:dokkaGenerate :core:service:dokkaGenerate :core:x:javaapi:api:dokkaGenerate || { echo "❌ Dokka failed"; exit 1; }
+          ./gradlew :core:tenant:api:dokkaGenerate :core:service:dokkaGenerate :core:x:javaapi:api:dokkaGenerate --continue || { echo "❌ Dokka failed"; exit 1; }
 
           echo "📖 Verifying Dokka documentation output..."
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Every matrix job in this workflow used the default `fail-fast: true`, and eight of its ten Gradle invocations ran without `--continue`. A red run therefore reported less than it had already discovered.

Run [32080409504](https://github.com/airbnb/viaduct/actions/runs/32080409504) is the clearest case. `Test (Java 21) macos-latest` failed 27 minutes in; the Java 11 and Java 17 macOS legs were cancelled 52s and 31s later, each also around 27 minutes in. Their `if: always()` upload still preserved partial JUnit XML — 694 KB and 484 KB respectively — but neither leg reached a verdict, so whether the failure was specific to Java 21 was unknowable without a rerun. Two legs discarded within a minute of finishing.

`nightly-build.yml`'s `windows-check` already runs with `fail-fast: false` and `--continue`. This brings push and pull-request CI in line with that.

### Changed

- `fail-fast: false` on `test` (6 legs) and `core-windows` (2 legs). Nothing in the workflow `needs:` either — only `validate-inputs`, `build` and `coverage-reports` are depended on.
- `fail-fast: false` on `coverage-reports`, whose three legs are independent projects.
- `--continue` on `core check` (Windows), on `checkRuntimeClasspathArtifactNamesAreUnique`, and on `detekt`, `ktlint` and `dokka`, so one push reports every violation instead of only the first module's. The publications check fans out to seven subprojects that apply `conventions.viaduct-fat-jar`, and its entire purpose is enumerating colliding archive filenames, so partial reporting turned one fix into a fix-and-rerun loop per collision.

## How was it tested?  What documentation was provided?

`actionlint` passes. That validates syntax only — it cannot check `fail-fast` or `--continue` semantics, so it is not evidence for the behaviour change.

CI on this PR exercises all six `test` legs, both `core-windows` legs, and every job given `--continue`. Confirming the new behaviour directly would need a red leg, which this PR does not produce, so the mechanism is argued from the runs cited above rather than demonstrated here.

`--continue`'s effect on failure signalling was verified separately on Gradle 8.11: with two independent failing tasks under one lifecycle task, the exit code is `1` both with and without the flag, and only the report changes, from naming one failing task to naming both. Jobs still go red and still exit non-zero.

One thing to watch on this run: `--continue` on the lint jobs may surface violations previously hidden behind an earlier module's failure. That would be pre-existing debt becoming visible rather than a regression here, but it would still need fixing before this can go green. Note also that `dokka` carries `continue-on-error: true` at the job level, so `--continue` there improves its logs and cannot change any outcome.