### PR TITLE
ci(alerts): retry a failed run once before alerting

### DIFF
--- a/.github/actions/collect-failure-info/action.yml
+++ b/.github/actions/collect-failure-info/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Run attempt number (optional); labeled in the alert only when above 1'
     required: false
     default: ''
+  outcome:
+    description: '"failure" (default) or "retry_success" for a run a retry recovered'
+    required: false
+    default: ''
 
 outputs:
   text:
@@ -46,6 +50,7 @@ runs:
         SHA: ${{ inputs.sha }}
         ACTOR: ${{ inputs.actor }}
         ATTEMPT: ${{ inputs.attempt }}
+        OUTCOME: ${{ inputs.outcome }}
       run: |
         # Build the full payload — format_alert.py handles empty sha/actor
         # gracefully via .get() + truthiness checks.
@@ -56,12 +61,14 @@ runs:
           --arg sha "$SHA" \
           --arg actor "$ACTOR" \
           --arg attempt "$ATTEMPT" \
+          --arg outcome "$OUTCOME" \
           --argjson jobs "$JOBS_JSON" \
           '{ branch: $branch, server_url: $server_url, repository: $repository,
              jobs: $jobs }
            + (if $sha  != "" then { sha: $sha }   else {} end)
            + (if $actor != "" then { actor: $actor } else {} end)
-           + (if $attempt != "" then { attempt: $attempt } else {} end)' | \
+           + (if $attempt != "" then { attempt: $attempt } else {} end)
+           + (if $outcome != "" then { outcome: $outcome } else {} end)' | \
           python3 .github/scripts/format_alert.py)
 
         {

--- a/.github/actions/collect-failure-info/action.yml
+++ b/.github/actions/collect-failure-info/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'GitHub actor (optional)'
     required: false
     default: ''
+  attempt:
+    description: 'Run attempt number (optional); labeled in the alert only when above 1'
+    required: false
+    default: ''
 
 outputs:
   text:
@@ -41,6 +45,7 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         SHA: ${{ inputs.sha }}
         ACTOR: ${{ inputs.actor }}
+        ATTEMPT: ${{ inputs.attempt }}
       run: |
         # Build the full payload — format_alert.py handles empty sha/actor
         # gracefully via .get() + truthiness checks.
@@ -50,11 +55,13 @@ runs:
           --arg repository "$REPOSITORY" \
           --arg sha "$SHA" \
           --arg actor "$ACTOR" \
+          --arg attempt "$ATTEMPT" \
           --argjson jobs "$JOBS_JSON" \
           '{ branch: $branch, server_url: $server_url, repository: $repository,
              jobs: $jobs }
            + (if $sha  != "" then { sha: $sha }   else {} end)
-           + (if $actor != "" then { actor: $actor } else {} end)' | \
+           + (if $actor != "" then { actor: $actor } else {} end)
+           + (if $attempt != "" then { attempt: $attempt } else {} end)' | \
           python3 .github/scripts/format_alert.py)
 
         {

--- a/.github/impldocs/actions-arch.md
+++ b/.github/impldocs/actions-arch.md
@@ -148,6 +148,8 @@ The emit step runs early so that `run_id` is available to the calling orchestrat
 
 - **Transient failures are retried before they alert.** CI Check and Periodic Green Check are re-run once on their first failure and alert only if the retry also fails. Nightly Build is not retried: its failures have been real defects, and it is the only Windows signal, so delaying that alert by a full run buys nothing.
 
+- **A retry that succeeds is still reported.** A run that ends `success` past its first attempt gets an informational notice naming what failed on attempt 1. Silence would hide the flake rate, which is the number that decides whether a flake is worth chasing. Re-running an already-green run reports nothing, since attempt 1 has no failed job to name.
+
 ### Alert Formatting
 
 All alerts are formatted by `.github/scripts/format_alert.py`, a pure Python script that reads JSON from stdin and writes formatted text to stdout.
@@ -160,26 +162,28 @@ All alerts are formatted by `.github/scripts/format_alert.py`, a pure Python scr
   "server_url": "https://github.com",
   "repository": "org/repo",
   "jobs": [
-    { "name": "Build and Test", "run_id": "12345" },
+    { "name": "Build and Test", "run_id": "12345", "tasks": [":core:tenant:runtime:compileTestKotlin"] },
     { "name": "API Compatibility", "run_id": "12346" }
   ],
   "sha": "abc1234...",
   "actor": "username",
-  "attempt": 2
+  "attempt": 2,
+  "outcome": "retry_success"
 }
 ```
 
 - `branch`, `server_url`, `repository`, `jobs` are required.
 - `sha`, `actor` are optional (present for push-triggered failures).
 - `attempt` is optional and rendered only above 1, so the label means the run had already been retried.
-- `jobs` is a non-empty array. Each entry has a `name` (display label) and `run_id` (used to construct the URL `{server_url}/{repository}/actions/runs/{run_id}`).
+- `outcome` is optional, either `failure` (the default) or `retry_success`. It selects the emoji and verb. An unrecognized value is rejected rather than silently read as a failure.
+- `jobs` is a non-empty array. Each entry has a `name` (display label), a `run_id` (used to construct the URL `{server_url}/{repository}/actions/runs/{run_id}`), and an optional `tasks` array of failing Gradle task paths.
 
 **Output format:**
 
-- Single failed job: one-line message with job name, branch, optional commit info, and link.
-- Multiple failed jobs: header line followed by a bulleted list of `name: url` entries.
+- One failed job with no tasks: a single line with job name, branch, optional commit info, and link.
+- Otherwise a header line followed by one bullet per job. A job with no tasks stays inline as `name: url`; a job with tasks puts its name, then up to 3 tasks one per line, then its link. Beyond 3 the last line gains `+N more`.
 
-Job names come from the run's job list, so an alert names the job that actually failed (`build-and-test / Test (Java 17) ubuntu-latest`) rather than the atomic that contained it.
+Job names come from the run's job list, so an alert names the job that actually failed (`build-and-test / Test (Java 17) ubuntu-latest`) rather than the atomic that contained it. Tasks come from `extract_failed_tasks.py` reading that job's log, which is why a failure with no Gradle task — an HTTP 429 from a dependency repository, say — still reports its job name.
 
 ### Alert Posting Protocol
 
@@ -197,26 +201,30 @@ The listener pattern in YAML:
 triage:
   runs-on: ubuntu-latest
   if: >-
-    github.event.workflow_run.conclusion == 'failure'
-    && github.event.workflow_run.head_branch == 'main'
+    github.event.workflow_run.head_branch == 'main'
     && contains(fromJSON('["push", "schedule"]'), github.event.workflow_run.event)
+    && (github.event.workflow_run.conclusion == 'failure'
+        || (github.event.workflow_run.conclusion == 'success'
+            && github.event.workflow_run.run_attempt > 1))
   outputs:
     text: ${{ steps.fmt.outputs.text }}
   steps:
     - uses: actions/checkout@v6
     - name: Retry once before alerting
       id: retry
-      if: github.event.workflow_run.run_attempt == 1 && <workflow is retry-eligible>
+      if: <failure> && github.event.workflow_run.run_attempt == 1 && <retry-eligible workflow>
       run: |
         # POST rerun-failed-jobs; set retried=true, or false if the call fails
-    - name: List failed jobs
+    - name: Collect the jobs and tasks that failed
       id: jobs
-      if: steps.retry.outputs.retried != 'true'
+      if: "!cancelled() && steps.retry.outputs.retried != 'true'"
       run: |
-        # gh api --paginate .../attempts/$ATTEMPT/jobs, select failures, build the jobs array
+        # query attempt 1 when the run ended in success, else the current attempt
+        # list failed job ids and names, pipe each job's log through extract_failed_tasks.py
+        # emit outcome=retry_success|failure, and an empty jobs_json when there is nothing to say
     - name: Format alert
       id: fmt
-      if: steps.retry.outputs.retried != 'true'
+      if: "!cancelled() && steps.jobs.outputs.jobs_json != ''"
       uses: ./.github/actions/collect-failure-info
 
 post:
@@ -228,7 +236,9 @@ post:
   secrets: inherit
 ```
 
