### PR TITLE
ci(build-and-test): run coverage only on schedule and dispatch

### DIFF
--- a/.github/impldocs/actions-arch.md
+++ b/.github/impldocs/actions-arch.md
@@ -42,7 +42,7 @@ An atomic workflow performs one well-defined, coherent, loosely-coupled function
 
 | Workflow | Purpose | Runs on |
 |---|---|---|
-| `build-and-test.yml` | Full build + test matrix, detekt, ktlint, coverage verification | PR, merge to main, daily schedule, manual |
+| `build-and-test.yml` | Full build + test matrix, detekt, ktlint; coverage on schedule and manual runs only | PR, merge to main, daily schedule, manual |
 | `demoapps-ci-check.yml` | Publish to Maven Local, test all demoapps against local artifacts | PR, merge to main, daily schedule, manual |
 | `bcv-api-check.yml` | Binary API compatibility check | PR, merge to main, daily schedule, manual |
 | `conventional-commit.yml` | Validate PR titles follow conventional commit format | PR, manual |
@@ -254,7 +254,6 @@ ci-trigger.yml  [orchestrator]
   |      validate-inputs --> test   (self-contained: compiles + runs tests, no build dep)
   |                     '--> build --> detekt
   |                                --> ktlint
-  |                                --> coverage-verification
   |
   |--- demoapps-ci-check.yml  [atomic]
   |      validate-inputs --> publish-to-maven-local --> test-starters
@@ -289,7 +288,7 @@ periodic-green-check.yml  [orchestrator]
   |      v
   |    ci-trigger.yml  [orchestrator]
   |      |
-  |      |--- build-and-test.yml  [atomic]
+  |      |--- build-and-test.yml  [atomic]   (adds coverage-reports --> coverage-summary)
   |      |--- demoapps-ci-check.yml  [atomic]
   |      '--- bcv-api-check.yml  [atomic]
   |

--- a/.github/impldocs/actions-arch.md
+++ b/.github/impldocs/actions-arch.md
@@ -355,7 +355,7 @@ manual dispatch / workflow_call
   v
 ci-trigger.yml  [orchestrator]
   |
-  |--- build-and-test.yml  [atomic]
+  |--- build-and-test.yml  [atomic]   (adds coverage-reports --> coverage-summary)
   |--- demoapps-ci-check.yml  [atomic]
   '--- bcv-api-check.yml  [atomic]
 

--- a/.github/impldocs/release-runbook.md
+++ b/.github/impldocs/release-runbook.md
@@ -235,7 +235,6 @@ gh run list --workflow=ci-trigger.yml --repo airbnb/viaduct --limit 5
 This runs three sub-workflows:
 
 1. **build-and-test** — compiles and runs all unit tests, plus the coverage reports and summary
-   (those run on `schedule` and `workflow_dispatch` only, so a dispatch reaches them)
 2. **demoapps-ci-check** — tests all demo apps against locally-published artifacts (Java 17 + 21)
 3. **bcv-api-check** — binary API compatibility check
 

--- a/.github/impldocs/release-runbook.md
+++ b/.github/impldocs/release-runbook.md
@@ -234,7 +234,8 @@ gh run list --workflow=ci-trigger.yml --repo airbnb/viaduct --limit 5
 
 This runs three sub-workflows:
 
-1. **build-and-test** — compiles and runs all unit tests
+1. **build-and-test** — compiles and runs all unit tests, plus the coverage reports and summary
+   (those run on `schedule` and `workflow_dispatch` only, so a dispatch reaches them)
 2. **demoapps-ci-check** — tests all demo apps against locally-published artifacts (Java 17 + 21)
 3. **bcv-api-check** — binary API compatibility check
 

--- a/.github/scripts/format_coverage_summary.py
+++ b/.github/scripts/format_coverage_summary.py
@@ -14,7 +14,7 @@ Output has two sections:
 
 Exit codes:
   0 - success
