### PR TITLE
ci(build-and-test): capture build output state on test failure

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -158,6 +158,55 @@ jobs:
           name: junit-results-java-${{ matrix.java }}-${{ matrix.os }}
           path: '**/build/test-results/test/*.xml'
 
+      # Build outputs live only on the runner, so a compile failure that blames a classpath or a
+      # generated source leaves no evidence behind. The manifest's size and second-resolution mtime
+      # distinguish an absent class from a truncated one and order writes against the failing task;
+      # generated sources are archived whole because their content is the thing under suspicion;
+      # disk and memory rule resource exhaustion in or out.
+      - name: Capture build output state
+        if: failure()
+        run: |
+          echo "🔍 Capturing build output state..."
+          out=build/failure-state
+          mkdir -p "$out"
+
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            stat_cmd=(stat -f '%z %Sm %N' -t '%FT%T')
+          else
+            stat_cmd=(stat -c '%s %y %n')
+          fi
+
+          find . -type f \
+            \( -path "*/build/classes/*" \
+               -o -path "*/build/libs/*.jar" \
+               -o -path "*/build/contract-tests/*" \
+               -o -path "*/build/generated/*" \) -print0 \
+            | xargs -0 -r "${stat_cmd[@]}" \
+            | gzip > "$out/build-outputs.txt.gz"
+
+          find . -type d \( -name contract-tests -o -name generated \) -path "*/build/*" \
+            > "$out/generated-dirs.txt"
+          if [ -s "$out/generated-dirs.txt" ]; then
+            tar czf "$out/generated-sources.tgz" -T "$out/generated-dirs.txt"
+          fi
+
+          df -h > "$out/disk.txt"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            vm_stat > "$out/memory.txt"
+          else
+            free -m > "$out/memory.txt"
+          fi
+
+          echo "✅ Captured $(gzip -dc "$out/build-outputs.txt.gz" | wc -l) build output files"
+        shell: bash
+
+      - name: Upload build output state
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: failure-state-java-${{ matrix.java }}-${{ matrix.os }}
+          path: build/failure-state
+
 
   core-windows:
     runs-on: windows-latest


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

`main` has an intermittent compile failure that passes on re-run. Classifying every attempt-1 `Test` and `Build` failure on `main` gives:

- **17** cross-module compile failures — a consumer's `compileTest*` dies seconds after starting, unable to read a large fraction of one producer module. Run [32076806679](https://github.com/airbnb/viaduct/actions/runs/32076806679) emitted 9404 error lines spanning `viaduct.api.context`, `.types`, `.select.SelectionSet`, `.reflect.Type`.
- **4** test-execution failures, including the already-fixed `ResolverValueGenTest`.
- **5** platform failures: two empty jobs, and the 2026-08-17 `429`/`503` codeload incident.

Both attempt-1 `Build` failures are in that last group, so **`Build` has no Gradle failures at all** while `Test` has 17 — an asymmetry worth keeping in mind.

Compiled outputs and generated sources exist only on the runner, so none of the 17 left behind any evidence of what the classpath actually contained. Every conclusion drawn so far, including a build-cache explanation that today's log re-read contradicts, is inference from a stack trace. This adds the missing capture so the next occurrence is conclusive without a re-run.

### Changed

Two steps on the `test` job, both `if: failure()`:

- **A manifest** of every `build/classes/**`, `build/libs/*.jar`, `build/contract-tests/**` and `build/generated/**` file, with byte size and second-resolution mtime. Size separates an absent class from a truncated one; mtime orders writes against the failing task. `stat` is selected on `RUNNER_OS` because the BSD and GNU formats differ.
- **An archive of the generated sources** themselves. Their content is the current prime suspect: several of the 17 report their first error inside a generated file under `<module>/build/contract-tests/tenant-merged/`, and the two most frequent failing modules — `:core:x:javaapi:runtime` (8) and `:core:tenant:runtime` (5) — are both `feature-app-contract-tests` consumers.

Plus `df -h` and a memory snapshot, to rule resource exhaustion in or out. No current log carries either.

### Deliberately not included

- **Any behaviour change** — no Gradle flag, memory, worker-count or cache-mode change. The mechanism is not established, so a green run must not be attributable to a mitigation. In particular this does *not* set `cache-read-only` on `test`: cold caches correlate with the failure (14 of the 17 ran with ≤41 of ~330 tasks from cache, against 75 and 167 on green legs), so restricting cache writes is as likely to make it worse as better.
- **`core-windows` and the nightly `windows-check`.** Both would need a third `stat`/memory branch for Windows, and neither has produced this signature. Worth extending once the capture has proved itself.

## How was it tested?  What documentation was provided?

- `actionlint .github/workflows/build-and-test.yml` — exit 0. Syntax only; it cannot check the script.
- The step's script was run verbatim in a fixture tree on macOS: a populated tree produced the manifest, the archive and both snapshots, and correctly reported a zero-byte `.class` as `0`; an empty tree with no `build/` directories exited 0 and skipped the archive rather than erroring. `xargs -r` and `tar -T` were confirmed to work on BSD as well as GNU. The Linux branch (`stat -c`, `free -m`) is standard but was not executed locally.
- **Not verified end-to-end against a real CI failure.** These steps are skipped on a green run, so this PR's own CI exercises only that they parse and do not fire. Confirming the artifact contents needs a failing leg, which I will force on a fork dispatch rather than by breaking `main`.