-Empty text is how a retried run stays quiet, so `post` keys off the text rather than `triage`'s result. A skipped retry step leaves `retried` unset, which also alerts. If the re-run call fails the listener alerts instead, because going silent is worse than one extra alert.
+Empty text is how a retried run stays quiet, so `post` keys off the text rather than `triage`'s result. A skipped retry step leaves `retried` unset, which also alerts. If the re-run call fails, or a job's log cannot be read, the listener still alerts, because going silent is worse than one extra alert or one missing task name.
+
+Only the collection step knows whether the run recovered, so it emits `outcome` rather than having the format step recompute it.
 
 ## Workflow Diagrams
 
@@ -260,8 +270,10 @@ ci-trigger.yml  [orchestrator]
   v
 ci-retry-then-alert.yml  [listener]
   |
-  |--- attempt 1 --> rerun-failed-jobs, no alert
-  '--- attempt 2 --> post-alerts.yml [helper] --> Slack + Discord
+  |--- failure, attempt 1 --> rerun-failed-jobs, no message
+  |--- failure, attempt 2 --> post-alerts.yml [helper] --> Slack + Discord
+  '--- success, attempt 2 --> post-alerts.yml [helper] --> Slack + Discord
+                              (informational; names what failed on attempt 1)
 ```
 
 ### Daily Schedule (2pm UTC)

--- a/.github/impldocs/actions-arch.md
+++ b/.github/impldocs/actions-arch.md
@@ -32,7 +32,7 @@ An atomic workflow performs one well-defined, coherent, loosely-coupled function
 
 - Must expose a `run_id` workflow output, always, unconditionally. This allows orchestrators to construct direct URLs to the atomic's run. The `run_id` is emitted early in the workflow (before any step that might fail) so it is available even when the workflow fails.
 
-- Must not send notifications. Atomics do not know whether they were launched by a human (who is watching) or by an orchestrator (which will handle notifications). Notification logic belongs exclusively in orchestrators.
+- Must not send notifications. Atomics do not know whether they were launched by a human who is watching. Notification logic belongs to the failure listener (see [Notification Architecture](#notification-architecture)).
 
 - Must be manually dispatchable via `workflow_dispatch`. Every atomic should be independently runnable by hand for debugging and validation.
 
@@ -55,11 +55,9 @@ An orchestrator composes atomics (and possibly inline jobs) into a higher-level 
 
 **Rules for orchestrators:**
 
-- Own all notification decisions. When an orchestrator detects that a child atomic failed, it formats an alert and routes it through the alert-posting helper (see [Notification Architecture](#notification-architecture)).
+- Must not send failure notifications either. A run's failure alerting belongs to `ci-retry-then-alert.yml`, which observes completed runs from outside them (see [Notification Architecture](#notification-architecture)). An orchestrator may still alert on a condition only it can detect, as `periodic-green-check.yml` does for branch staleness.
 
-- Must be manually dispatchable via `workflow_dispatch`. When launched manually, notifications are **never** sent. Notifications are reserved for automatic triggers (`push`, `schedule`, or `workflow_call` with `send_alerts: true`). This prevents noise when a human is already watching the run.
-
-- Not every orchestrator must notify. The rule is that only orchestrators *may* notify, and only on automatic triggers.
+- Must be manually dispatchable via `workflow_dispatch`. A manual dispatch does not alert, because whoever triggered it is watching.
 
 **Current orchestrators:**
 
@@ -76,7 +74,18 @@ An orchestrator helper is a reusable workflow that orchestrators delegate to for
 
 | Workflow | Purpose | Runs on |
 |---|---|---|
-| `post-alerts.yml` | Post pre-formatted alert text to Slack and Discord | called by orchestrators on failure, manual (test mode) |
+| `post-alerts.yml` | Post pre-formatted alert text to Slack and Discord | called by listeners and orchestrators on failure, manual (test mode) |
+
+### Listener Workflows
+
+A listener runs on `workflow_run`, after another run completes. It sees that run's conclusion and attempt number, which no job inside the run can observe.
+
+| Workflow | Purpose | Runs on |
+|---|---|---|
+| `ci-retry-then-alert.yml` | Retry a failed CI run once, then alert if the retry also fails | completion of CI Check, Nightly Build, Periodic Green Check |
+| `ci-watchdog.yml` | Alert on startup failures, which stop in-run jobs from running at all | completion of CI Check, Nightly Build, Periodic Green Check, Release |
+
+`ci-retry-then-alert.yml` holds `actions: write`, the only such grant in the repo, because re-running a run requires it. It is a sibling of `ci-watchdog.yml` rather than a job inside it so that a broken retry cannot take the watchdog down with it.
 
 ### Release Workflows
 
@@ -133,9 +142,11 @@ The emit step runs early so that `run_id` is available to the calling orchestrat
 
 - **Notifications link to diagnostic info; they do not contain it.** An alert message names the failed job and links to its run. It does not reproduce logs, stack traces, or error details.
 
-- **Only orchestrators send notifications.** Atomics never notify. This avoids double-alerting and keeps notification policy in one place per automation flow.
+- **One listener owns failure alerting.** `ci-retry-then-alert.yml` is the only place a run's failure becomes an alert. Neither atomics nor orchestrators notify on failure. A second alerting path anywhere means double-alerting.
 
-- **Manual runs never notify.** When a human triggers `workflow_dispatch`, they are watching. Alerts would be noise. Notifications fire only on automatic triggers: `push` events, `schedule` events, or `workflow_call` with explicit `send_alerts: true`.
+- **Manual runs never notify.** When a human triggers `workflow_dispatch`, they are watching. The listener therefore alerts only for `push` and `schedule` runs, and only on `main`.
+
+- **Transient failures are retried before they alert.** CI Check and Periodic Green Check are re-run once on their first failure and alert only if the retry also fails. Nightly Build is not retried: its failures have been real defects, and it is the only Windows signal, so delaying that alert by a full run buys nothing.
 
 ### Alert Formatting
 
@@ -153,12 +164,14 @@ All alerts are formatted by `.github/scripts/format_alert.py`, a pure Python scr
     { "name": "API Compatibility", "run_id": "12346" }
   ],
   "sha": "abc1234...",
-  "actor": "username"
+  "actor": "username",
+  "attempt": 2
 }
 ```
 
 - `branch`, `server_url`, `repository`, `jobs` are required.
 - `sha`, `actor` are optional (present for push-triggered failures).
+- `attempt` is optional and rendered only above 1, so the label means the run had already been retried.
 - `jobs` is a non-empty array. Each entry has a `name` (display label) and `run_id` (used to construct the URL `{server_url}/{repository}/actions/runs/{run_id}`).
 
 **Output format:**
@@ -166,46 +179,56 @@ All alerts are formatted by `.github/scripts/format_alert.py`, a pure Python scr
 - Single failed job: one-line message with job name, branch, optional commit info, and link.
 - Multiple failed jobs: header line followed by a bulleted list of `name: url` entries.
 
+Job names come from the run's job list, so an alert names the job that actually failed (`build-and-test / Test (Java 17) ubuntu-latest`) rather than the atomic that contained it.
+
 ### Alert Posting Protocol
 
-Orchestrators do not post to Slack or Discord directly. Instead they:
+Nothing posts to Slack or Discord directly. Instead:
 
-1. **Format** the alert text by piping JSON through `format_alert.py`. The JSON is constructed safely using `jq -n --arg` to prevent injection.
-2. **Set** the text as a job output. Multi-line output (from multi-job alerts) requires heredoc syntax in `$GITHUB_OUTPUT`.
+1. **Format** the alert text with `.github/actions/collect-failure-info`, which pipes JSON through `format_alert.py`. The JSON is constructed with `jq -n --arg` to prevent injection.
+2. **Set** the text as a job output. Multi-line output (from multi-job alerts) requires heredoc syntax in `$GITHUB_OUTPUT`, which the composite action handles.
 3. **Call** `post-alerts.yml` via `workflow_call` with the `text` input.
 
 `post-alerts.yml` is the sole workflow that holds Slack and Discord credentials. Its `post-call` job posts the text to both Slack (`chat.postMessage` API with `SLACK_BOT_TOKEN`) and Discord (webhook with `DISCORD_CI_WEBHOOK_URL`). Callers pass `secrets: inherit`.
 
