### PR TITLE
ci(alerts): keep the coverage summary advisory and label re-run alerts

### DIFF
--- a/.github/actions/collect-failure-info/action.yml
+++ b/.github/actions/collect-failure-info/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'GitHub actor (optional)'
     required: false
     default: ''
+  attempt:
+    description: 'Run attempt number (optional); labeled in the alert only when above 1'
+    required: false
+    default: ''
 
 outputs:
   text:
@@ -41,8 +45,9 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         SHA: ${{ inputs.sha }}
         ACTOR: ${{ inputs.actor }}
+        ATTEMPT: ${{ inputs.attempt }}
       run: |
-        # Build the full payload — format_alert.py handles empty sha/actor
+        # Build the full payload — format_alert.py handles empty sha/actor/attempt
         # gracefully via .get() + truthiness checks.
         text=$(jq -n \
           --arg branch "$BRANCH" \
@@ -50,11 +55,13 @@ runs:
           --arg repository "$REPOSITORY" \
           --arg sha "$SHA" \
           --arg actor "$ACTOR" \
+          --arg attempt "$ATTEMPT" \
           --argjson jobs "$JOBS_JSON" \
           '{ branch: $branch, server_url: $server_url, repository: $repository,
              jobs: $jobs }
            + (if $sha  != "" then { sha: $sha }   else {} end)
