### PR TITLE
ci(workflows): report every matrix leg, key concurrency per entry point

### DIFF
--- a/.github/workflows/bcv-api-check.yml
+++ b/.github/workflows/bcv-api-check.yml
@@ -13,7 +13,9 @@ permissions:
     contents: read
 
 concurrency:
-    group: bcv-api-check-${{ github.ref }}
+    # A called workflow's `github` context is the invoking run's, so `github.workflow` is the top-level
+    # workflow name — keying on it stops distinct entry points sharing one group and cancelling each other.
+    group: bcv-api-check-${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,9 @@ permissions:
   actions: read
 
 concurrency:
-  group: build-and-test-${{ github.ref }}
+  # A called workflow's `github` context is the invoking run's, so `github.workflow` is the top-level
+  # workflow name — keying on it stops distinct entry points sharing one group and cancelling each other.
+  group: build-and-test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/demoapps-ci-check.yml
+++ b/.github/workflows/demoapps-ci-check.yml
@@ -22,7 +22,9 @@ permissions:
   actions: read
 
 concurrency:
-  group: demoapps-ci-${{ github.ref }}
+  # A called workflow's `github` context is the invoking run's, so `github.workflow` is the top-level
+  # workflow name — keying on it stops distinct entry points sharing one group and cancelling each other.
+  group: demoapps-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
@@ -85,6 +87,7 @@ jobs:
     needs: publish-to-maven-local
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         demoapp: [cli-starter, jetty-starter, ktor-starter, micronaut-starter, spring-starter]
         java: ['17', '21']
@@ -116,6 +119,7 @@ jobs:
     needs: publish-to-maven-local
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ${{ fromJSON(inputs.os || '["ubuntu-latest","macos-latest"]') }}
         java: ${{ fromJSON(inputs.java_versions || '["17","21"]') }}
@@ -200,6 +204,7 @@ jobs:
     needs: publish-to-maven-local
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - gradle_version: "8.11"


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Two ways CI discards signal it has already paid for.

**Matrix legs cancel each other.** In `demoapps-ci-check.yml`, `test-starters` (5 demoapps × 2 JDKs), `test-starwars` (2 OS × 2 JDKs) and `test-gradle-matrix` (2 Gradle versions) all took the `fail-fast: true` default; `test-kotlin-matrix` was the only matrix that opted out. No job declares `needs:` on any of them, so nothing consumes a leg's result — a failure simply cancels its siblings, discarding the legs that were about to answer a different question: is the failure specific to one demoapp, one OS, or one Gradle version?

Run [32311764499](https://github.com/airbnb/viaduct/actions/runs/32311764499) on `main`, 2026-08-19: `Test ktor-starter (Java 17)` failed and the other **9 `test-starters` legs were canceled**, reducing a 10-leg matrix to a single observation. Same argument as #411, and the same trade-off it accepted: a broken commit now runs its full matrix instead of bailing early, costing wall-clock and concurrency slots on a run that is already red. Standard runners are free for public repositories, so no minute multiplier applies.

**Distinct entry points share one concurrency group.** All three leaf reusable workflows were keyed `<name>-${{ github.ref }}` with `cancel-in-progress` true on every ref except `main` (#402 fixed `main` only). Each is reachable from more than one top-level run:

- `demoapps-ci-check.yml` — `ci-trigger.yml:33` (push/PR), `demoapps-nightly-check.yml:45` (nightly), and its own `workflow_dispatch`.
- `build-and-test.yml` and `bcv-api-check.yml` — only `ci-trigger.yml` calls them, but `ci-trigger.yml:16` declares `workflow_call` and `periodic-green-check.yml:40` calls it, so both are also reachable under a `Periodic Green Check` run, plus their own `workflow_dispatch`.

Because `schedule` events always run on the default branch, the exposure is `workflow_dispatch` on a non-`main` ref — the release-branch flow. On 2026-08-07, `CI Check` and `Nightly Build` were dispatched on `release/v2.0.0` 16 seconds apart (runs [31216222349](https://github.com/airbnb/viaduct/actions/runs/31216222349), [31216241460](https://github.com/airbnb/viaduct/actions/runs/31216241460)). The newer run took the shared group, `CI Check` lost 5 of its 6 `demoapps-ci-check` jobs to cancellation, and that run's conclusion flipped to `cancelled`.

### Changed

- `fail-fast: false` on `test-starters`, `test-starwars` and `test-gradle-matrix`.
- All three leaf workflows add `github.workflow` to their concurrency key, giving each entry point its own group. `cancel-in-progress` is unchanged: superseding an older run within one entry point and ref is still the behavior we want.

The key relies on `github.workflow` resolving to the *invoking* run's workflow rather than the immediate caller's. That is load-bearing — `periodic-green-check.yml → ci-trigger.yml → demoapps-ci-check.yml` separates only under that reading — and GitHub's context documentation does not say which it is, so it was measured rather than assumed.

## How was it tested?  What documentation was provided?

- `actionlint` on all three changed workflows.
- **`github.workflow` semantics, measured.** Throwaway three-level chain (`Probe Entry B` → `Probe Mid` → `Probe Callee`, `workflow_call` at each hop) on a fork branch. The innermost job, running `zz-probe-callee.yml`, printed `github.workflow = Probe Entry B` and `github.workflow_ref = .../zz-probe-entry-b.yml@...` — the entry point, at two levels of nesting. The key therefore separates every path listed above. Fork run `32202962525`; probe branch deleted.
- **Evidence loss, observed.** Run 32311764499: 1 failure and 9 cancellations, every one inside `test-starters`, while `test-starwars`, `test-kotlin-matrix` and `test-gradle-matrix` all completed. That also confirms `fail-fast` is scoped to one matrix rather than the whole workflow.
- **Cross-entry-point cancellation, observed.** In run 31216222349, 5 of the 6 `demoapps-ci-check` jobs ended `cancelled` — only `validate-inputs` had finished, and the four matrix jobs died before expanding — while all 24 `build-and-test` jobs and `bcv-api-check` succeeded. The two leaves unreachable from `Nightly Build` survived and the one reachable from it did not, which is a within-run control on the shared-group explanation. It also shows a called workflow's group scopes to its own jobs while still flipping the run's conclusion.
- **`needs:` inventory.** In `demoapps-ci-check.yml` the only `needs:` targets are `validate-inputs` and `publish-to-maven-local`, so no job consumes a matrix leg's result.
- This PR's own CI is green over all 16 legs ([run 32255973021](https://github.com/airbnb/viaduct/actions/runs/32255973021), `pull_request` event). It cannot exercise the cross-entry-point case, and `fail-fast: false` only changes behavior when a leg fails, so a green run demonstrates neither fix.