### PR TITLE
fix(ci): run Copybara on Java 25

### DIFF
--- a/.github/copydemoapps/build.gradle.kts
+++ b/.github/copydemoapps/build.gradle.kts
@@ -36,7 +36,7 @@ tasks.register<JavaExec>("runCopybara") {
     dependsOn(downloadCopybara)
 
     javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
     })
 
     // Default to repo root (two levels up from .github/copydemoapps/),

--- a/.github/workflows/push-demoapps.yml
+++ b/.github/workflows/push-demoapps.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
 
       - name: Push ${{ matrix.demoapp }} via Copybara
         env:


### PR DESCRIPTION
## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

Every nightly demoapp push has failed since 2026-08-25, and the release path would fail the same
way: `release.yml`, `e2e-snapshot-test.yml` and `demoapps-nightly-check.yml` all call
`push-demoapps.yml`.

`.github/copydemoapps` downloads `copybara_deploy.jar` from `releases/latest`, deliberately
unpinned. Copybara `v20260824` is built for Java 25, so `runCopybara` cannot load its main class
under the Java 21 pin:

```
UnsupportedClassVersionError: com/google/copybara/Main has been compiled by a more recent version
of the Java Runtime (class file version 69.0), this version of the Java Runtime only recognizes
class file versions up to 65.0
```

All five jobs in the [2026-08-25 nightly](https://github.com/airbnb/viaduct/actions/runs/32815624559)
fail identically.

This raises the runner JDK and the `runCopybara` toolchain to 25. Both are required: `setup-java`
installs the JDK that the toolchain then selects. Keeping the jar unpinned preserves the trade-off
already documented in `build.gradle.kts`, at the cost that a future Copybara JDK bump recurs as the
same two-line change. `check-published-demoapps.yml` also pins Java 21 and is unchanged — it does
not run Copybara.

## How was it tested?  What documentation was provided?
<!--- required -->

- **Copybara runs on Java 25**, observed on a runner via a `push-demoapps` dispatch of this branch
  ([run](https://github.com/geovannefduarte/viaduct/actions/runs/32874031352)): Temurin 25.0.4-7
  installed, the `runCopybara` toolchain resolved to it, and `com.google.copybara.Main` loaded and
  reported `Copybara (Version: v20260824)`. No `UnsupportedClassVersionError`. It then stops at
  `Cannot find reference(s): [gd--fix-copybara-java-25]`, because Copybara resolves refs against
  `airbnb/viaduct` and the branch exists only on the fork.
- The same jar under Java 21 reproduces the error above verbatim.
- `com/google/copybara/Main.class` in the current `releases/latest` jar has major version 69, so
  Java 25 is exactly sufficient rather than a guess at the floor.
- `actionlint` clean.

No check on this PR exercises the change: `push-demoapps.yml` is reachable only from the release,
e2e and nightly entry points, none of which run on a pull request. The dispatch above stands in for
that coverage.

<!---  Questions:
- What customer-facing flows does this change affect, and how were they tested?
- Are these changes covered by automated tests? --->