-The orchestrator pattern in YAML:
+The listener pattern in YAML:
 
 ```yaml
-format-alerts:
-  needs: [child-a, child-b]
+triage:
   runs-on: ubuntu-latest
   if: >-
-    always()
-    && (needs.child-a.result == 'failure' || needs.child-b.result == 'failure')
-    && (github.event_name == 'push' || inputs.send_alerts == true)
+    github.event.workflow_run.conclusion == 'failure'
+    && github.event.workflow_run.head_branch == 'main'
+    && contains(fromJSON('["push", "schedule"]'), github.event.workflow_run.event)
   outputs:
     text: ${{ steps.fmt.outputs.text }}
   steps:
     - uses: actions/checkout@v6
+    - name: Retry once before alerting
+      id: retry
+      if: github.event.workflow_run.run_attempt == 1 && <workflow is retry-eligible>
+      run: |
+        # POST rerun-failed-jobs; set retried=true, or false if the call fails
+    - name: List failed jobs
+      id: jobs
+      if: steps.retry.outputs.retried != 'true'
+      run: |
+        # gh api --paginate .../attempts/$ATTEMPT/jobs, select failures, build the jobs array
     - name: Format alert
       id: fmt
-      run: |
-        # Build jobs array from failed children using jq
-        # Pipe to format_alert.py
-        # Write text to $GITHUB_OUTPUT using heredoc
-      shell: bash
+      if: steps.retry.outputs.retried != 'true'
+      uses: ./.github/actions/collect-failure-info
 
-send-alerts:
-  needs: [format-alerts]
-  if: always() && needs.format-alerts.result == 'success'
+post:
+  needs: [triage]
+  if: always() && needs.triage.outputs.text != ''
   uses: ./.github/workflows/post-alerts.yml
   with:
-    text: ${{ needs.format-alerts.outputs.text }}
+    text: ${{ needs.triage.outputs.text }}
   secrets: inherit
 ```
+
+Empty text is how a retried run stays quiet, so `post` keys off the text rather than `triage`'s result. A skipped retry step leaves `retried` unset, which also alerts. If the re-run call fails the listener alerts instead, because going silent is worse than one extra alert.
 
 ## Workflow Diagrams
 
@@ -229,11 +252,16 @@ ci-trigger.yml  [orchestrator]
   |                                                --> test-kotlin-matrix
   |                                                --> test-gradle-matrix
   |
-  |--- bcv-api-check.yml  [atomic]
-  |      api-compatibility
+  '--- bcv-api-check.yml  [atomic]
+         api-compatibility
+
+[on push, once the run completes with conclusion=failure]
   |
-  '--- [on push, if any atomic failed]
-         format-alerts --> send-alerts --> post-alerts.yml [helper] --> Slack + Discord
+  v
+ci-retry-then-alert.yml  [listener]
+  |
+  |--- attempt 1 --> rerun-failed-jobs, no alert
+  '--- attempt 2 --> post-alerts.yml [helper] --> Slack + Discord
 ```
 
 ### Daily Schedule (2pm UTC)
@@ -247,19 +275,21 @@ periodic-green-check.yml  [orchestrator]
   |--- ci-check
   |      |
   |      v
-  |    ci-trigger.yml  [orchestrator, send_alerts: true]
+  |    ci-trigger.yml  [orchestrator]
   |      |
   |      |--- build-and-test.yml  [atomic]
   |      |--- demoapps-ci-check.yml  [atomic]
-  |      |--- bcv-api-check.yml  [atomic]
-  |      |
-  |      '--- [if any atomic failed]
-  |             format-alerts --> send-alerts --> post-alerts.yml [helper] --> Slack + Discord
+  |      '--- bcv-api-check.yml  [atomic]
   |
   '--- staleness-check  [inline job]
          |
          '-- [if stale]
                format-alert --> send-staleness-alert --> post-alerts.yml [helper] --> Slack + Discord
+
+[once the run completes with conclusion=failure]
+  |
+  v
+ci-retry-then-alert.yml  [listener]   (retried once, like CI Check)
 ```
 
 ### Nightly Build (6am UTC weekdays)
@@ -269,6 +299,11 @@ schedule / manual dispatch
   |
   v
 nightly-build.yml  [orchestrator, thin wrapper]
+  |
+  |--- windows-check  [inline job, matrix: Java 17, 21]
+  |      the only place the unscoped root `check` runs on Windows
+  |
+  |--- demoapps-standalone-windows  [inline job, matrix: Java 17, 21]
   |
   v
 demoapps-nightly-check.yml  [orchestrator]
