### PR TITLE
test(gradle-plugins): resolve TestKit fixture jars from a synced repo

### DIFF
--- a/gradle-plugins/module-java/src/test/kotlin/viaduct/gradle/ViaductJavaModulePluginFunctionalTest.kt
+++ b/gradle-plugins/module-java/src/test/kotlin/viaduct/gradle/ViaductJavaModulePluginFunctionalTest.kt
@@ -1,10 +1,8 @@
 package viaduct.gradle
 
 import java.io.File
-import java.util.jar.JarFile
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -252,116 +250,6 @@ class ViaductJavaModulePluginFunctionalTest {
         )
         assertTrue(result.output.contains("CODEGEN_DEPENDS_ON_ASSEMBLY=true"), result.output)
         assertTrue(result.output.contains("JAR_EXCLUDES_RAW_DESCRIPTORS=true"), result.output)
-    }
-
-    @Test
-    fun `Java module jar packages assembled registry without raw descriptors`() {
-        writeJavaRegistryArtifactFixture()
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withPluginClasspath(combinedPluginClasspath())
-            .withArguments(":app:javaresolvers:jar")
-            .build()
-
-        assertTrue(result.output.contains("BUILD SUCCESSFUL"), result.output)
-
-        val jarFile = File(projectDir, "app/javaresolvers/build/libs/javaresolvers.jar")
-        assertTrue(jarFile.exists(), "Expected Java module JAR to be created")
-        JarFile(jarFile).use { jar ->
-            val entries = jar.entries().asSequence().map { it.name }.toList()
-            assertTrue(
-                entries.contains(
-                    "META-INF/viaduct/modules/com.example.topology.javaresolvers.json"
-                ),
-                "Expected assembled Java module registry in JAR; entries: $entries",
-            )
-            assertFalse(
-                entries.any { it.startsWith("viaduct-registry/") },
-                "Did not expect raw APT descriptors in JAR; entries: $entries",
-            )
-        }
-    }
-
-    private fun writeJavaRegistryArtifactFixture() {
-        writeJavaApplicationAndModuleFixture()
-        val publicationsDir = findOssRoot().resolve("publications")
-        File(projectDir, "settings.gradle.kts").appendText(
-            """
-
-            includeBuild("${publicationsDir.invariantSeparatorsPath}")
-            """.trimIndent()
-        )
-        File(projectDir, "gradle.properties").writeText(
-            """
-            org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g
-            org.gradle.workers.max=1
-            """.trimIndent()
-        )
-
-        File(projectDir, "app/build.gradle").appendText(
-            """
-
-            repositories {
-                mavenCentral()
-            }
-            """.trimIndent()
-        )
-        File(projectDir, "app/javaresolvers/build.gradle").appendText(
-            """
-
-            repositories {
-                mavenCentral()
-            }
-
-            dependencies {
-                implementation 'com.airbnb.viaduct:javaapi-api'
-            }
-            """.trimIndent()
-        )
-
-        val schemaDir = File(
-            projectDir,
-            "app/javaresolvers/src/main/viaduct/schema",
-        ).also { it.mkdirs() }
-        File(schemaDir, "schema.graphqls").writeText(
-            """
-            extend type Query {
-              greeting: String @resolver
-            }
-            """.trimIndent()
-        )
-
-        val resolverDir = File(
-            projectDir,
-            "app/javaresolvers/src/main/java/com/example/topology/javaresolvers",
-        ).also { it.mkdirs() }
-        File(resolverDir, "GreetingResolver.java").writeText(
-            """
-            package com.example.topology.javaresolvers;
-
-            import com.example.topology.javaresolvers.resolverbases.QueryResolvers;
-            import java.util.concurrent.CompletableFuture;
-            import viaduct.java.api.annotations.Resolver;
-
-            @Resolver
-            public final class GreetingResolver extends QueryResolvers.Greeting {
-              @Override
-              public CompletableFuture<String> resolve(Context ctx) {
-                return CompletableFuture.completedFuture("hello");
-              }
-            }
-            """.trimIndent()
-        )
-    }
-
-    private fun findOssRoot(): File {
-        return generateSequence(File(System.getProperty("user.dir")).canonicalFile) { it.parentFile }
-            .firstOrNull { candidate ->
-                File(candidate, "publications/settings.gradle.kts").exists() &&
-                    File(candidate, "gradle-plugins/settings.gradle.kts").exists()
-            }
-            ?: error("Could not locate Viaduct OSS root from ${System.getProperty("user.dir")}")
     }
 
     private fun writeJavaApplicationAndModuleFixture() {

--- a/gradle-plugins/module/build.gradle.kts
+++ b/gradle-plugins/module/build.gradle.kts
@@ -35,6 +35,33 @@ dependencies {
     testImplementation(libs.kotlin.gradle.plugin)
 }
 
+val testFixtureArtifacts: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    // Composite substitution bypasses the fat jars' POM dependency stripping, so a transitive
+    // resolve would also copy every substituted core jar into the fixture repo.
+    isTransitive = false
+}
+
+dependencies {
+    testFixtureArtifacts("com.airbnb.viaduct:api:${project.version}")
+    testFixtureArtifacts("com.airbnb.viaduct:buildtime:${project.version}")
+}
+
+val testFixtureRepoDir = layout.buildDirectory.dir("test-fixture-repo")
+
+val syncTestFixtureRepo by tasks.registering(Sync::class) {
+    from(testFixtureArtifacts)
+    into(testFixtureRepoDir)
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+}
+
+tasks.named<Test>("test") {
+    inputs.files(syncTestFixtureRepo).withPropertyName("testFixtureRepo")
+    systemProperty("viaduct.testFixtureRepo", testFixtureRepoDir.get().asFile.absolutePath)
+    systemProperty("viaduct.testFixtureVersion", project.version.toString())
+}
+
 // Include version in JAR manifest for JAR introspection and debugging
 tasks.jar {
     manifest {

--- a/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductModulePluginModuleConfigExecutionTest.kt
+++ b/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductModulePluginModuleConfigExecutionTest.kt
@@ -140,6 +140,18 @@ class ViaductModulePluginModuleConfigExecutionTest {
         assertTrue(result.output.contains("BUILD SUCCESSFUL"), "Expected build to succeed")
     }
 
+    private val fixtureRepoPath: String
+        get() = File(
+            requireNotNull(System.getProperty("viaduct.testFixtureRepo")) {
+                "viaduct.testFixtureRepo is set by the test task; run this suite through Gradle"
+            }
+        ).invariantSeparatorsPath
+
+    private val fixtureVersion: String
+        get() = requireNotNull(System.getProperty("viaduct.testFixtureVersion")) {
+            "viaduct.testFixtureVersion is set by the test task; run this suite through Gradle"
+        }
+
     private fun combinedPluginClasspath(): List<File> {
         return System.getProperty("java.class.path")
             .split(File.pathSeparator)
@@ -147,11 +159,9 @@ class ViaductModulePluginModuleConfigExecutionTest {
     }
 
     private fun writeStatefulExecutionProject() {
-        val publicationsDir = findOssRoot().resolve("publications")
         writeGradleProperties()
         File(projectDir, "settings.gradle.kts").writeViaductSettings(
             modules = mapOf(":" to "resolvers"),
-            includedBuilds = listOf(publicationsDir),
         )
         File(projectDir, "build.gradle.kts").writeText(
             """
@@ -164,10 +174,11 @@ class ViaductModulePluginModuleConfigExecutionTest {
 
             repositories {
                 mavenCentral()
+                flatDir { dirs("$fixtureRepoPath") }
             }
 
             dependencies {
-                implementation("com.airbnb.viaduct:api")
+                implementation("com.airbnb.viaduct:api:$fixtureVersion")
             }
             """.trimIndent()
         )
@@ -187,14 +198,12 @@ class ViaductModulePluginModuleConfigExecutionTest {
     }
 
     private fun writeCrossTenantLocalExecutionProject() {
-        val publicationsDir = findOssRoot().resolve("publications")
         writeGradleProperties()
         File(projectDir, "settings.gradle.kts").writeViaductSettings(
             modules = linkedMapOf(
                 ":alpha" to "alpha",
                 ":beta" to "beta",
             ),
-            includedBuilds = listOf(publicationsDir),
         )
         File(projectDir, "build.gradle.kts").writeText(
             """
@@ -205,6 +214,7 @@ class ViaductModulePluginModuleConfigExecutionTest {
 
             repositories {
                 mavenCentral()
+                flatDir { dirs("$fixtureRepoPath") }
             }
             """.trimIndent()
         )
@@ -221,10 +231,11 @@ class ViaductModulePluginModuleConfigExecutionTest {
 
                 repositories {
                     mavenCentral()
+                    flatDir { dirs("$fixtureRepoPath") }
                 }
 
                 dependencies {
-                    implementation("com.airbnb.viaduct:api")
+                    implementation("com.airbnb.viaduct:api:$fixtureVersion")
                 }
                 """.trimIndent()
             )
@@ -302,13 +313,4 @@ class ViaductModulePluginModuleConfigExecutionTest {
             override suspend fun resolve(ctx: Context) = "viaduct"
         }
         """.trimIndent()
-
-    private fun findOssRoot(): File {
-        return generateSequence(File(System.getProperty("user.dir")).canonicalFile) { it.parentFile }
-            .firstOrNull { candidate ->
-                File(candidate, "publications/settings.gradle.kts").exists() &&
-                    File(candidate, "gradle-plugins/settings.gradle.kts").exists()
-            }
-            ?: error("Could not locate Viaduct OSS root from ${System.getProperty("user.dir")}")
-    }
 }

--- a/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductSettingsTestFixtures.kt
+++ b/gradle-plugins/module/src/test/kotlin/viaduct/gradle/ViaductSettingsTestFixtures.kt
@@ -7,16 +7,10 @@ internal fun File.writeViaductSettings(
     modulePackagePrefix: String = "com.example.test",
     modules: Map<String, String>,
     plainIncludes: List<String> = emptyList(),
-    includedBuilds: List<File> = emptyList(),
 ) {
     val plainIncludeBlock = plainIncludes.joinToString("\n") { includePath ->
         """
         include("${includePath.removePrefix(":")}")
-        """.trimIndent()
-    }
-    val includedBuildBlock = includedBuilds.joinToString("\n") { includedBuild ->
-        """
-        includeBuild("${includedBuild.invariantSeparatorsPath}")
         """.trimIndent()
     }
     val moduleIncludeBlock = modules.entries.joinToString("\n\n") { (projectPath, suffix) ->
@@ -28,7 +22,6 @@ internal fun File.writeViaductSettings(
         """.trimIndent().prependIndent("    ")
     }
     val optionalPlainIncludes = plainIncludeBlock.takeIf { it.isNotBlank() }?.let { "\n$it\n" } ?: ""
-    val optionalIncludedBuilds = includedBuildBlock.takeIf { it.isNotBlank() }?.let { "\n$it\n" } ?: ""
     val optionalModuleIncludes = moduleIncludeBlock.takeIf { it.isNotBlank() }?.let { "\n\n$it" } ?: ""
 
     writeText(
@@ -38,7 +31,7 @@ internal fun File.writeViaductSettings(
         }
 
         rootProject.name = "test"
-        $optionalPlainIncludes$optionalIncludedBuilds
+        $optionalPlainIncludes
         includeViaductApplication {
             project("$applicationProjectPath")
             modulePackagePrefix("$modulePackagePrefix")$optionalModuleIncludes

--- a/gradle-plugins/settings.gradle.kts
+++ b/gradle-plugins/settings.gradle.kts
@@ -37,9 +37,10 @@ plugins {
 }
 
 // Standalone `./gradlew -p gradle-plugins ...` needs composite substitution for dependencies
-// that normally resolve because OSS root includes both `core` and `build-logic`.
+// that normally resolve because OSS root includes `core`, `build-logic`, and `publications`.
 includeBuild("../core")
 includeBuild("../build-logic")
+includeBuild("../publications")
 
 include(":common")
 include(":settings")

--- a/impldocs/gradle-build-architecture.md
+++ b/impldocs/gradle-build-architecture.md
@@ -80,6 +80,8 @@ As an included build, `publications` participates in Gradle's automatic dependen
 
 `gradle-plugins` contains the Viaduct application and module Gradle plugins used by application developers. It depends on select `core` libraries (e.g., `shared:graphql`, `shared:viaductschema`) which are resolved via composite auto-substitution during development and via Maven coordinates when published.
 
+It also includes `publications` solely so that `module`'s build can resolve the fat jars and sync them into `module/build/test-fixture-repo` for its TestKit tests. The generated fixture projects read that directory through a `flatDir` repository, so a nested TestKit daemon never owns `publications/*/build`.
+
 ## The `build-logic` Build
 
 `build-logic` is a special included build that provides precompiled script plugins (build conventions) used across all other builds. It defines conventions for Kotlin static analysis (detekt and ktlint), Java static analysis (Error Prone, NullAway, and Google Java Format), publishing, JaCoCo, and Dokka documentation. Every other `settings.gradle.kts` includes `build-logic` via `pluginManagement { includeBuild("../build-logic") }`.


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

The `module` and `module-java` TestKit fixtures resolved `com.airbnb.viaduct:api` and `buildtime` by appending `includeBuild("<oss-root>/publications")` to the generated fixture `settings.gradle.kts`. `publications/settings.gradle.kts` in turn includes `../core`, so a nested TestKit daemon could execute tasks in the live `publications/` and `core/` trees while the outer build was reading their outputs.

Deleting `publications/api/build/libs/api-2.1.0-SNAPSHOT.jar` and running `:gradle-plugins:module:test` reproduced it: the jar reappeared at **size 0** during the test, with zero `:publications:` tasks in the outer build's log — the writer was the nested daemon. That is the shape of the intermittent `Unresolved reference` / `zip END header not found` failures on `main`, e.g. https://github.com/airbnb/viaduct/actions/runs/32979252478.

`module` now resolves the fat jars through a non-transitive configuration, syncs them into `build/test-fixture-repo`, and hands the fixtures a `flatDir` repository plus the version as system properties. `gradle-plugins/settings.gradle.kts` includes `../publications` so that resolution substitutes to local source. `writeViaductSettings`'s `includedBuilds` parameter and both `findOssRoot()` helpers are gone.

`module-java` drops out entirely. Its one artifact-resolving TestKit test duplicated `PluginExecutionSmokeTest.jarShipsAssembledRegistryWithoutRawDescriptors`, which asserts the same two things plus that `classes/java/main/viaduct-registry` exists, and runs in the composite against real artifacts. `gradle-plugins/CLAUDE.md` prescribes that split, and `:java-one-project` is listed there as owning "what the module jar ships". Removing it saves 52 MB of per-build jar copying.

## How was it tested?  What documentation was provided?

`./gradlew -p gradle-plugins check --no-configuration-cache` — exit 0, including ktlint and detekt.

After deleting all four fat jars, `./gradlew :gradle-plugins:module:test :gradle-plugins:gradletestapps:java-one-project:test --rerun`: both `publications:*:shadowJar` tasks complete before the test task, and the api jar is written once during the sync phase and not touched while the tests run.