### PR TITLE
ci(release): derive the artifact probe list from the build

### DIFF
--- a/.github/impldocs/release-runbook.md
+++ b/.github/impldocs/release-runbook.md
@@ -516,14 +516,19 @@ If `release.yml` fails after some artifacts are published (e.g., Plugin Portal s
 
 If `release.yml` fails during an RC publication after publishing `${RELEASE_VER}-${RC_VER}`, do not reuse that RC version. Fix the issue, increment to the next RC version, and rerun the workflow.
 
+### `Derive the published coordinates` fails
+
+This step runs in `publish` before anything is pushed, so Maven Central and the Plugin Portal are untouched and no cleanup is needed. Either a build configuration failure, or `if-no-files-found: error` on a derivation that produced nothing. Reproduce with `./gradlew writePublishedCoordinates` at the release SHA.
+
+A release branch cut before this step existed does not carry the task. Cherry-pick it onto the branch before releasing from it.
+
 ### `wait-for-new-artifacts` fails
 
 Artifacts are already on Maven Central, but no tag or GitHub release exists yet. See [Publication fails partway through](#publication-fails-partway-through) before re-running.
 
 - **`not visible after 30m of polling`** — the error names each missing `.pom` URL and its last HTTP status. A `429` or `503` means retry. A persistent `404` means that coordinate is not on the CDN: either the derivation lists something the release does not publish, or the publication dropped it.
-- **`no coordinates found` / `no '<repository>' coordinates found`** — `writePublishedCoordinates` produced nothing usable, so the job refuses to pass without probing. Either a project stopped applying `conventions.viaduct-publishing`, or the orchestration wiring broke.
-- **`coordinates carry version X, expected Y`** — the published `VERSION` disagrees with the version being probed. An `rc_ver` input that does not match the RC number in `VERSION` produces this.
-- **the `Derive the published coordinates` step fails** — a build configuration failure, not a propagation problem. Reproduce with `./gradlew writePublishedCoordinates` at the release SHA.
+- **`no coordinates found` / `no '<repository>' coordinates found`** — the `published-coordinates` artifact arrived with nothing the probe could use. The derivation itself runs in `publish`, so this points at the artifact hand-off rather than at the Gradle task.
+- **`coordinates carry version X, expected Y`** — the published `VERSION` disagrees with the version being probed. Reaching this means the `validate` job's version check was bypassed, since it catches the same mismatch before publication.
 
 ### Demo app tests fail after push
 

--- a/.github/impldocs/release-runbook.md
+++ b/.github/impldocs/release-runbook.md
@@ -468,6 +468,7 @@ packaged JVM — so this also exercises the packaged-distribution path.
 | `confirmDemoAppVersions` | Validates demo app versions match VERSION (fails on mismatch) |
 | `bumpSnapshotVersion` | Inserts/replaces `-rc.XXXX` in a SNAPSHOT version, syncs demo apps |
 | `unbumpSnapshotVersion` | Removes the `-rc.XXXX` marker from a SNAPSHOT version, syncs demo apps |
+| `writePublishedCoordinates` | Records every published coordinate to `<module>/build/reports/publication/coordinates.txt`; `release.yml` probes these for CDN visibility |
 
 `bumpSnapshotVersion` / `unbumpSnapshotVersion` are only for ephemeral SNAPSHOT publication testing. Public release candidates use explicit versions like `X.Y.Z-rc.N`.
 
@@ -514,6 +515,14 @@ If `release.yml` fails after some artifacts are published (e.g., Plugin Portal s
 ### RC publication fails partway through
 
 If `release.yml` fails during an RC publication after publishing `${RELEASE_VER}-${RC_VER}`, do not reuse that RC version. Fix the issue, increment to the next RC version, and rerun the workflow.
+
+### `wait-for-new-artifacts` fails
+
+Artifacts are already on Maven Central, but no tag or GitHub release exists yet. Re-running the workflow is safe — publication is idempotent and tagging has not happened.
+
+- **`not visible after 30m of polling`** — CDN propagation. The error names each missing `.pom` URL and its last HTTP status. A `429` or `503` means retry; a persistent `404` means the coordinate is not published and the derivation is wrong.
+- **`no coordinates found` / `no '<repository>' coordinates found`** — `writePublishedCoordinates` produced nothing usable, so the job refuses to pass without probing. Either a project stopped applying `conventions.viaduct-publishing`, or the orchestration wiring broke.
+- **`coordinates carry version X, expected Y`** — the checked-out `VERSION` disagrees with the version being released.
 
 ### Demo app tests fail after push
 

--- a/.github/impldocs/release-runbook.md
+++ b/.github/impldocs/release-runbook.md
@@ -518,11 +518,12 @@ If `release.yml` fails during an RC publication after publishing `${RELEASE_VER}
 
 ### `wait-for-new-artifacts` fails
 
-Artifacts are already on Maven Central, but no tag or GitHub release exists yet. Re-running the workflow is safe — publication is idempotent and tagging has not happened.
+Artifacts are already on Maven Central, but no tag or GitHub release exists yet. See [Publication fails partway through](#publication-fails-partway-through) before re-running.
 
-- **`not visible after 30m of polling`** — CDN propagation. The error names each missing `.pom` URL and its last HTTP status. A `429` or `503` means retry; a persistent `404` means the coordinate is not published and the derivation is wrong.
+- **`not visible after 30m of polling`** — the error names each missing `.pom` URL and its last HTTP status. A `429` or `503` means retry. A persistent `404` means that coordinate is not on the CDN: either the derivation lists something the release does not publish, or the publication dropped it.
 - **`no coordinates found` / `no '<repository>' coordinates found`** — `writePublishedCoordinates` produced nothing usable, so the job refuses to pass without probing. Either a project stopped applying `conventions.viaduct-publishing`, or the orchestration wiring broke.
-- **`coordinates carry version X, expected Y`** — the checked-out `VERSION` disagrees with the version being released.
+- **`coordinates carry version X, expected Y`** — the published `VERSION` disagrees with the version being probed. An `rc_ver` input that does not match the RC number in `VERSION` produces this.
+- **the `Derive the published coordinates` step fails** — a build configuration failure, not a propagation problem. Reproduce with `./gradlew writePublishedCoordinates` at the release SHA.
 
 ### Demo app tests fail after push
 

--- a/.github/impldocs/release-runbook.md
+++ b/.github/impldocs/release-runbook.md
@@ -528,7 +528,7 @@ Artifacts are already on Maven Central, but no tag or GitHub release exists yet.
 
 - **`not visible after 30m of polling`** — the error names each missing `.pom` URL and its last HTTP status. A `429` or `503` means retry. A persistent `404` means that coordinate is not on the CDN: either the derivation lists something the release does not publish, or the publication dropped it.
 - **`no coordinates found` / `no '<repository>' coordinates found`** — the `published-coordinates` artifact arrived with nothing the probe could use. The derivation itself runs in `publish`, so this points at the artifact hand-off rather than at the Gradle task.
-- **`coordinates carry version X, expected Y`** — the published `VERSION` disagrees with the version being probed. Reaching this means the `validate` job's version check was bypassed, since it catches the same mismatch before publication.
+- **`coordinates carry version X, expected Y`** — the published `VERSION` disagrees with the version being probed. `validate` catches an `rc_ver` mismatch before publication, so reaching this points at the release branch moving between `validate` and `publish` rather than at a bad `rc_ver`. Check the branch's history for a push mid-release.
 
 ### Demo app tests fail after push
 

--- a/.github/scripts/probe_published_artifacts.py
+++ b/.github/scripts/probe_published_artifacts.py
@@ -145,8 +145,7 @@ def probe(
 ):
     """Poll every URL until all are visible or the shared deadline passes.
 
-    Returns each still-missing URL with the last status seen for it. One deadline
-    covers every URL, so the worst case does not grow with the artifact count.
+    Returns each still-missing URL with the last status seen for it.
     """
     deadline = now() + timeout_seconds
     pending = list(urls)

--- a/.github/scripts/probe_published_artifacts.py
+++ b/.github/scripts/probe_published_artifacts.py
@@ -15,6 +15,7 @@ Exit codes:
 
 import argparse
 import collections
+import http.client
 import os
 import sys
 import time
@@ -90,7 +91,8 @@ def read_coordinates(paths):
 def find_problems(coordinates, expected_version):
     """Reasons the derived list cannot be trusted as a release gate.
 
-    An empty or partial list would let the job pass without probing anything.
+    An empty list, or one missing a whole repository, would let the job pass
+    without probing what it was meant to probe.
     """
     problems = []
     if not coordinates:
@@ -129,7 +131,7 @@ def http_status(url):
             return response.status
     except urllib.error.HTTPError as error:
         return error.code
-    except OSError:
+    except (OSError, http.client.HTTPException):
         return 0
 
 
@@ -190,8 +192,9 @@ def main(argv=None, fetch=http_status):
     )
     args = parser.parse_args(argv)
 
+    paths = find_coordinate_files(args.root)
     try:
-        coordinates = read_coordinates(find_coordinate_files(args.root))
+        coordinates = read_coordinates(paths)
     except ValueError as error:
         print(f"::error::malformed coordinate file: {error}")
         return 1
@@ -202,8 +205,17 @@ def main(argv=None, fetch=http_status):
             print(f"::error::{problem}")
         return 1
 
+    # Logged so a release can be diffed against a known-good run.
+    counts = collections.Counter(c.repository for c in coordinates)
+    breakdown = ", ".join(f"{counts[name]} {name}" for name in sorted(counts))
+    print(
+        f"Derived {len(coordinates)} coordinates for {args.version} from"
+        f" {len(paths)} projects ({breakdown})"
+    )
+    for path in paths:
+        print(f"  {path}")
+
     urls = [pom_url(coordinate) for coordinate in coordinates]
-    print(f"Probing {len(urls)} artifacts for {args.version}")
     missing = probe(
         urls, args.timeout_seconds, args.sleep_seconds, fetch=fetch
     )

--- a/.github/scripts/probe_published_artifacts.py
+++ b/.github/scripts/probe_published_artifacts.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Waits for a release's published artifacts to become visible on their CDNs.
+
+Reads the coordinate files written by the `writePublishedCoordinates` Gradle
+task, derives one `.pom` URL per coordinate, and polls every URL that is not yet
+visible until a single global deadline expires. Deriving the list from the build
+keeps it from drifting away from what the release actually published.
+
+Usage: probe_published_artifacts.py --version 2.0.0 [--root .]
+
+Exit codes:
+  0 - every derived artifact is visible
+  1 - the derived list is unusable, or artifacts are missing at the deadline
+"""
+
+import argparse
+import collections
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+COORDINATE_DIR = "build/reports/publication"
+COORDINATE_FILE_NAME = "coordinates.txt"
+
+REPOSITORY_BASES = {
+    "central": "https://repo.maven.apache.org/maven2",
+    "portal": "https://plugins.gradle.org/m2",
+}
+
+DEFAULT_TIMEOUT_SECONDS = 1800
+DEFAULT_SLEEP_SECONDS = 30
+
+Coordinate = collections.namedtuple(
+    "Coordinate", ["repository", "group", "artifact", "version"]
+)
+
+
+def find_coordinate_files(root):
+    """Find every coordinates.txt the Gradle task wrote under root."""
+    found = []
+    for dirpath, _, filenames in os.walk(root):
+        if COORDINATE_FILE_NAME not in filenames:
+            continue
+        if not dirpath.replace("\\", "/").endswith(COORDINATE_DIR):
+            continue
+        found.append(os.path.join(dirpath, COORDINATE_FILE_NAME))
+    return sorted(found)
+
+
+def parse_coordinates(text):
+    coordinates = []
+    for number, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) != 2:
+            raise ValueError(
+                f"line {number}: expected '<repository> <group>:<artifact>:"
+                f"<version>', got {line!r}"
+            )
+        repository, gav = fields
+        if repository not in REPOSITORY_BASES:
+            raise ValueError(
+                f"line {number}: unknown repository {repository!r}; expected one"
+                f" of {', '.join(sorted(REPOSITORY_BASES))}"
+            )
+        parts = gav.split(":")
+        if len(parts) != 3 or not all(parts):
+            raise ValueError(
+                f"line {number}: expected '<group>:<artifact>:<version>', got"
+                f" {gav!r}"
+            )
+        coordinates.append(Coordinate(repository, *parts))
+    return coordinates
+
+
+def read_coordinates(paths):
+    seen = []
+    for path in paths:
+        with open(path, encoding="utf-8") as handle:
+            for coordinate in parse_coordinates(handle.read()):
+                if coordinate not in seen:
+                    seen.append(coordinate)
+    return seen
+
+
+def find_problems(coordinates, expected_version):
+    """Reasons the derived list cannot be trusted as a release gate.
+
+    An empty or partial list would let the job pass without probing anything.
+    """
+    problems = []
+    if not coordinates:
+        problems.append(
+            "no coordinates found; writePublishedCoordinates produced nothing"
+        )
+        return problems
+    repositories = {coordinate.repository for coordinate in coordinates}
+    for required in sorted(REPOSITORY_BASES):
+        if required not in repositories:
+            problems.append(f"no '{required}' coordinates found")
+    unexpected = sorted(
+        {c.version for c in coordinates if c.version != expected_version}
+    )
+    if unexpected:
+        problems.append(
+            f"coordinates carry version {', '.join(unexpected)}, expected"
+            f" {expected_version}"
+        )
+    return problems
+
+
+def pom_url(coordinate):
+    base = REPOSITORY_BASES[coordinate.repository]
+    group_path = coordinate.group.replace(".", "/")
+    file_name = f"{coordinate.artifact}-{coordinate.version}.pom"
+    return (
+        f"{base}/{group_path}/{coordinate.artifact}/{coordinate.version}/"
+        f"{file_name}"
+    )
+
+
+def http_status(url):
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            return response.status
+    except urllib.error.HTTPError as error:
+        return error.code
+    except OSError:
+        return 0
+
+
+def probe(
+    urls,
+    timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+    sleep_seconds=DEFAULT_SLEEP_SECONDS,
+    fetch=http_status,
+    now=time.monotonic,
+    sleep=time.sleep,
+):
+    """Poll every URL until all are visible or the shared deadline passes.
+
+    Returns each still-missing URL with the last status seen for it. One deadline
+    covers every URL, so the worst case does not grow with the artifact count.
+    """
+    deadline = now() + timeout_seconds
+    pending = list(urls)
+    last_status = {}
+    attempt = 0
+    while True:
+        attempt += 1
+        still_pending = []
+        for url in pending:
+            status = fetch(url)
+            last_status[url] = status
+            if status == 200:
+                print(f"  ✅ {url}")
+            else:
+                print(f"  ⏳ HTTP {status} {url}")
+                still_pending.append(url)
+        pending = still_pending
+        if not pending:
+            return []
+        remaining = deadline - now()
+        if remaining <= 0:
+            return [(url, last_status[url]) for url in pending]
+        print(
+            f"  {len(pending)} of {len(urls)} still missing (attempt"
+            f" {attempt}) — sleeping {sleep_seconds}s"
+        )
+        sleep(min(sleep_seconds, remaining))
+
+
+def main(argv=None, fetch=http_status):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--version", required=True, help="version the release published"
+    )
+    parser.add_argument(
+        "--root", default=".", help="directory to scan for coordinate files"
+    )
+    parser.add_argument(
+        "--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS
+    )
+    parser.add_argument(
+        "--sleep-seconds", type=int, default=DEFAULT_SLEEP_SECONDS
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        coordinates = read_coordinates(find_coordinate_files(args.root))
+    except ValueError as error:
+        print(f"::error::malformed coordinate file: {error}")
+        return 1
+
+    problems = find_problems(coordinates, args.version)
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}")
+        return 1
+
+    urls = [pom_url(coordinate) for coordinate in coordinates]
+    print(f"Probing {len(urls)} artifacts for {args.version}")
+    missing = probe(
+        urls, args.timeout_seconds, args.sleep_seconds, fetch=fetch
+    )
+    if missing:
+        minutes = args.timeout_seconds // 60
+        for url, status in missing:
+            print(
+                f"::error::not visible after {minutes}m of polling (last status"
+                f" HTTP {status}): {url}"
+            )
+        return 1
+    print(f"✅ all {len(urls)} artifacts are visible")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_probe_published_artifacts.py
+++ b/.github/scripts/tests/test_probe_published_artifacts.py
@@ -1,0 +1,290 @@
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from probe_published_artifacts import (
+    Coordinate,
+    find_coordinate_files,
+    find_problems,
+    main,
+    parse_coordinates,
+    pom_url,
+    probe,
+    read_coordinates,
+)
+
+CENTRAL = "central com.airbnb.viaduct:api:2.0.0"
+PORTAL = (
+    "portal com.airbnb.viaduct.application-gradle-plugin:"
+    "com.airbnb.viaduct.application-gradle-plugin.gradle.plugin:2.0.0"
+)
+
+
+def write_coordinate_file(root, project, *lines):
+    directory = os.path.join(root, project, "build/reports/publication")
+    os.makedirs(directory)
+    path = os.path.join(directory, "coordinates.txt")
+    with open(path, "w") as handle:
+        handle.write("\n".join(lines) + "\n")
+    return path
+
+
+class TestParseCoordinates(unittest.TestCase):
+
+    def test_parses_central(self):
+        self.assertEqual(
+            parse_coordinates(CENTRAL),
+            [Coordinate("central", "com.airbnb.viaduct", "api", "2.0.0")],
+        )
+
+    def test_parses_portal_marker(self):
+        marker = parse_coordinates(PORTAL)[0]
+        self.assertEqual(marker.repository, "portal")
+        self.assertEqual(marker.group, "com.airbnb.viaduct.application-gradle-plugin")
+        self.assertTrue(marker.artifact.endswith(".gradle.plugin"))
+
+    def test_skips_blank_lines(self):
+        self.assertEqual(len(parse_coordinates(f"\n{CENTRAL}\n\n")), 1)
+
+    def test_rejects_unknown_repository(self):
+        with self.assertRaises(ValueError) as caught:
+            parse_coordinates("jcenter com.airbnb.viaduct:api:2.0.0")
+        self.assertIn("unknown repository", str(caught.exception))
+
+    def test_rejects_missing_version(self):
+        with self.assertRaises(ValueError) as caught:
+            parse_coordinates("central com.airbnb.viaduct:api")
+        self.assertIn("<group>:<artifact>:<version>", str(caught.exception))
+
+    def test_rejects_empty_gav_segment(self):
+        with self.assertRaises(ValueError):
+            parse_coordinates("central com.airbnb.viaduct::2.0.0")
+
+    def test_rejects_extra_fields(self):
+        with self.assertRaises(ValueError):
+            parse_coordinates("central com.airbnb.viaduct:api:2.0.0 extra")
+
+
+class TestPomUrl(unittest.TestCase):
+
+    def test_central_url(self):
+        coordinate = Coordinate("central", "com.airbnb.viaduct.service", "api", "2.0.0")
+        self.assertEqual(
+            pom_url(coordinate),
+            "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/service/api/"
+            "2.0.0/api-2.0.0.pom",
+        )
+
+    def test_portal_url(self):
+        self.assertEqual(
+            pom_url(parse_coordinates(PORTAL)[0]),
+            "https://plugins.gradle.org/m2/com/airbnb/viaduct/"
+            "application-gradle-plugin/"
+            "com.airbnb.viaduct.application-gradle-plugin.gradle.plugin/2.0.0/"
+            "com.airbnb.viaduct.application-gradle-plugin.gradle.plugin-2.0.0.pom",
+        )
+
+
+class TestFindCoordinateFiles(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_finds_files_across_nested_projects(self):
+        write_coordinate_file(self.tmpdir, "publications/api", CENTRAL)
+        write_coordinate_file(self.tmpdir, "core/x/javaapi/registry-apt", CENTRAL)
+        found = find_coordinate_files(self.tmpdir)
+        self.assertEqual(len(found), 2)
+
+    def test_ignores_coordinates_outside_the_report_dir(self):
+        stray = os.path.join(self.tmpdir, "build")
+        os.makedirs(stray)
+        with open(os.path.join(stray, "coordinates.txt"), "w") as handle:
+            handle.write(CENTRAL + "\n")
+        self.assertEqual(find_coordinate_files(self.tmpdir), [])
+
+    def test_returns_empty_when_nothing_was_written(self):
+        self.assertEqual(find_coordinate_files(self.tmpdir), [])
+
+
+class TestReadCoordinates(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_collects_across_files(self):
+        write_coordinate_file(self.tmpdir, "publications/api", CENTRAL)
+        write_coordinate_file(self.tmpdir, "gradle-plugins/application", PORTAL)
+        coordinates = read_coordinates(find_coordinate_files(self.tmpdir))
+        self.assertEqual({c.repository for c in coordinates}, {"central", "portal"})
+
+    def test_drops_duplicates(self):
+        write_coordinate_file(self.tmpdir, "one", CENTRAL)
+        write_coordinate_file(self.tmpdir, "two", CENTRAL)
+        self.assertEqual(len(read_coordinates(find_coordinate_files(self.tmpdir))), 1)
+
+    def test_reads_multiple_lines_from_one_file(self):
+        write_coordinate_file(self.tmpdir, "gradle-plugins/application", CENTRAL, PORTAL)
+        self.assertEqual(len(read_coordinates(find_coordinate_files(self.tmpdir))), 2)
+
+
+class TestFindProblems(unittest.TestCase):
+
+    def all_coordinates(self):
+        return parse_coordinates(f"{CENTRAL}\n{PORTAL}")
+
+    def test_no_problems_when_both_repositories_present(self):
+        self.assertEqual(find_problems(self.all_coordinates(), "2.0.0"), [])
+
+    def test_empty_list_is_a_problem(self):
+        problems = find_problems([], "2.0.0")
+        self.assertEqual(len(problems), 1)
+        self.assertIn("produced nothing", problems[0])
+
+    def test_missing_portal_is_a_problem(self):
+        problems = find_problems(parse_coordinates(CENTRAL), "2.0.0")
+        self.assertIn("no 'portal' coordinates found", problems)
+
+    def test_missing_central_is_a_problem(self):
+        problems = find_problems(parse_coordinates(PORTAL), "2.0.0")
+        self.assertIn("no 'central' coordinates found", problems)
+
+    def test_version_mismatch_is_a_problem(self):
+        problems = find_problems(self.all_coordinates(), "2.1.0")
+        self.assertEqual(len(problems), 1)
+        self.assertIn("expected 2.1.0", problems[0])
+
+
+class FakeClock:
+    """A clock that only advances when the code under test sleeps."""
+
+    def __init__(self):
+        self.elapsed = 0.0
+        self.slept = []
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.elapsed += seconds
+
+
+class TestProbe(unittest.TestCase):
+
+    def setUp(self):
+        self.clock = FakeClock()
+
+    def run_probe(self, urls, fetch, **kwargs):
+        return probe(
+            urls,
+            fetch=fetch,
+            now=lambda: self.clock.elapsed,
+            sleep=self.clock.sleep,
+            **kwargs,
+        )
+
+    def test_returns_empty_when_all_visible(self):
+        self.assertEqual(self.run_probe(["a", "b"], lambda url: 200), [])
+        self.assertEqual(self.clock.slept, [])
+
+    def test_reports_every_missing_url_not_just_the_first(self):
+        missing = self.run_probe(
+            ["a", "b", "c"],
+            lambda url: 200 if url == "b" else 404,
+            timeout_seconds=0,
+        )
+        self.assertEqual([url for url, _ in missing], ["a", "c"])
+
+    def test_reports_the_last_status_seen(self):
+        missing = self.run_probe(["a", "b"], {"a": 429, "b": 503}.get, timeout_seconds=0)
+        self.assertEqual(missing, [("a", 429), ("b", 503)])
+
+    def test_reports_zero_when_the_request_never_reached_a_server(self):
+        missing = self.run_probe(["a"], lambda url: 0, timeout_seconds=0)
+        self.assertEqual(missing, [("a", 0)])
+
+    def test_stops_polling_a_url_once_it_appears(self):
+        seen = []
+        failures = {"b": 1}
+
+        def fetch(url):
+            seen.append(url)
+            if failures.get(url, 0) > 0:
+                failures[url] -= 1
+                return 404
+            return 200
+
+        self.assertEqual(
+            self.run_probe(["a", "b"], fetch, timeout_seconds=100), []
+        )
+        self.assertEqual(seen, ["a", "b", "b"])
+
+    def test_deadline_is_global_not_per_url(self):
+        urls = [f"url-{number}" for number in range(20)]
+        missing = self.run_probe(
+            urls, lambda url: 404, timeout_seconds=60, sleep_seconds=30
+        )
+        self.assertEqual([url for url, _ in missing], urls)
+        self.assertLessEqual(self.clock.elapsed, 60)
+
+    def test_final_sleep_does_not_overshoot_the_deadline(self):
+        self.run_probe(
+            ["a"], lambda url: 404, timeout_seconds=10, sleep_seconds=30
+        )
+        self.assertEqual(self.clock.slept, [10])
+
+
+class TestMain(unittest.TestCase):
+    """Covers the exit codes and ::error:: output that release.yml depends on."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def run_main(self, version, fetch=lambda url: 200):
+        with contextlib.redirect_stdout(io.StringIO()) as captured:
+            code = main(
+                ["--version", version, "--root", self.tmpdir, "--timeout-seconds", "0"],
+                fetch=fetch,
+            )
+        return code, captured.getvalue()
+
+    def test_succeeds_when_every_artifact_is_visible(self):
+        write_coordinate_file(self.tmpdir, "publications/api", CENTRAL, PORTAL)
+        code, output = self.run_main("2.0.0")
+        self.assertEqual(code, 0)
+        self.assertIn("all 2 artifacts are visible", output)
+
+    def test_fails_when_nothing_was_derived(self):
+        code, output = self.run_main("2.0.0")
+        self.assertEqual(code, 1)
+        self.assertIn("::error::no coordinates found", output)
+
+    def test_fails_on_a_malformed_coordinate_file(self):
+        write_coordinate_file(self.tmpdir, "publications/api", "central nonsense")
+        code, output = self.run_main("2.0.0")
+        self.assertEqual(code, 1)
+        self.assertIn("::error::malformed coordinate file", output)
+
+    def test_fails_on_a_version_mismatch(self):
+        write_coordinate_file(self.tmpdir, "publications/api", CENTRAL, PORTAL)
+        code, output = self.run_main("2.1.0")
+        self.assertEqual(code, 1)
+        self.assertIn("expected 2.1.0", output)
+
+    def test_fails_naming_the_missing_artifact_and_its_status(self):
+        write_coordinate_file(self.tmpdir, "publications/api", CENTRAL, PORTAL)
+        code, output = self.run_main(
+            "2.0.0", fetch=lambda url: 200 if "plugins.gradle.org" in url else 404
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("::error::not visible", output)
+        self.assertIn("last status HTTP 404", output)
+        self.assertIn("/com/airbnb/viaduct/api/2.0.0/api-2.0.0.pom", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_probe_published_artifacts.py
+++ b/.github/scripts/tests/test_probe_published_artifacts.py
@@ -1,10 +1,14 @@
 import contextlib
+import http.client
 import io
 import os
+import shutil
 import sys
 import tempfile
 import unittest
+import urllib.error
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -12,6 +16,7 @@ from probe_published_artifacts import (
     Coordinate,
     find_coordinate_files,
     find_problems,
+    http_status,
     main,
     parse_coordinates,
     pom_url,
@@ -91,10 +96,36 @@ class TestPomUrl(unittest.TestCase):
         )
 
 
-class TestFindCoordinateFiles(unittest.TestCase):
+class TestHttpStatus(unittest.TestCase):
+
+    def status_when_urlopen_raises(self, error):
+        with mock.patch("urllib.request.urlopen", side_effect=error):
+            return http_status("https://example.invalid/a.pom")
+
+    def test_returns_the_code_for_an_http_error(self):
+        error = urllib.error.HTTPError(
+            "https://example.invalid/a.pom", 429, "Too Many Requests", {}, None
+        )
+        self.assertEqual(self.status_when_urlopen_raises(error), 429)
+
+    def test_returns_zero_for_a_connection_failure(self):
+        error = urllib.error.URLError("connection refused")
+        self.assertEqual(self.status_when_urlopen_raises(error), 0)
+
+    def test_returns_zero_for_a_truncated_response(self):
+        # IncompleteRead is not an OSError, so it needs its own except clause.
+        error = http.client.IncompleteRead(b"partial")
+        self.assertEqual(self.status_when_urlopen_raises(error), 0)
+
+
+class TempDirTestCase(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir)
+
+
+class TestFindCoordinateFiles(TempDirTestCase):
 
     def test_finds_files_across_nested_projects(self):
         write_coordinate_file(self.tmpdir, "publications/api", CENTRAL)
@@ -113,10 +144,7 @@ class TestFindCoordinateFiles(unittest.TestCase):
         self.assertEqual(find_coordinate_files(self.tmpdir), [])
 
 
-class TestReadCoordinates(unittest.TestCase):
-
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+class TestReadCoordinates(TempDirTestCase):
 
     def test_collects_across_files(self):
         write_coordinate_file(self.tmpdir, "publications/api", CENTRAL)
@@ -179,13 +207,14 @@ class TestProbe(unittest.TestCase):
         self.clock = FakeClock()
 
     def run_probe(self, urls, fetch, **kwargs):
-        return probe(
-            urls,
-            fetch=fetch,
-            now=lambda: self.clock.elapsed,
-            sleep=self.clock.sleep,
-            **kwargs,
-        )
+        with contextlib.redirect_stdout(io.StringIO()):
+            return probe(
+                urls,
+                fetch=fetch,
+                now=lambda: self.clock.elapsed,
+                sleep=self.clock.sleep,
+                **kwargs,
+            )
 
     def test_returns_empty_when_all_visible(self):
         self.assertEqual(self.run_probe(["a", "b"], lambda url: 200), [])
@@ -238,11 +267,8 @@ class TestProbe(unittest.TestCase):
         self.assertEqual(self.clock.slept, [10])
 
 
-class TestMain(unittest.TestCase):
+class TestMain(TempDirTestCase):
     """Covers the exit codes and ::error:: output that release.yml depends on."""
-
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
 
     def run_main(self, version, fetch=lambda url: 200):
         with contextlib.redirect_stdout(io.StringIO()) as captured:

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -159,6 +159,18 @@ jobs:
         run: echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      # Runs before publishing so a ref that cannot report its coordinates fails
+      # while Maven Central is still untouched.
+      - name: Derive the published coordinates
+        run: ./gradlew writePublishedCoordinates --no-daemon --stacktrace
+        shell: bash
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: published-coordinates
+          path: '**/build/reports/publication/coordinates.txt'
+          if-no-files-found: error
+
       - name: Publish artifacts
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.VIADUCT_SONATYPE_USERNAME }}

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: true
         type: boolean
+      expected_version:
+        description: "Version the caller intends to publish; checked against VERSION"
+        required: false
+        default: ''
+        type: string
     outputs:
       source_sha:
         description: "SHA of the published commit"
@@ -98,6 +103,22 @@ jobs:
             --mode "${{ inputs.mode }}" \
             --branch "${{ inputs.ref }}" \
             --version-file ../source/VERSION
+        shell: bash
+
+      # validate_release_state.py never sees the caller's rc_ver, and it accepts any
+      # rc.N for the base version, so the two can disagree without it noticing.
+      - name: Confirm VERSION matches the version the caller will publish
+        if: inputs.expected_version != ''
+        env:
+          EXPECTED: ${{ inputs.expected_version }}
+          ACTUAL: ${{ steps.validate.outputs.effective_version }}
+        run: |
+          set -euo pipefail
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::Caller expects to publish '${EXPECTED}' but VERSION on ${{ inputs.ref }} is '${ACTUAL}'"
+            exit 1
+          fi
+          echo "✅ VERSION matches the requested version '${ACTUAL}'"
         shell: bash
 
   confirm-versions:
@@ -160,12 +181,14 @@ jobs:
         shell: bash
 
       # Runs before publishing so a ref that cannot report its coordinates fails
-      # while Maven Central is still untouched.
+      # while Maven Central is still untouched. Only release.yml probes the result.
       - name: Derive the published coordinates
+        if: inputs.mode != 'snapshot'
         run: ./gradlew writePublishedCoordinates --no-daemon --stacktrace
         shell: bash
 
       - uses: actions/upload-artifact@v6
+        if: inputs.mode != 'snapshot'
         with:
           name: published-coordinates
           path: '**/build/reports/publication/coordinates.txt'

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -105,17 +105,17 @@ jobs:
             --version-file ../source/VERSION
         shell: bash
 
-      # validate_release_state.py never sees the caller's rc_ver, and it accepts any
-      # rc.N for the base version, so the two can disagree without it noticing.
+      # validate_release_state.py accepts any rc.N for the base version and never sees rc_ver
       - name: Confirm VERSION matches the version the caller will publish
         if: inputs.expected_version != ''
         env:
           EXPECTED: ${{ inputs.expected_version }}
           ACTUAL: ${{ steps.validate.outputs.effective_version }}
+          REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           if [ "$EXPECTED" != "$ACTUAL" ]; then
-            echo "::error::Caller expects to publish '${EXPECTED}' but VERSION on ${{ inputs.ref }} is '${ACTUAL}'"
+            echo "::error::Caller expects to publish '${EXPECTED}' but VERSION on ${REF} is '${ACTUAL}'"
             exit 1
           fi
           echo "✅ VERSION matches the requested version '${ACTUAL}'"
@@ -180,8 +180,8 @@ jobs:
         run: echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      # Runs before publishing so a ref that cannot report its coordinates fails
-      # while Maven Central is still untouched. Only release.yml probes the result.
+      # Must stay ahead of the publish step: a ref that cannot report its coordinates
+      # has to fail while Maven Central is still untouched.
       - name: Derive the published coordinates
         if: inputs.mode != 'snapshot'
         run: ./gradlew writePublishedCoordinates --no-daemon --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
       ref: ${{ needs.preflight.outputs.source_ref }}
       run_checks: true
       confirm_versions: true
+      expected_version: ${{ needs.preflight.outputs.published_version }}
     secrets: inherit
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,25 +138,22 @@ jobs:
     needs: [preflight, publish, push-demoapps]
     runs-on: ubuntu-latest
     steps:
+      # No `ref:` — the probe script must match the dispatched workflow, not the
+      # release branch, which may predate it.
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.publish.outputs.source_sha }}
 
-      - uses: ./.github/actions/setup-build
+      - uses: actions/download-artifact@v7
         with:
-          java-version: '21'
-          cache-read-only: true
-
-      - name: Derive the published coordinates
-        run: ./gradlew writePublishedCoordinates --no-daemon --stacktrace
-        shell: bash
+          name: published-coordinates
+          path: coordinates
 
       - name: Probe Maven Central and Plugin Portal for ${{ needs.preflight.outputs.published_version }}
         env:
           VERSION: ${{ needs.preflight.outputs.published_version }}
         run: |
           set -euo pipefail
-          python3 .github/scripts/probe_published_artifacts.py --version "$VERSION"
+          python3 .github/scripts/probe_published_artifacts.py \
+            --root coordinates --version "$VERSION"
         shell: bash
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,41 +135,28 @@ jobs:
   # newly-published version even though publish succeeded.
   # ---------------------------------------------------------------------------
   wait-for-new-artifacts:
-    needs: [preflight, push-demoapps]
+    needs: [preflight, publish, push-demoapps]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.publish.outputs.source_sha }}
+
+      - uses: ./.github/actions/setup-build
+        with:
+          java-version: '21'
+          cache-read-only: true
+
+      - name: Derive the published coordinates
+        run: ./gradlew writePublishedCoordinates --no-daemon --stacktrace
+        shell: bash
+
       - name: Probe Maven Central and Plugin Portal for ${{ needs.preflight.outputs.published_version }}
         env:
           VERSION: ${{ needs.preflight.outputs.published_version }}
         run: |
           set -euo pipefail
-          URLS=(
-            "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/api/${VERSION}/api-${VERSION}.pom"
-            "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/runtime/${VERSION}/runtime-${VERSION}.pom"
-            "https://repo.maven.apache.org/maven2/com/airbnb/viaduct/gradle/common/${VERSION}/common-${VERSION}.pom"
-            "https://plugins.gradle.org/m2/com/airbnb/viaduct/application-gradle-plugin/com.airbnb.viaduct.application-gradle-plugin.gradle.plugin/${VERSION}/com.airbnb.viaduct.application-gradle-plugin.gradle.plugin-${VERSION}.pom"
-          )
-          MAX_ATTEMPTS=60
-          SLEEP_SECONDS=30
-          for url in "${URLS[@]}"; do
-            echo "Probing $url"
-            attempt=0
-            while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
-              attempt=$((attempt + 1))
-              code=$(curl -sL -o /dev/null -w "%{http_code}" "$url" || echo "000")
-              if [[ "$code" == "200" ]]; then
-                echo "  ✅ available (attempt ${attempt})"
-                break
-              fi
-              if [[ $attempt -eq $MAX_ATTEMPTS ]]; then
-                echo "::error::Artifact $url not visible after $((MAX_ATTEMPTS * SLEEP_SECONDS / 60))m of polling (last status: $code)"
-                exit 1
-              fi
-              echo "  ⏳ HTTP $code (attempt ${attempt}/${MAX_ATTEMPTS}) — sleeping ${SLEEP_SECONDS}s"
-              sleep "$SLEEP_SECONDS"
-            done
-          done
-          echo "✅ All probed artifacts are visible"
+          python3 .github/scripts/probe_published_artifacts.py --version "$VERSION"
         shell: bash
 
   # ---------------------------------------------------------------------------

--- a/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
+++ b/build-logic/src/main/kotlin/buildroot/orchestration.gradle.kts
@@ -235,6 +235,11 @@ registerServiceBackedAggregate(
     aggregateKey = "publishToSnapshots",
     description = "[orchestration] Publishes all publishable SUBPROJECTS in THIS build to Central Portal snapshots.",
 )
+registerServiceBackedAggregate(
+    aggregateName = "orchestrationWritePublishedCoordinatesAll",
+    aggregateKey = "writePublishedCoordinates",
+    description = "[orchestration] Records the published coordinates of all publishable SUBPROJECTS in THIS build.",
+)
 
 // ---------------- In INCLUDED BUILDS: alias conventional tasks to aggregates ----------------
 
@@ -280,6 +285,12 @@ if (gradle.parent != null) {
         aggregateName = "orchestrationPublishAllToSnapshots",
         group = "publishing",
         description = "Publishes all publishable subprojects in this included build to Central Portal snapshots."
+    )
+    aliasConventionalTaskToAggregate(
+        conventionalName = "writePublishedCoordinates",
+        aggregateName = "orchestrationWritePublishedCoordinatesAll",
+        group = "publishing",
+        description = "Records the published coordinates of all publishable subprojects in this included build."
     )
     aliasConventionalTaskToAggregate(
         conventionalName = "detekt",
@@ -363,6 +374,13 @@ if (gradle.parent == null) {
         usesService(orchestrationRegistry)
         dependsOn(provider { orchestrationRegistry.get().tasksFor("publishToSnapshots") })
         dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationPublishAllToSnapshots") })
+    }
+
+    // published coordinates: root subprojects (via registry) + included builds' aggregate
+    ensureTask("writePublishedCoordinates", "publishing", "Records the published coordinates of root subprojects + participating included builds.") {
+        usesService(orchestrationRegistry)
+        dependsOn(provider { orchestrationRegistry.get().tasksFor("writePublishedCoordinates") })
+        dependsOn(participatingIncludedBuilds().map { it.task(":orchestrationWritePublishedCoordinatesAll") })
     }
 
     // detekt: root subprojects (via registry) + included builds' aggregate

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -64,8 +64,7 @@ val writePublishedCoordinates = tasks.register<WritePublishedCoordinatesTask>("w
 }
 registerForOrchestrationAggregate("writePublishedCoordinates", "writePublishedCoordinates")
 
-// Deferred because the consumer's `gradlePlugin { }` block is unreadable until it is evaluated.
-// Gated on plugin-publish because `kotlin-dsl` fills that same extension with script plugin ids.
+// `gradlePlugin.plugins` is empty until the consumer's block is evaluated.
 afterEvaluate {
     val publishedVersion = project.version.toString()
     val central = "central ${project.group}:${project.name}:$publishedVersion"

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -64,19 +64,6 @@ val writePublishedCoordinates = tasks.register<WritePublishedCoordinatesTask>("w
 }
 registerForOrchestrationAggregate("writePublishedCoordinates", "writePublishedCoordinates")
 
-// `gradlePlugin.plugins` is empty until the consumer's block is evaluated.
-afterEvaluate {
-    val publishedVersion = project.version.toString()
-    val central = "central ${project.group}:${project.name}:$publishedVersion"
-    val markers = if (pluginManager.hasPlugin("com.gradle.plugin-publish")) {
-        extensions.getByType(GradlePluginDevelopmentExtension::class.java)
-            .plugins.map { "portal ${it.id}:${it.id}.gradle.plugin:$publishedVersion" }
-    } else {
-        emptyList()
-    }
-    writePublishedCoordinates.configure { coordinates.set(listOf(central) + markers) }
-}
-
 // Apply standard Viaduct POM metadata to all Maven publications.
 pluginManager.withPlugin("maven-publish") {
     project.extensions.getByType(PublishingExtension::class.java)
@@ -160,18 +147,34 @@ run {
 }
 
 // 🔑 Defer coordinates() until after the consumer has configured viaductPublishing { ... }.
+// `gradlePlugin.plugins` is likewise empty until the consumer's block is evaluated.
 afterEvaluate {
     // Resolve lazily here (now it's safe to .get()).
     val resolvedName = viaductPublishing.name.get().ifBlank { project.name }.let { "Viaduct :: $it" }
     val resolvedDescription = viaductPublishing.description.get().ifBlank { "" }
 
+    val publishedGroup = project.group.toString()
+    val publishedArtifact = project.name
+    val publishedVersion = project.version.toString()
+
     extensions.configure<MavenPublishBaseExtension> {
-        coordinates(project.group.toString(), project.name, project.version.toString())
+        coordinates(publishedGroup, publishedArtifact, publishedVersion)
 
         pom {
             name.set(resolvedName)
             if (resolvedDescription.isNotBlank()) description.set(resolvedDescription) else description.set("Viaduct library ${project.name}")
         }
+    }
+
+    val markers = if (pluginManager.hasPlugin("com.gradle.plugin-publish")) {
+        extensions.getByType(GradlePluginDevelopmentExtension::class.java)
+            .plugins.map { "portal ${it.id}:${it.id}.gradle.plugin:$publishedVersion" }
+    } else {
+        emptyList()
+    }
+    writePublishedCoordinates.configure {
+        val central = "central $publishedGroup:$publishedArtifact:$publishedVersion"
+        coordinates.set(listOf(central) + markers)
     }
 }
 

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -166,16 +166,14 @@ afterEvaluate {
         }
     }
 
+    val central = "central $publishedGroup:$publishedArtifact:$publishedVersion"
     val markers = if (pluginManager.hasPlugin("com.gradle.plugin-publish")) {
         extensions.getByType(GradlePluginDevelopmentExtension::class.java)
             .plugins.map { "portal ${it.id}:${it.id}.gradle.plugin:$publishedVersion" }
     } else {
         emptyList()
     }
-    writePublishedCoordinates.configure {
-        val central = "central $publishedGroup:$publishedArtifact:$publishedVersion"
-        coordinates.set(listOf(central) + markers)
-    }
+    writePublishedCoordinates.configure { coordinates.set(listOf(central) + markers) }
 }
 
 plugins.withId("org.jetbrains.kotlin.jvm") {

--- a/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/viaduct-publishing.gradle.kts
@@ -4,14 +4,23 @@ import buildroot.registerForOrchestrationAggregate
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.*
 import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 import org.gradle.plugins.signing.SigningExtension
+import org.gradle.work.DisableCachingByDefault
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.register
 
 plugins {
     id("com.vanniktech.maven.publish")
@@ -36,6 +45,38 @@ val publishMinimal = providers.gradleProperty("publishMinimal").isPresent
 registerForOrchestrationAggregate("publishToMavenLocal", "publishToMavenLocal")
 registerForOrchestrationAggregate("publishToMavenCentral", "publishAllPublicationsToMavenCentralRepository")
 registerForOrchestrationAggregate("publishToSnapshots", "publishAllPublicationsToSnapshotsRepository")
+
+@DisableCachingByDefault(because = "Writes a single small file")
+abstract class WritePublishedCoordinatesTask : DefaultTask() {
+    @get:Input abstract val coordinates: ListProperty<String>
+    @get:OutputFile abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        outputFile.get().asFile
+            .writeText(coordinates.get().joinToString(separator = "\n", postfix = "\n"))
+    }
+}
+
+val writePublishedCoordinates = tasks.register<WritePublishedCoordinatesTask>("writePublishedCoordinates") {
+    description = "Records this project's published coordinates for the release workflow to probe."
+    outputFile.set(layout.buildDirectory.file("reports/publication/coordinates.txt"))
+}
+registerForOrchestrationAggregate("writePublishedCoordinates", "writePublishedCoordinates")
+
+// Deferred because the consumer's `gradlePlugin { }` block is unreadable until it is evaluated.
+// Gated on plugin-publish because `kotlin-dsl` fills that same extension with script plugin ids.
+afterEvaluate {
+    val publishedVersion = project.version.toString()
+    val central = "central ${project.group}:${project.name}:$publishedVersion"
+    val markers = if (pluginManager.hasPlugin("com.gradle.plugin-publish")) {
+        extensions.getByType(GradlePluginDevelopmentExtension::class.java)
+            .plugins.map { "portal ${it.id}:${it.id}.gradle.plugin:$publishedVersion" }
+    } else {
+        emptyList()
+    }
+    writePublishedCoordinates.configure { coordinates.set(listOf(central) + markers) }
+}
 
 // Apply standard Viaduct POM metadata to all Maven publications.
 pluginManager.withPlugin("maven-publish") {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above
      using the Conventional Commit format. This is enforced by CI https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!-- Describe the why and what of this change. -->
<!-- Please link to relevant issues.  (Large issues must be discussed in an issue.) -->

`wait-for-new-artifacts` polls Maven Central and the Plugin Portal so `verify-demoapps` does not race the CDN for a freshly published version. Its URL list was hardcoded, which made it a weak gate in three ways.

- It was edited by hand, and `a23a8ddf1` shows what happens when it isn't. A stale entry polls until the budget expires, then fails after `publish` and before `create-release`: artifacts on Maven Central, no tag, no release.
- It covered 4 of 18 published coordinates. Three of the fourteen it missed are resolved by `verify-demoapps`: `com.airbnb.viaduct:buildtime`, `com.airbnb.viaduct:test-fixtures`, and the `module-gradle-plugin` marker.
- Its 30-minute budget applied per URL, so the worst case grew with the list and only the first missing artifact was reported.

A new `writePublishedCoordinates` task in `conventions.viaduct-publishing` records `group:artifact:version` plus any Plugin Portal markers, aggregated across included builds by the orchestration registry that already spans root `publishToMavenCentral`. `probe_published_artifacts.py` derives the `.pom` URLs and polls them against one 30-minute deadline, naming every missing artifact and its last HTTP status. It fails on a malformed coordinate file, on no coordinates, on a missing repository, or on a version that differs from the release version; without those an empty list would pass the gate without probing anything.

Both new failure points sit before publication. `publish` derives the coordinates and uploads them as an artifact before pushing anything, so a ref that cannot report its coordinates fails with Maven Central untouched; `wait-for-new-artifacts` downloads them and needs no JDK or release-branch checkout. `validate` now also compares `VERSION` against the version the caller intends to publish: `validate_release_state.py` never sees the `rc_ver` input and accepts any `rc.N` for the base version, so the two could previously disagree and publish one version while probing another.

Snapshot publishes skip both new steps. A release branch cut before this merges does not carry the task, so releasing from it needs a cherry-pick first.

## How was it tested?  What documentation was provided?

Run live against both CDNs at `2.0.0`: all 18 coordinates (14 Maven Central, 4 Plugin Portal) resolve, exit 0.
The set of projects applying `conventions.viaduct-publishing` is unchanged since that tag, so the derivation neither over- nor under-generates against a shipped release.

Each of the four probe failure paths exits 1 naming the offending coordinate and its status, including `com.airbnb.viaduct.shared:graphql:2.0.0` at `HTTP 404`.

`python3 -m unittest discover -s .github/scripts/tests`: passes, 35 new tests.
`./gradlew -p build-logic detekt`: clean.
`./gradlew writePublishedCoordinates` stores a configuration cache entry and writes all 18 coordinates from a clean output tree.

`release-runbook.md` documents the new task, the probe's failure modes, and the derivation step’s own failure path.