@@ -291,7 +326,15 @@ demoapps-nightly-check.yml  [orchestrator]
   |
   '--- cleanup (if tmp/* branch)
          delete tmp branches from viaduct-dev/* repos
+
+[once the run completes with conclusion=failure]
+  |
+  v
+ci-retry-then-alert.yml  [listener]
+  '--- post-alerts.yml [helper] --> Slack + Discord   (no retry; alerts on the first failure)
 ```
+
+The listener watches `nightly-build.yml`, so the Windows jobs are covered without any alerting inside the run. That is what they previously lacked: alerting used to live in `demoapps-nightly-check.yml` and was gated on its own four jobs, so a nightly that failed only on Windows was silent.
 
 ### CI Check (via `ci-trigger.yml`)
 
@@ -303,24 +346,23 @@ ci-trigger.yml  [orchestrator]
   |
   |--- build-and-test.yml  [atomic]
   |--- demoapps-ci-check.yml  [atomic]
-  |--- bcv-api-check.yml  [atomic]
-  |
-  '--- [if any atomic failed && send_alerts]
-         format-alerts --> send-alerts --> post-alerts.yml [helper] --> Slack + Discord
+  '--- bcv-api-check.yml  [atomic]
+
+A manual dispatch does not alert, because the listener only handles `push` and `schedule` runs.
 ```
 
 ### Manual Dispatch
 
 Every workflow supports `workflow_dispatch` so it can be run by hand independently. This serves two purposes: **testing** (validate a workflow change on a branch before merging) and **on-demand execution** (run a check or suite without waiting for its automatic trigger).
 
-Notifications are suppressed on manual dispatch — the person who triggered the run is already watching.
+Notifications are suppressed on manual dispatch, because the person who triggered the run is already watching.
 
 | Workflow | What you'd run it for | Key inputs |
 |---|---|---|
 | `build-and-test.yml` | Test a specific OS/Java combination | `os`, `java_versions` |
 | `demoapps-ci-check.yml` | Test demoapps against a specific OS/Java combination | `os`, `java_versions` |
 | `bcv-api-check.yml` | Check API compatibility on a branch | — |
-| `ci-trigger.yml` | Run the full CI suite on demand | `send_alerts` (default: off) |
+| `ci-trigger.yml` | Run the full CI suite on demand | — |
 | `demoapps-nightly-check.yml` | Run the end-to-end snapshot validation loop | `ref`, `run_ci_check` (default: off) |
 | `nightly-build.yml` | Trigger the nightly validation without waiting for cron | — |
 | `periodic-green-check.yml` | Run scheduled checks without waiting for cron | `branch`, `mode` (ci-check / staleness-check / all) |

--- a/.github/scripts/extract_failed_tasks.py
+++ b/.github/scripts/extract_failed_tasks.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Extracts the Gradle tasks that failed from a GitHub Actions job log.
+
+Reads a job log on stdin and prints one task path per line, deduplicated, in the
+order they appear.
+
+Prints nothing when no Gradle task failed. A job can fail without one, as
+happens when a dependency repository returns HTTP 429 or a runner step dies
+before Gradle starts.
+
+Exit codes:
+  0 - success, including when no failing task is present
+"""
+
+import re
+import sys
+
+# Windows runners emit CRLF, so the log is normalized before matching.
+TASK_FAILED = re.compile(r"> Task (\S+) FAILED")
+
+
+def extract_failed_tasks(log: str) -> list:
+    tasks = []
+    for match in TASK_FAILED.finditer(log.replace("\r", "")):
+        task = match.group(1)
+        if task not in tasks:
+            tasks.append(task)
+    return tasks
+
+
+def main():
+    # Job logs carry arbitrary test output, which is not guaranteed to be valid UTF-8.
+    log = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+    for task in extract_failed_tasks(log):
+        print(task)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/extract_failed_tasks.py
+++ b/.github/scripts/extract_failed_tasks.py
@@ -15,13 +15,16 @@ Exit codes:
 import re
 import sys
 
-# Windows runners emit CRLF, so the log is normalized before matching.
 TASK_FAILED = re.compile(r"> Task (\S+) FAILED")
+
+# Job logs are coloured, and Windows runners emit CRLF. Both are stripped before matching.
+ANSI = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 
 
 def extract_failed_tasks(log: str) -> list:
+    plain = ANSI.sub("", log).replace("\r", "")
     tasks = []
-    for match in TASK_FAILED.finditer(log.replace("\r", "")):
+    for match in TASK_FAILED.finditer(plain):
         task = match.group(1)
         if task not in tasks:
             tasks.append(task)

--- a/.github/scripts/format_alert.py
+++ b/.github/scripts/format_alert.py
@@ -10,14 +10,19 @@ Reads a JSON object from stdin with the following fields:
     jobs        - non-empty array of failed jobs, each with:
                     name   - display name of the job/workflow
                     run_id - GitHub Actions run ID (used to construct the URL)
+                    tasks  - optional array of failing Gradle task paths
 
   Optional:
     sha         - commit SHA (for push-triggered failures)
     actor       - GitHub username who pushed (for push-triggered failures)
     attempt     - run attempt number; labeled only when above 1
+    outcome     - "failure" (default), or "retry_success" for a run that a
+                  retry recovered
 
 Prints formatted alert text to stdout. Single-job alerts produce one line;
-multi-job alerts produce a header line followed by a bulleted list of jobs.
+multi-job alerts produce a header line followed by a bulleted list of jobs. Any
+job carrying tasks switches the whole message to the header form, listing each
+job's tasks beneath it.
 
 Exit codes:
   0 - success
@@ -26,6 +31,13 @@ Exit codes:
 
 import json
 import sys
+
+OUTCOMES = {
+    "failure": (":red_circle:", "failed"),
+    "retry_success": (":large_yellow_circle:", "needed a retry"),
+}
+
+MAX_TASKS_SHOWN = 3
 
 
 def format_attempt_label(attempt) -> str:
@@ -36,11 +48,22 @@ def format_attempt_label(attempt) -> str:
     return f", attempt {n}" if n > 1 else ""
 
 
+def format_task_lines(tasks) -> list:
+    shown = tasks[:MAX_TASKS_SHOWN]
+    lines = [f"  `{task}`" for task in shown]
+    hidden = len(tasks) - len(shown)
+    if hidden:
+        lines[-1] += f" +{hidden} more"
+    return lines
+
+
 def format_alert(data: dict) -> str:
     branch = data["branch"]
     server_url = data["server_url"]
     repository = data["repository"]
     jobs = data["jobs"]
+
+    emoji, verb = OUTCOMES.get(data.get("outcome"), OUTCOMES["failure"])
 
     sha = data.get("sha")
     actor = data.get("actor")
@@ -58,12 +81,19 @@ def format_alert(data: dict) -> str:
     def job_url(job):
         return f"{server_url}/{repository}/actions/runs/{job['run_id']}"
 
-    if len(jobs) == 1:
+    if len(jobs) == 1 and not jobs[0].get("tasks"):
         job = jobs[0]
-        return f":red_circle: {job['name']} failed on `{branch}`{commit_info} ({job_url(job)})"
+        return f"{emoji} {job['name']} {verb} on `{branch}`{commit_info} ({job_url(job)})"
 
-    header = f":red_circle: CI failed on `{branch}`{commit_info}"
-    lines = [header] + [f"• {job['name']}: {job_url(job)}" for job in jobs]
+    lines = [f"{emoji} CI {verb} on `{branch}`{commit_info}"]
+    for job in jobs:
+        tasks = job.get("tasks") or []
+        if not tasks:
+            lines.append(f"• {job['name']}: {job_url(job)}")
+            continue
+        lines.append(f"• {job['name']}")
+        lines.extend(format_task_lines(tasks))
+        lines.append(f"  {job_url(job)}")
     return "\n".join(lines)
 
 
@@ -92,6 +122,14 @@ def main():
         if not isinstance(job, dict) or "name" not in job or "run_id" not in job:
             print(f"jobs[{i}] must have 'name' and 'run_id' fields", file=sys.stderr)
             return 1
+        if "tasks" in job and not isinstance(job["tasks"], list):
+            print(f"jobs[{i}]['tasks'] must be an array", file=sys.stderr)
+            return 1
+
+    outcome = data.get("outcome")
+    if outcome is not None and outcome not in OUTCOMES:
+        print(f"'outcome' must be one of: {', '.join(sorted(OUTCOMES))}", file=sys.stderr)
+        return 1
 
     print(format_alert(data))
     return 0

--- a/.github/scripts/format_alert.py
+++ b/.github/scripts/format_alert.py
@@ -14,6 +14,7 @@ Reads a JSON object from stdin with the following fields:
   Optional:
     sha         - commit SHA (for push-triggered failures)
     actor       - GitHub username who pushed (for push-triggered failures)
+    attempt     - run attempt number; labeled only when above 1
 
 Prints formatted alert text to stdout. Single-job alerts produce one line;
 multi-job alerts produce a header line followed by a bulleted list of jobs.
@@ -25,6 +26,14 @@ Exit codes:
 
 import json
 import sys
+
+
+def format_attempt_label(attempt) -> str:
+    try:
+        n = int(attempt)
+    except (TypeError, ValueError):
+        return ""
+    return f", attempt {n}" if n > 1 else ""
 
 
 def format_alert(data: dict) -> str:
@@ -43,6 +52,8 @@ def format_alert(data: dict) -> str:
         commit_info = f" — commit `{sha[:7]}`"
     elif actor:
         commit_info = f" — pushed by {actor}"
+
+    commit_info += format_attempt_label(data.get("attempt"))
 
     def job_url(job):
         return f"{server_url}/{repository}/actions/runs/{job['run_id']}"

--- a/.github/scripts/tests/test_extract_failed_tasks.py
+++ b/.github/scripts/tests/test_extract_failed_tasks.py
@@ -60,6 +60,14 @@ class TestExtractFailedTasks(unittest.TestCase):
         log = "> Task :test FAILED\n"
         self.assertEqual([":test"], extract_failed_tasks(log))
 
+    def test_ansi_colour_codes_are_stripped(self):
+        log = "\x1b[36;1m> Task :core:shared:utils:test FAILED\x1b[0m\n"
+        self.assertEqual([":core:shared:utils:test"], extract_failed_tasks(log))
+
+    def test_ansi_codes_adjacent_to_the_task_path(self):
+        log = "> Task \x1b[1m:core:tenant:api:compileKotlin\x1b[0m FAILED\n"
+        self.assertEqual([":core:tenant:api:compileKotlin"], extract_failed_tasks(log))
+
 
 class BinaryStdin:
     def __init__(self, data: bytes):

--- a/.github/scripts/tests/test_extract_failed_tasks.py
+++ b/.github/scripts/tests/test_extract_failed_tasks.py
@@ -1,0 +1,99 @@
+import sys
+import unittest
+from io import BytesIO, StringIO
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from extract_failed_tasks import extract_failed_tasks, main
+
+
+class TestExtractFailedTasks(unittest.TestCase):
+
+    def test_single_task(self):
+        log = "> Task :core:x:javaapi:runtime:compileTestKotlin FAILED\n"
+        self.assertEqual([":core:x:javaapi:runtime:compileTestKotlin"], extract_failed_tasks(log))
+
+    def test_no_failing_task(self):
+        log = "> Task :core:tenant:api:compileKotlin\nBUILD SUCCESSFUL in 2m\n"
+        self.assertEqual([], extract_failed_tasks(log))
+
+    def test_empty_log(self):
+        self.assertEqual([], extract_failed_tasks(""))
+
+    def test_crlf_line_endings(self):
+        log = "> Task :core:shared:utils:test FAILED\r\n> Task :publications:runtime:check FAILED\r\n"
+        self.assertEqual(
+            [":core:shared:utils:test", ":publications:runtime:check"],
+            extract_failed_tasks(log),
+        )
+
+    def test_duplicates_collapse(self):
+        log = (
+            "> Task :core:shared:utils:test FAILED\n"
+            "some other output\n"
+            "> Task :core:shared:utils:test FAILED\n"
+        )
+        self.assertEqual([":core:shared:utils:test"], extract_failed_tasks(log))
+
+    def test_order_is_preserved(self):
+        log = (
+            "> Task :zebra:test FAILED\n"
+            "> Task :alpha:test FAILED\n"
+            "> Task :middle:test FAILED\n"
+        )
+        self.assertEqual([":zebra:test", ":alpha:test", ":middle:test"], extract_failed_tasks(log))
+
+    def test_gradle_test_failure_line_is_not_a_task(self):
+        log = "BatchResolverIntegrationTest > batch resolver resolves film characters() FAILED\n"
+        self.assertEqual([], extract_failed_tasks(log))
+
+    def test_failed_without_task_prefix_is_ignored(self):
+        log = "BUILD FAILED in 4m 29s\nExecution failed for task ':test'.\n"
+        self.assertEqual([], extract_failed_tasks(log))
+
+    def test_timestamped_log_lines(self):
+        log = "2026-08-24T13:42:38.7729370Z > Task :test FAILED\n"
+        self.assertEqual([":test"], extract_failed_tasks(log))
+
+    def test_task_without_project_path(self):
+        log = "> Task :test FAILED\n"
+        self.assertEqual([":test"], extract_failed_tasks(log))
+
+
+class BinaryStdin:
+    def __init__(self, data: bytes):
+        self.buffer = BytesIO(data)
+
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self.stdout = sys.stdout
+        sys.stdout = StringIO()
+
+    def tearDown(self):
+        sys.stdout = self.stdout
+        sys.stdin = sys.__stdin__
+
+    def test_prints_one_task_per_line(self):
+        sys.stdin = BinaryStdin(b"> Task :a:test FAILED\n> Task :b:test FAILED\n")
+        code = main()
+        self.assertEqual(0, code)
+        self.assertEqual([":a:test", ":b:test"], sys.stdout.getvalue().splitlines())
+
+    def test_prints_nothing_when_no_task_failed(self):
+        sys.stdin = BinaryStdin(b"BUILD SUCCESSFUL in 2m\n")
+        code = main()
+        self.assertEqual(0, code)
+        self.assertEqual("", sys.stdout.getvalue())
+
+    def test_invalid_utf8_does_not_crash(self):
+        sys.stdin = BinaryStdin(b"\xff\xfe garbage\n> Task :a:test FAILED\n")
+        code = main()
+        self.assertEqual(0, code)
+        self.assertEqual([":a:test"], sys.stdout.getvalue().splitlines())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_format_alert.py
+++ b/.github/scripts/tests/test_format_alert.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from format_alert import format_alert, format_attempt_label, main
+from format_alert import format_alert, format_attempt_label, format_task_lines, main
 
 
 BASE = {
@@ -158,6 +158,118 @@ class TestAttemptLabel(unittest.TestCase):
 
     def test_label_helper_rejects_none(self):
         self.assertEqual("", format_attempt_label(None))
+
+
+class TestOutcome(unittest.TestCase):
+
+    MULTI = {
+        "branch": "main",
+        "server_url": "https://github.com",
+        "repository": "example/repo",
+        "jobs": [
+            {"name": "Build and Test", "run_id": "111"},
+            {"name": "Demo App Tests", "run_id": "222"},
+        ],
+    }
+
+    def test_absent_outcome_reads_as_failure(self):
+        result = format_alert(BASE)
+        self.assertIn(":red_circle:", result)
+        self.assertIn("failed on", result)
+
+    def test_explicit_failure_matches_the_default(self):
+        self.assertEqual(format_alert(BASE), format_alert({**BASE, "outcome": "failure"}))
+
+    def test_retry_success_single_job(self):
+        result = format_alert({**BASE, "outcome": "retry_success"})
+        self.assertIn(":large_yellow_circle:", result)
+        self.assertIn("Build and Test needed a retry on `main`", result)
+        self.assertNotIn("failed", result)
+
+    def test_retry_success_multi_job_header(self):
+        lines = format_alert({**self.MULTI, "outcome": "retry_success"}).splitlines()
+        self.assertEqual(":large_yellow_circle: CI needed a retry on `main`", lines[0])
+
+    def test_unknown_outcome_is_rejected(self):
+        sys.stdin = StringIO(json.dumps({**BASE, "outcome": "flaky"}))
+        self.assertEqual(main(), 1)
+        sys.stdin = sys.__stdin__
+
+
+class TestFailingTasks(unittest.TestCase):
+
+    WITH_TASKS = {
+        "branch": "main",
+        "server_url": "https://github.com",
+        "repository": "example/repo",
+        "jobs": [
+            {
+                "name": "build-and-test / Test (Java 17) ubuntu-latest",
+                "run_id": "123",
+                "tasks": [":core:x:javaapi:runtime:compileTestKotlin"],
+            }
+        ],
+    }
+
+    def test_no_tasks_anywhere_keeps_the_single_line_form(self):
+        self.assertEqual(1, len(format_alert(BASE).splitlines()))
+
+    def test_no_tasks_anywhere_keeps_the_inline_bullet_form(self):
+        multi = {**BASE, "jobs": [
+            {"name": "A", "run_id": "1"},
+            {"name": "B", "run_id": "2"},
+        ]}
+        self.assertIn("• A: https://github.com/example/repo/actions/runs/1", format_alert(multi))
+
+    def test_empty_task_list_is_treated_as_no_tasks(self):
+        data = {**BASE, "jobs": [{"name": "Build and Test", "run_id": "123", "tasks": []}]}
+        self.assertEqual(format_alert(BASE), format_alert(data))
+
+    def test_one_job_with_tasks_uses_the_header_form(self):
+        lines = format_alert(self.WITH_TASKS).splitlines()
+        self.assertEqual(":red_circle: CI failed on `main`", lines[0])
+        self.assertEqual("• build-and-test / Test (Java 17) ubuntu-latest", lines[1])
+        self.assertEqual("  `:core:x:javaapi:runtime:compileTestKotlin`", lines[2])
+        self.assertEqual("  https://github.com/example/repo/actions/runs/123", lines[3])
+
+    def test_tasks_are_capped_at_three_with_an_overflow_count(self):
+        data = {**self.WITH_TASKS}
+        data["jobs"] = [{**data["jobs"][0], "tasks": [f":t{n}" for n in range(9)]}]
+        lines = format_alert(data).splitlines()
+        self.assertIn("  `:t0`", lines)
+        self.assertIn("  `:t1`", lines)
+        self.assertIn("  `:t2` +6 more", lines)
+        self.assertNotIn("  `:t3`", lines)
+
+    def test_exactly_three_tasks_has_no_overflow_count(self):
+        data = {**self.WITH_TASKS}
+        data["jobs"] = [{**data["jobs"][0], "tasks": [":a", ":b", ":c"]}]
+        self.assertNotIn("more", format_alert(data))
+
+    def test_job_without_tasks_stays_inline_beside_one_with_tasks(self):
+        data = {**self.WITH_TASKS}
+        data["jobs"] = data["jobs"] + [{"name": "Bare Job", "run_id": "456"}]
+        lines = format_alert(data).splitlines()
+        self.assertEqual("• Bare Job: https://github.com/example/repo/actions/runs/456", lines[4])
+        self.assertEqual(5, len(lines))
+
+    def test_retry_success_with_tasks(self):
+        lines = format_alert({**self.WITH_TASKS, "outcome": "retry_success"}).splitlines()
+        self.assertEqual(":large_yellow_circle: CI needed a retry on `main`", lines[0])
+        self.assertEqual("  `:core:x:javaapi:runtime:compileTestKotlin`", lines[2])
+
+    def test_tasks_must_be_an_array(self):
+        data = {**BASE, "jobs": [{"name": "A", "run_id": "1", "tasks": ":not:a:list"}]}
+        sys.stdin = StringIO(json.dumps(data))
+        self.assertEqual(main(), 1)
+        sys.stdin = sys.__stdin__
+
+    def test_task_lines_helper_caps_and_counts(self):
+        self.assertEqual(["  `:a`", "  `:b`", "  `:c` +1 more"],
+                         format_task_lines([":a", ":b", ":c", ":d"]))
+
+    def test_task_lines_helper_on_empty_input(self):
+        self.assertEqual([], format_task_lines([]))
 
 
 class TestMainErrorHandling(unittest.TestCase):

--- a/.github/scripts/tests/test_format_alert.py
+++ b/.github/scripts/tests/test_format_alert.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from format_alert import format_alert, main
+from format_alert import format_alert, format_attempt_label, main
 
 
 BASE = {
@@ -119,6 +119,45 @@ class TestFormatAlertMultiJob(unittest.TestCase):
         lines = format_alert(data).splitlines()
         self.assertIn("`deadbee`", lines[0])
         self.assertIn("bob", lines[0])
+
+    def test_multi_job_attempt_label_on_header_only(self):
+        data = {**self.MULTI, "attempt": 2}
+        lines = format_alert(data).splitlines()
+        self.assertIn(", attempt 2", lines[0])
+        for line in lines[1:]:
+            self.assertNotIn("attempt", line)
+
+
+class TestAttemptLabel(unittest.TestCase):
+
+    def test_absent_attempt_is_unlabeled(self):
+        self.assertNotIn("attempt", format_alert(BASE))
+
+    def test_first_attempt_is_unlabeled(self):
+        self.assertNotIn("attempt", format_alert({**BASE, "attempt": 1}))
+
+    def test_second_attempt_is_labeled(self):
+        self.assertIn(", attempt 2", format_alert({**BASE, "attempt": 2}))
+
+    def test_attempt_as_string_is_labeled(self):
+        self.assertIn(", attempt 3", format_alert({**BASE, "attempt": "3"}))
+
+    def test_unparseable_attempt_is_unlabeled(self):
+        self.assertNotIn("attempt", format_alert({**BASE, "attempt": ""}))
+
+    def test_label_precedes_the_url(self):
+        result = format_alert({**BASE, "sha": "abc1234567", "actor": "raymie", "attempt": 2})
+        self.assertLess(result.index(", attempt 2"), result.index(EXPECTED_URL))
+
+    def test_label_follows_the_actor(self):
+        result = format_alert({**BASE, "sha": "abc1234567", "actor": "raymie", "attempt": 2})
+        self.assertLess(result.index("raymie"), result.index(", attempt 2"))
+
+    def test_label_without_sha_or_actor(self):
+        self.assertIn("`main`, attempt 2", format_alert({**BASE, "attempt": 2}))
+
+    def test_label_helper_rejects_none(self):
+        self.assertEqual("", format_attempt_label(None))
 
 
 class TestMainErrorHandling(unittest.TestCase):

--- a/.github/workflows/ci-retry-then-alert.yml
+++ b/.github/workflows/ci-retry-then-alert.yml
@@ -1,6 +1,6 @@
 name: CI Retry and Alert
-# Alerts on failed CI runs, retrying the pure-CI entry points once first. Listens from outside the
-# run because a job cannot observe its own run's second attempt.
+# Alerts on failed CI runs, retrying the pure-CI entry points once first, and reports the runs a retry
+# recovered. Listens from outside the run because a job cannot observe its own run's second attempt.
 
 on:
   workflow_run:
@@ -14,11 +14,14 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    # Success past the first attempt means a retry recovered the run; no other state produces it.
     # Pull requests and manual dispatches have a human watching the run.
     if: >-
-      github.event.workflow_run.conclusion == 'failure'
-      && github.event.workflow_run.head_branch == 'main'
+      github.event.workflow_run.head_branch == 'main'
       && contains(fromJSON('["push", "schedule"]'), github.event.workflow_run.event)
+      && (github.event.workflow_run.conclusion == 'failure'
+          || (github.event.workflow_run.conclusion == 'success'
+              && github.event.workflow_run.run_attempt > 1))
     outputs:
       text: ${{ steps.fmt.outputs.text }}
     steps:
@@ -27,7 +30,8 @@ jobs:
       - name: Retry once before alerting
         id: retry
         if: >-
-          github.event.workflow_run.run_attempt == 1
+          github.event.workflow_run.conclusion == 'failure'
+          && github.event.workflow_run.run_attempt == 1
           && contains(fromJSON('["CI Check", "Periodic Green Check"]'), github.event.workflow_run.name)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -44,38 +48,83 @@ jobs:
         shell: bash
 
       # A skipped step leaves its outputs unset, so this also covers the runs that are never retried.
-      - name: List failed jobs
+      - name: Collect the jobs and tasks that failed
         id: jobs
-        if: '!cancelled() && steps.retry.outputs.retried != ''true'''
+        if: "!cancelled() && steps.retry.outputs.retried != 'true'"
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
-          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
           set -uo pipefail
-          # --paginate: gh api returns an arbitrary subset without it.
-          names=$(gh api --paginate \
-            "repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${ATTEMPT}/jobs?per_page=100" \
-            --jq '.jobs[] | select(.conclusion == "failure") | .name') || {
-            echo "::warning::Could not list the failed jobs of ${RUN_ID}"
-            names=""
-          }
 
-          # A run can fail with no job reporting failure, and format_alert.py rejects an empty list.
-          if [ -z "$names" ]; then
-            names="$WORKFLOW_NAME"
+          # A recovered run reports what broke on the first attempt, not on the one that passed.
+          if [ "$CONCLUSION" = "success" ]; then
+            attempt=1
+            echo "outcome=retry_success" >> "$GITHUB_OUTPUT"
+          else
+            attempt="$RUN_ATTEMPT"
+            echo "outcome=failure" >> "$GITHUB_OUTPUT"
           fi
 
-          jobs_json=$(printf '%s\n' "$names" | jq -R -s -c --arg run_id "$RUN_ID" \
-            'split("\n") | map(select(length > 0)) | map({name: ., run_id: $run_id})')
+          # --paginate: gh api returns an arbitrary subset without it.
+          failed=$(gh api --paginate \
+            "repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${attempt}/jobs?per_page=100" \
+            --jq '.jobs[] | select(.conclusion == "failure") | [.id, .name] | @tsv') || {
+            echo "::warning::Could not list the failed jobs of ${RUN_ID}"
+            failed=""
+          }
+
+          if [ -z "$failed" ]; then
+            # Re-running an already-green run leaves nothing to report.
+            if [ "$CONCLUSION" = "success" ]; then
+              echo "Attempt ${attempt} recorded no failed job, so there is nothing to report"
+              echo "jobs_json=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # A run can fail with no job reporting failure, and format_alert.py rejects an empty list.
+            failed=$(printf '\t%s' "$WORKFLOW_NAME")
+          fi
+
+          # One self-contained object per job, so a job that cannot be rendered drops out alone.
+          objects=$(mktemp)
+          logs_read=0
+          while IFS=$'\t' read -r job_id job_name; do
+            [ -n "$job_name" ] || continue
+            tasks='[]'
+            # Bounds the log reading. The most failed jobs seen in one run is 10.
+            if [ -n "$job_id" ] && [ "$logs_read" -lt 15 ]; then
+              logs_read=$((logs_read + 1))
+              if log=$(gh api "repos/${REPOSITORY}/actions/jobs/${job_id}/logs" 2>/dev/null); then
+                tasks=$(printf '%s' "$log" | python3 .github/scripts/extract_failed_tasks.py \
+                  | jq -R -s -c 'split("\n") | map(select(length > 0))') || tasks='[]'
+              else
+                echo "::warning::Could not read the log of job ${job_id}"
+              fi
+            fi
+            jq -n -c --arg name "$job_name" --arg run_id "$RUN_ID" --argjson tasks "$tasks" \
+              '{name: $name, run_id: $run_id, tasks: $tasks}' >> "$objects" || true
+          done <<< "$failed"
+
+          jobs_json=$(jq -s -c '.' "$objects") || jobs_json='[]'
+          rm -f "$objects"
+
+          # Naming the workflow beats posting nothing, and format_alert.py rejects an empty list.
+          if [ "$jobs_json" = "[]" ]; then
+            echo "::warning::Could not build the job list for ${RUN_ID}"
+            jobs_json=$(jq -n -c --arg name "$WORKFLOW_NAME" --arg run_id "$RUN_ID" \
+              '[{name: $name, run_id: $run_id}]')
+          fi
+
           echo "jobs_json=${jobs_json}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Format alert
         id: fmt
-        if: '!cancelled() && steps.retry.outputs.retried != ''true'''
+        if: "!cancelled() && steps.jobs.outputs.jobs_json != ''"
         uses: ./.github/actions/collect-failure-info
         with:
           jobs_json: ${{ steps.jobs.outputs.jobs_json }}
@@ -85,6 +134,7 @@ jobs:
           sha: ${{ github.event.workflow_run.head_sha }}
           actor: ${{ github.event.workflow_run.actor.login }}
           attempt: ${{ github.event.workflow_run.run_attempt }}
+          outcome: ${{ steps.jobs.outputs.outcome }}
 
   post:
     needs: [triage]

--- a/.github/workflows/ci-retry-then-alert.yml
+++ b/.github/workflows/ci-retry-then-alert.yml
@@ -1,0 +1,96 @@
+name: CI Retry and Alert
+# Alerts on failed CI runs, retrying the pure-CI entry points once first. Listens from outside the
+# run because a job cannot observe its own run's second attempt.
+
+on:
+  workflow_run:
+    workflows: ["CI Check", "Nightly Build", "Periodic Green Check"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    # Pull requests and manual dispatches have a human watching the run.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.head_branch == 'main'
+      && contains(fromJSON('["push", "schedule"]'), github.event.workflow_run.event)
+    outputs:
+      text: ${{ steps.fmt.outputs.text }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Retry once before alerting
+        id: retry
+        if: >-
+          github.event.workflow_run.run_attempt == 1
+          && contains(fromJSON('["CI Check", "Periodic Green Check"]'), github.event.workflow_run.name)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          if gh api -X POST "repos/${REPOSITORY}/actions/runs/${RUN_ID}/rerun-failed-jobs"; then
+            echo "Re-running failed jobs of ${RUN_ID}; alerting only if the retry also fails"
+            echo "retried=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not re-run ${RUN_ID} — alerting on the first attempt instead"
+            echo "retried=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      # A skipped step leaves its outputs unset, so this also covers the runs that are never retried.
+      - name: List failed jobs
+        id: jobs
+        if: '!cancelled() && steps.retry.outputs.retried != ''true'''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -uo pipefail
+          # --paginate: gh api returns an arbitrary subset without it.
+          names=$(gh api --paginate \
+            "repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${ATTEMPT}/jobs?per_page=100" \
+            --jq '.jobs[] | select(.conclusion == "failure") | .name') || {
+            echo "::warning::Could not list the failed jobs of ${RUN_ID}"
+            names=""
+          }
+
+          # A run can fail with no job reporting failure, and format_alert.py rejects an empty list.
+          if [ -z "$names" ]; then
+            names="$WORKFLOW_NAME"
+          fi
+
+          jobs_json=$(printf '%s\n' "$names" | jq -R -s -c --arg run_id "$RUN_ID" \
+            'split("\n") | map(select(length > 0)) | map({name: ., run_id: $run_id})')
+          echo "jobs_json=${jobs_json}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Format alert
+        id: fmt
+        if: '!cancelled() && steps.retry.outputs.retried != ''true'''
+        uses: ./.github/actions/collect-failure-info
+        with:
+          jobs_json: ${{ steps.jobs.outputs.jobs_json }}
+          branch: ${{ github.event.workflow_run.head_branch }}
+          server_url: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+          actor: ${{ github.event.workflow_run.actor.login }}
+          attempt: ${{ github.event.workflow_run.run_attempt }}
+
+  post:
+    needs: [triage]
+    # Empty text is how a retried run stays quiet, so the alert cannot key off triage's result.
+    if: always() && needs.triage.outputs.text != ''
+    uses: ./.github/workflows/post-alerts.yml
+    with:
+      text: ${{ needs.triage.outputs.text }}
+    secrets: inherit

--- a/.github/workflows/ci-retry-then-alert.yml
+++ b/.github/workflows/ci-retry-then-alert.yml
@@ -91,6 +91,7 @@ jobs:
 
           # One self-contained object per job, so a job that cannot be rendered drops out alone.
           objects=$(mktemp)
+          fetch_error=$(mktemp)
           logs_read=0
           while IFS=$'\t' read -r job_id job_name; do
             [ -n "$job_name" ] || continue
@@ -98,11 +99,17 @@ jobs:
             # Bounds the log reading. The most failed jobs seen in one run is 10.
             if [ -n "$job_id" ] && [ "$logs_read" -lt 15 ]; then
               logs_read=$((logs_read + 1))
-              if log=$(gh api "repos/${REPOSITORY}/actions/jobs/${job_id}/logs" 2>/dev/null); then
+              # curl, not gh: job logs carry terminal escape sequences, which gh api refuses to emit.
+              log=$(curl -sSL --fail-with-body \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "${GITHUB_API_URL}/repos/${REPOSITORY}/actions/jobs/${job_id}/logs" \
+                2>"$fetch_error") || log=""
+              if [ -n "$log" ]; then
                 tasks=$(printf '%s' "$log" | python3 .github/scripts/extract_failed_tasks.py \
                   | jq -R -s -c 'split("\n") | map(select(length > 0))') || tasks='[]'
               else
-                echo "::warning::Could not read the log of job ${job_id}"
+                echo "::warning::Could not read the log of job ${job_id}: $(tr '\n' ' ' < "$fetch_error" | tail -c 300)"
               fi
             fi
             jq -n -c --arg name "$job_name" --arg run_id "$RUN_ID" --argjson tasks "$tasks" \
@@ -110,7 +117,7 @@ jobs:
           done <<< "$failed"
 
           jobs_json=$(jq -s -c '.' "$objects") || jobs_json='[]'
-          rm -f "$objects"
+          rm -f "$objects" "$fetch_error"
 
           # Naming the workflow beats posting nothing, and format_alert.py rejects an empty list.
           if [ "$jobs_json" = "[]" ]; then

--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -7,19 +7,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      send_alerts:
-        description: "Send Slack/Discord alerts on failure"
-        required: false
-        default: false
-        type: boolean
   workflow_call:
-    inputs:
-      send_alerts:
-        description: "Send Slack/Discord alerts on failure"
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -34,66 +22,3 @@ jobs:
 
   bcv-api-check:
     uses: ./.github/workflows/bcv-api-check.yml
-
-  format-alerts:
-    needs: [build-and-test, demoapps-ci-check, bcv-api-check]
-    runs-on: ubuntu-latest
-    if: >-
-      always()
-      && (needs.build-and-test.result == 'failure'
-          || needs.demoapps-ci-check.result == 'failure'
-          || needs.bcv-api-check.result == 'failure')
-      && (github.event_name == 'push' || inputs.send_alerts == true)
-    outputs:
-      text: ${{ steps.fmt.outputs.text }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Format alert
-        id: fmt
-        env:
-          BRANCH: ${{ github.ref_name }}
-          SERVER_URL: ${{ github.server_url }}
-          REPOSITORY: ${{ github.repository }}
-          SHA: ${{ github.sha }}
-          ACTOR: ${{ github.actor }}
-          BAT_RESULT: ${{ needs.build-and-test.result }}
-          BAT_RUN_ID: ${{ needs.build-and-test.outputs.run_id }}
-          DCC_RESULT: ${{ needs.demoapps-ci-check.result }}
-          DCC_RUN_ID: ${{ needs.demoapps-ci-check.outputs.run_id }}
-          BCV_RESULT: ${{ needs.bcv-api-check.result }}
-          BCV_RUN_ID: ${{ needs.bcv-api-check.outputs.run_id }}
-        run: |
-          jobs_json='[]'
-          if [ "$BAT_RESULT" = "failure" ]; then
-            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Build and Test" --arg run_id "$BAT_RUN_ID" '. + [{"name": $name, "run_id": $run_id}]')
-          fi
-          if [ "$DCC_RESULT" = "failure" ]; then
-            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Demo App Tests" --arg run_id "$DCC_RUN_ID" '. + [{"name": $name, "run_id": $run_id}]')
-          fi
-          if [ "$BCV_RESULT" = "failure" ]; then
-            jobs_json=$(echo "$jobs_json" | jq -c --arg name "API Compatibility" --arg run_id "$BCV_RUN_ID" '. + [{"name": $name, "run_id": $run_id}]')
-          fi
-          text=$(jq -n \
-            --arg branch "$BRANCH" \
-            --arg server_url "$SERVER_URL" \
-            --arg repository "$REPOSITORY" \
-            --arg sha "$SHA" \
-            --arg actor "$ACTOR" \
-            --argjson jobs "$jobs_json" \
-            '{"branch": $branch, "server_url": $server_url, "repository": $repository, "sha": $sha, "actor": $actor, "jobs": $jobs}' | \
-            python3 .github/scripts/format_alert.py)
-          {
-            echo "text<<ALERT_EOF"
-            echo "$text"
-            echo "ALERT_EOF"
-          } >> "$GITHUB_OUTPUT"
-        shell: bash
-
-  send-alerts:
-    needs: [format-alerts]
-    if: always() && needs.format-alerts.result == 'success'
-    uses: ./.github/workflows/post-alerts.yml
-    with:
-      text: ${{ needs.format-alerts.outputs.text }}
-    secrets: inherit

--- a/.github/workflows/demoapps-nightly-check.yml
+++ b/.github/workflows/demoapps-nightly-check.yml
@@ -109,66 +109,6 @@ jobs:
       use_snapshot_repo: true
 
   # ---------------------------------------------------------------------------
-  # Alert on failure — post to Slack and Discord
-  # ---------------------------------------------------------------------------
-  format-alerts:
-    needs: [publish-snapshot, push-demoapps, wait-for-publication, check-demoapps]
-    runs-on: ubuntu-latest
-    if: >-
-      always()
-      && (needs.publish-snapshot.result == 'failure'
-          || needs.push-demoapps.result == 'failure'
-          || needs.wait-for-publication.result == 'failure'
-          || needs.check-demoapps.result == 'failure')
-    outputs:
-      text: ${{ steps.fmt.outputs.text }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Build failed-jobs list
-        id: jobs
-        env:
-          PUBLISH_RESULT: ${{ needs.publish-snapshot.result }}
-          PUSH_RESULT: ${{ needs.push-demoapps.result }}
-          WAIT_RESULT: ${{ needs.wait-for-publication.result }}
-          CHECK_RESULT: ${{ needs.check-demoapps.result }}
-        run: |
-          jobs_json='[]'
-          if [ "$PUBLISH_RESULT" = "failure" ]; then
-            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Publish Snapshot" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
-          fi
-          if [ "$PUSH_RESULT" = "failure" ]; then
-            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Push Demoapps" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
-          fi
-          if [ "$WAIT_RESULT" = "failure" ]; then
-            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Wait for Publication" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
-          fi
-          if [ "$CHECK_RESULT" = "failure" ]; then
-            jobs_json=$(echo "$jobs_json" | jq -c --arg name "Check Demoapps" --arg run_id "${{ github.run_id }}" '. + [{"name": $name, "run_id": $run_id}]')
-          fi
-          echo "jobs_json=${jobs_json}" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Format alert
-        id: fmt
-        uses: ./.github/actions/collect-failure-info
-        with:
-          jobs_json: ${{ steps.jobs.outputs.jobs_json }}
-          branch: ${{ inputs.ref }}
-          server_url: ${{ github.server_url }}
-          repository: ${{ github.repository }}
-          sha: ${{ github.sha }}
-          actor: ${{ github.actor }}
-
-  send-alerts:
-    needs: [format-alerts]
-    if: always() && needs.format-alerts.result == 'success'
-    uses: ./.github/workflows/post-alerts.yml
-    with:
-      text: ${{ needs.format-alerts.outputs.text }}
-    secrets: inherit
-
-  # ---------------------------------------------------------------------------
   # Delete temporary branches in viaduct-dev/* repos (ephemeral refs only).
   # Runs only when check-demoapps succeeded, so a failed run keeps its branches and
   # "Re-run failed jobs" can re-clone them. Stale tmp/* branches from failed or

--- a/.github/workflows/periodic-green-check.yml
+++ b/.github/workflows/periodic-green-check.yml
@@ -38,8 +38,6 @@ jobs:
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.mode == 'all' || inputs.mode == 'ci-check'))
     uses: ./.github/workflows/ci-trigger.yml
-    with:
-      send_alerts: true
     secrets: inherit
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Two defects in CI failure alerting.

- **A run that fails once and passes on re-run still alerts.** The cross-module `compileTestKotlin` failure is 17 of the last 26 first-attempt failures on `main` and has cleared on re-run every time ([example](https://github.com/airbnb/viaduct/actions/runs/32199780064)).
- **The nightly's Windows jobs never alert.** 8 of the last 12 `Nightly Build` runs failed, every one only on `Full Check (Windows, Java 17|21)` ([example](https://github.com/airbnb/viaduct/actions/runs/32105558018)). Alerting sat in `demoapps-nightly-check.yml`, gated on that workflow's own jobs.

A job cannot observe its own run's second attempt, so both need a `workflow_run` listener.

### Changed

New `ci-retry-then-alert.yml`, watching completed `CI Check`, `Nightly Build` and `Periodic Green Check` runs on `main`, for `push` and `schedule` only:

| Watched workflow | First failure | Second failure | Recovered by a retry |
|---|---|---|---|
| `CI Check`, `Periodic Green Check` | re-run failed jobs, silent | alert | notice |
| `Nightly Build` | alert | — | notice |

`Nightly Build` is not retried: its failures have been real defects, and it is the only Windows signal. Retry is bounded by `run_attempt == 1`.

**A retry that succeeds is reported rather than swallowed**, since otherwise the flake rate is invisible. `success` past attempt 1 means a retry recovered the run. Since 2026-07-01 that would have been 18 notices against 6 runs that stayed red, so roughly 2-3 messages a week.

Messages now name the failing job and its Gradle task, read from the job log by the new `extract_failed_tasks.py`:

```
before  Build and Test failed on `main` — commit `4ca5b19`
after   CI needed a retry on `main` — commit `12a1874` by viaductbot, attempt 2
        • build-and-test / Test (Java 17) ubuntu-latest
          `:core:x:javaapi:runtime:compileTestKotlin`
```

Alerting is removed from `ci-trigger.yml` and `demoapps-nightly-check.yml`, along with `ci-trigger.yml`'s now-unused `send_alerts` input. Keeping either would alert twice. `ci-watchdog.yml` is untouched, since `startup_failure` is disjoint from `failure`.

### Review notes

- `actions: write` is new to this repo. It is required by `rerun-failed-jobs` and scoped to this workflow.
- Failing safe is deliberate. A failed re-run call, an unreadable job log, or a payload that cannot be built all still post what is known. Only an already-green re-run is silent.
- Tasks are capped at 3 per job, and Gradle reports them in completion order under `--continue`, so on a run with many failures the 3 shown are arbitrary.
- Two intended reductions: a hand-dispatched run no longer alerts, and a broken `main` is reported one run later for the workflows that retry.

## How was it tested?  What documentation was provided?

- **Every message shape, against 6 real runs**, by running the collection pipeline locally: the flake as a retry-success naming `:core:x:javaapi:runtime:compileTestKotlin`, the Windows nightly's 9 tasks capped to 3, the `429` storm's 10 jobs with one task, the green-re-run guard posting nothing, and one confirming a no-task alert is byte-identical to the previous behavior.
- **The whole chain, live on a fork's default branch.** A throwaway workflow that fails its first attempt and passes its second: attempt 1 failed 12:18:06, the listener fired 12:18:08 and called `rerun-failed-jobs`, **attempt 2 was created 11 seconds later with nobody watching**, passed, and a second listener run fired 2 seconds after that and posted the retry-success notice naming both failing tasks. So `GITHUB_TOKEN` with `actions: write` can re-run a run, and a token-initiated re-run does fire a fresh `workflow_run` event — GitHub's recursion guard does not apply to it.
- **`rerun-failed-jobs` reaches jobs nested in called reusable workflows**: attempt 2 of 32199780064 lists 46 jobs against attempt 1's 48, with the failed test job re-executing for 3m02s.
- `python3 -m unittest discover -s .github/scripts/tests` — 69 tests across the two alert suites, up from 28, covering coloured and CRLF logs, duplicate and unordered tasks, invalid UTF-8, and lines where `FAILED` is not a task. `actionlint` is clean and runs shellcheck over the `run:` blocks; it does not validate `github.event.*` paths, so all 8 fields the listener reads were checked against a real run object.

That live probe is also what caught the one real defect here: `gh api` refuses to emit a job log because the log contains terminal escape sequences, so the first run of this reported its job without any task. Reading the log with `curl` fixes it, and `extract_failed_tasks.py` now strips ANSI codes. Neither the unit tests nor a local run could have found it — the installed `gh` has no such guard, only the runner's newer one does.

A `workflow_run` workflow resolves only from a repo's default branch, so this PR's CI still cannot exercise the listener. The verification above stands in for it.