-           + (if $actor != "" then { actor: $actor } else {} end)' | \
+           + (if $actor != "" then { actor: $actor } else {} end)
+           + (if $attempt != "" then { attempt: $attempt } else {} end)' | \
           python3 .github/scripts/format_alert.py)
 
         {

--- a/.github/scripts/format_alert.py
+++ b/.github/scripts/format_alert.py
@@ -14,6 +14,7 @@ Reads a JSON object from stdin with the following fields:
   Optional:
     sha         - commit SHA (for push-triggered failures)
     actor       - GitHub username who pushed (for push-triggered failures)
+    attempt     - run attempt number; labeled only when above 1
 
 Prints formatted alert text to stdout. Single-job alerts produce one line;
 multi-job alerts produce a header line followed by a bulleted list of jobs.
@@ -25,6 +26,14 @@ Exit codes:
 
 import json
 import sys
+
+
+def format_attempt_label(attempt) -> str:
+    try:
+        n = int(attempt)
+    except (TypeError, ValueError):
+        return ""
+    return f", attempt {n}" if n > 1 else ""
 
 
 def format_alert(data: dict) -> str:
@@ -43,6 +52,8 @@ def format_alert(data: dict) -> str:
         commit_info = f" — commit `{sha[:7]}`"
     elif actor:
         commit_info = f" — pushed by {actor}"
+
+    commit_info += format_attempt_label(data.get("attempt"))
 
     def job_url(job):
         return f"{server_url}/{repository}/actions/runs/{job['run_id']}"

--- a/.github/scripts/tests/test_format_alert.py
+++ b/.github/scripts/tests/test_format_alert.py
@@ -120,6 +120,45 @@ class TestFormatAlertMultiJob(unittest.TestCase):
         self.assertIn("`deadbee`", lines[0])
         self.assertIn("bob", lines[0])
 
+    def test_multi_job_attempt_label_on_header(self):
+        data = {**self.MULTI, "attempt": "3"}
+        lines = format_alert(data).splitlines()
+        self.assertIn("attempt 3", lines[0])
+        for line in lines[1:]:
+            self.assertNotIn("attempt", line)
+
+
+class TestAttemptLabel(unittest.TestCase):
+
+    def test_absent_attempt_has_no_label(self):
+        self.assertNotIn("attempt", format_alert(BASE))
+
+    def test_first_attempt_has_no_label(self):
+        self.assertNotIn("attempt", format_alert({**BASE, "attempt": "1"}))
+
+    def test_second_attempt_is_labeled(self):
+        self.assertIn(", attempt 2", format_alert({**BASE, "attempt": "2"}))
+
+    def test_integer_attempt_is_accepted(self):
+        self.assertIn("attempt 4", format_alert({**BASE, "attempt": 4}))
+
+    def test_unparseable_attempt_is_ignored(self):
+        self.assertNotIn("attempt", format_alert({**BASE, "attempt": ""}))
+        self.assertNotIn("attempt", format_alert({**BASE, "attempt": "later"}))
+
+    def test_label_precedes_the_url(self):
+        result = format_alert({**BASE, "attempt": "2"})
+        self.assertLess(result.index("attempt 2"), result.index(EXPECTED_URL))
+
+    def test_label_coexists_with_commit_info(self):
+        result = format_alert({**BASE, "sha": "deadbeef12", "actor": "bob", "attempt": "2"})
+        self.assertIn("`deadbee`", result)
+        self.assertIn("bob", result)
+        self.assertIn("by bob, attempt 2", result)
+
+    def test_alert_is_still_one_line(self):
+        self.assertEqual(1, len(format_alert({**BASE, "attempt": "2"}).splitlines()))
+
 
 class TestMainErrorHandling(unittest.TestCase):
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -289,21 +289,25 @@ jobs:
     runs-on: ubuntu-latest
     name: Coverage Summary
     needs: coverage-reports
-    if: needs.coverage-reports.result == 'success'
+    # coverage-reports downgrades its Gradle failures to warnings, so a project may publish no artifact.
+    if: ${{ !cancelled() }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: coverage-core
           path: core
 
       - uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: coverage-build-logic
           path: build-logic
 
       - uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: coverage-gradle-plugins
           path: gradle-plugins

--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -49,14 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Format alert
-        id: fmt
+      - name: Collect failed jobs
+        id: jobs
         env:
-          BRANCH: ${{ github.ref_name }}
-          SERVER_URL: ${{ github.server_url }}
-          REPOSITORY: ${{ github.repository }}
-          SHA: ${{ github.sha }}
-          ACTOR: ${{ github.actor }}
           BAT_RESULT: ${{ needs.build-and-test.result }}
           BAT_RUN_ID: ${{ needs.build-and-test.outputs.run_id }}
           DCC_RESULT: ${{ needs.demoapps-ci-check.result }}
@@ -74,21 +69,20 @@ jobs:
           if [ "$BCV_RESULT" = "failure" ]; then
             jobs_json=$(echo "$jobs_json" | jq -c --arg name "API Compatibility" --arg run_id "$BCV_RUN_ID" '. + [{"name": $name, "run_id": $run_id}]')
           fi
-          text=$(jq -n \
-            --arg branch "$BRANCH" \
-            --arg server_url "$SERVER_URL" \
-            --arg repository "$REPOSITORY" \
-            --arg sha "$SHA" \
-            --arg actor "$ACTOR" \
-            --argjson jobs "$jobs_json" \
-            '{"branch": $branch, "server_url": $server_url, "repository": $repository, "sha": $sha, "actor": $actor, "jobs": $jobs}' | \
-            python3 .github/scripts/format_alert.py)
-          {
-            echo "text<<ALERT_EOF"
-            echo "$text"
-            echo "ALERT_EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "jobs_json=${jobs_json}" >> "$GITHUB_OUTPUT"
         shell: bash
+
+      - name: Format alert
+        id: fmt
+        uses: ./.github/actions/collect-failure-info
+        with:
+          jobs_json: ${{ steps.jobs.outputs.jobs_json }}
+          branch: ${{ github.ref_name }}
+          server_url: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          sha: ${{ github.sha }}
+          actor: ${{ github.actor }}
+          attempt: ${{ github.run_attempt }}
 
   send-alerts:
     needs: [format-alerts]

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -29,6 +29,7 @@ jobs:
           server_url: ${{ github.server_url }}
           repository: ${{ github.repository }}
           actor: ${{ github.event.workflow_run.actor.login }}
+          attempt: ${{ github.event.workflow_run.run_attempt }}
 
   post:
     needs: [format-alerts]

--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -159,6 +159,7 @@ jobs:
           repository: ${{ github.repository }}
           sha: ${{ github.sha }}
           actor: ${{ github.actor }}
+          attempt: ${{ github.run_attempt }}
 
   send-alerts:
     needs: [format-alerts]

--- a/.github/workflows/periodic-green-check.yml
+++ b/.github/workflows/periodic-green-check.yml
@@ -94,6 +94,7 @@ jobs:
           branch: ${{ inputs.branch || 'main' }}
           server_url: ${{ github.server_url }}
           repository: ${{ github.repository }}
+          attempt: ${{ github.run_attempt }}
 
   send-staleness-alert:
     needs: [staleness-check]

--- a/.github/workflows/post-alerts.yml
+++ b/.github/workflows/post-alerts.yml
@@ -58,6 +58,7 @@ jobs:
           server_url: ${{ github.server_url }}
           repository: ${{ github.repository }}
           actor: ${{ github.actor }}
+          attempt: ${{ github.run_attempt }}
 
   test-post:
     needs: [format-test]


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

**A transient dependency failure turns `main` red through an advisory job.** In run [32311746606](https://github.com/airbnb/viaduct/actions/runs/32311746606), `Coverage Summary` failed with `Artifact not found for name: coverage-core`. `Coverage (core)` could not resolve `org.jacoco:org.jacoco.ant:0.8.12`; Maven Central returned `429`. That step's `|| { echo "::warning::..." }` wrapper reported the job as successful. No reports were produced, so no artifact was uploaded. `coverage-summary`'s `needs.coverage-reports.result == 'success'` gate then passed, and `download-artifact` failed the job. The gate works as written. The defect is that `coverage-summary` requires artifacts an advisory job may not produce.

**Re-run alerts read identically to the original.** Run 32311746606 is attempt 2 and alerted twice with the same text. Runs [32199780064](https://github.com/airbnb/viaduct/actions/runs/32199780064) and [32285827987](https://github.com/airbnb/viaduct/actions/runs/32285827987) alerted on attempt-1 failures that passed on re-run.

### Changed

`coverage-summary` gets `continue-on-error: true` on its three `download-artifact` steps, and a
`!cancelled()` gate so one failed project no longer discards the summary for the other two.
`format_coverage_summary.py` already prints `⚠️ No per-module coverage reports found.` when it finds
none, so it needs no change.

`format_alert.py` gains an optional `attempt`, rendered only above 1:

```
before  :red_circle: Build and Test failed on `main` — commit `4ca5b19` by viaductbot (https://…)
after   :red_circle: Build and Test failed on `main` — commit `4ca5b19` by viaductbot, attempt 2 (https://…)
```

`.github/actions/collect-failure-info` already wrapped `format_alert.py` for four workflows.
`ci-trigger.yml` duplicated its payload construction inline, and now uses the action. All five call
sites pass `attempt`. `ci-watchdog.yml` passes `github.event.workflow_run.run_attempt`, because its
alert describes the observed run rather than the watchdog.

## How was it tested?  What documentation was provided?

- `actionlint` across every workflow.
- `python3 -m unittest tests.test_format_alert tests.test_format_coverage_summary`.
- The composite action's `jq` payload piped to `format_alert.py` using run 32311746606's values at attempt `""`, `1` and `2`, and with a two-job list. Exit 0 each time, output as quoted above.