-  1 - invalid arguments or no reports found
+  1 - invalid arguments
 """
 
 import os
@@ -85,8 +85,12 @@ def format_table(rows):
 
 def format_summary(scan_dirs):
     all_modules = []
+    dirs_without_reports = []
     for d in scan_dirs:
-        all_modules.extend(find_module_reports(d))
+        found = find_module_reports(d)
+        if not found:
+            dirs_without_reports.append(os.path.basename(os.path.normpath(d)))
+        all_modules.extend(found)
 
     if not all_modules:
         return "⚠️ No per-module coverage reports found."
@@ -100,6 +104,11 @@ def format_summary(scan_dirs):
     all_rows = sorted(rows, key=lambda r: r[0])
 
     lines = []
+    if dirs_without_reports:
+        missing = ", ".join(dirs_without_reports)
+        lines.append(f"⚠️ No coverage reports found for: {missing}")
+        lines.append("")
+
     if key_rows:
         lines.append("### Key Module Coverage")
         lines.append("")

--- a/.github/scripts/tests/test_format_coverage_summary.py
+++ b/.github/scripts/tests/test_format_coverage_summary.py
@@ -146,7 +146,7 @@ class TestFormatSummary(unittest.TestCase):
         self.assertIn("<details>", result)
 
     def test_names_dirs_without_reports(self):
-        empty_dir = os.path.join(tempfile.mkdtemp(), "gradle-plugins")
+        empty_dir = os.path.join(self.tmpdir, "gradle-plugins")
         os.makedirs(empty_dir)
         result = format_summary([self.core_dir, empty_dir])
         self.assertIn("⚠️ No coverage reports found for: gradle-plugins", result)
@@ -155,6 +155,12 @@ class TestFormatSummary(unittest.TestCase):
     def test_no_warning_when_all_dirs_have_reports(self):
         result = format_summary([self.core_dir])
         self.assertNotIn("No coverage reports found for", result)
+
+    def test_warns_when_no_dirs_have_reports(self):
+        empty_dir = os.path.join(self.tmpdir, "empty")
+        os.makedirs(empty_dir)
+        result = format_summary([empty_dir])
+        self.assertEqual(result, "⚠️ No per-module coverage reports found.")
 
     def test_all_table_sorted_alphabetically(self):
         result = format_summary([self.core_dir])

--- a/.github/scripts/tests/test_format_coverage_summary.py
+++ b/.github/scripts/tests/test_format_coverage_summary.py
@@ -145,6 +145,17 @@ class TestFormatSummary(unittest.TestCase):
         self.assertNotIn("Key Module Coverage", result)
         self.assertIn("<details>", result)
 
+    def test_names_dirs_without_reports(self):
+        empty_dir = os.path.join(tempfile.mkdtemp(), "gradle-plugins")
+        os.makedirs(empty_dir)
+        result = format_summary([self.core_dir, empty_dir])
+        self.assertIn("⚠️ No coverage reports found for: gradle-plugins", result)
+        self.assertIn("Key Module Coverage", result)
+
+    def test_no_warning_when_all_dirs_have_reports(self):
+        result = format_summary([self.core_dir])
+        self.assertNotIn("No coverage reports found for", result)
+
     def test_all_table_sorted_alphabetically(self):
         result = format_summary([self.core_dir])
         details_start = result.index("<details>")

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -215,6 +215,7 @@ jobs:
         shell: bash
 
   coverage-reports:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       # Independent per-project runs; an infra failure in one shouldn't cancel the others.
@@ -296,16 +297,19 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: coverage-core
           path: core
 
       - uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: coverage-build-logic
           path: build-logic
 
       - uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: coverage-gradle-plugins
           path: gradle-plugins


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

`Coverage Summary` was the only failing job in three otherwise-green `main` runs — [32810149792](https://github.com/airbnb/viaduct/actions/runs/32810149792), [32311746606](https://github.com/airbnb/viaduct/actions/runs/32311746606), [30778351585](https://github.com/airbnb/viaduct/actions/runs/30778351585) — each on a `download-artifact` step, for a report that was never produced.

The cause is upstream and masked. `jacocoTestReport` could not resolve `org.jacoco:org.jacoco.ant:0.8.12` from Maven Central (`403` once, `429` twice). The `|| { echo "::warning::…" }` wrapper kept `Coverage (<module>)` green, `upload-artifact` found nothing to upload, and `coverage-summary` then passed its `needs.coverage-reports.result == 'success'` gate and hard-failed on the missing artifact. The job that fails is not the job that broke.

Coverage also gates nothing today: `testCodeCoverageVerification` sits behind the same `|| { warning }` with a literal `TODO`, and the summary only writes `$GITHUB_STEP_SUMMARY`. It costs 29–33 job-minutes on every push and every pull request.

- `coverage-reports` now runs only on `schedule` and `workflow_dispatch`. The daily 2pm UTC run reaches it through `periodic-green-check.yml` → `ci-trigger.yml`, so no new trigger is needed, and `coverage-summary` needs no gate of its own — a skipped `coverage-reports` yields `result == 'skipped'`, which its existing `if` rejects.
- The three downloads in `coverage-summary` are `continue-on-error: true`, so a missing report degrades the summary instead of failing the run.
- `format_coverage_summary.py` names any module directory that yielded no reports. Without it, losing `coverage-core` silently drops the entire "Key Module Coverage" section — which is what the first download failing meant in two of the three runs above.

The `::warning::` masking stays. Every observed cause was Maven Central rejecting the same POM, and unmasking would turn a rate-limit into a red `main`.

## How was it tested?  What documentation was provided?

- Push/PR path: [33114369738](https://github.com/airbnb/viaduct/actions/runs/33114369738) — coverage jobs `skipped`, all six `Build` jobs green.
- Schedule/dispatch path: [33116742359](https://github.com/geovannefduarte/viaduct/actions/runs/33116742359) — coverage runs with the gate in place, through a `workflow_call`.
- `python3 -m unittest discover -s .github/scripts/tests` — 16 tests in `test_format_coverage_summary.py`, including the two new cases.
- Simulating the observed failure (no `core` reports, `build-logic` and `gradle-plugins` present) prints `⚠️ No coverage reports found for: core` and exits 0. The same input on the previous script prints the two tables with no mention of `core`.
- No branch ruleset requires these checks, so skipping cannot block a merge.
- Docs: `actions-arch.md` — coverage removed from the push/PR diagram, added to the schedule and dispatch diagrams. `release-runbook.md` — step 4's dispatch also runs coverage.